### PR TITLE
ci: update the runs-on labels for improved clarity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   build:
     name: Build TSS Crypto Library
-    runs-on: network-node-linux-medium
+    runs-on: network-node-auxiliary-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   build:
     name: Publish Release
-    runs-on: network-node-linux-medium
+    runs-on: network-node-auxiliary-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0


### PR DESCRIPTION
**Description**:

This pull request changes the CI runner labels for improved clarity and distinction between the Dallas and Chicago clusters.

**Related issue(s)**:

Fixes #43 

