### PR TITLE
feat: 15185 expose PairingFriendlyCurve impl with SPI

### DIFF
--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/AltBn128.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/AltBn128.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.cryptography.altbn128;
+
+import static com.hedera.cryptography.altbn128.common.ValidationUtils.expectOrThrow;
+
+import com.hedera.cryptography.pairings.api.BilinearPairing;
+import com.hedera.cryptography.pairings.api.Curve;
+import com.hedera.cryptography.pairings.api.Field;
+import com.hedera.cryptography.pairings.api.Group;
+import com.hedera.cryptography.pairings.api.GroupElement;
+import com.hedera.cryptography.pairings.api.PairingFriendlyCurve;
+import com.hedera.cryptography.pairings.api.curves.KnownCurves;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Represents a bilinear pairing friendly curve alt-bn-128 and its component
+ *  {@code G₁}, {@code G₂} and {@code Fq} (Finite Field).
+ */
+public class AltBn128 implements PairingFriendlyCurve {
+    /**
+     * The finite field
+     */
+    private final AltBn128Field field = new AltBn128Field();
+    /**
+     * First group of the curve
+     */
+    private final AltBn128Group group1 = new AltBn128Group(AltBN128CurveGroup.GROUP1);
+    /**
+     * Second group of the curve
+     */
+    private final AltBn128Group group2 = new AltBn128Group(AltBN128CurveGroup.GROUP2);
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public Curve curve() {
+        return KnownCurves.ALT_BN128;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public Field field() {
+        return field;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public Group group1() {
+        return group1;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public Group group2() {
+        return group2;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public Group getOtherGroup(@NonNull final Group group) {
+        AltBn128Group other = expectOrThrow(AltBn128Group.class, group);
+        return this.group1.getGroup() == other.getGroup() ? group2 : group1;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public BilinearPairing pairingBetween(@NonNull final GroupElement element1, @NonNull final GroupElement element2) {
+        return new AltBn128BilinearPairing(element1, element2);
+    }
+}

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/spi/AltBn128Provider.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/spi/AltBn128Provider.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.cryptography.altbn128.spi;
+
+import com.hedera.cryptography.altbn128.AltBn128;
+import com.hedera.cryptography.altbn128.adapter.jni.ArkBn254Adapter;
+import com.hedera.cryptography.pairings.api.Curve;
+import com.hedera.cryptography.pairings.api.PairingFriendlyCurve;
+import com.hedera.cryptography.pairings.spi.PairingFriendlyCurveProvider;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * An SPI provider for {@link AltBn128}
+ */
+public class AltBn128Provider extends PairingFriendlyCurveProvider {
+
+    /**
+     * The instance being provided.
+     */
+    final AtomicReference<PairingFriendlyCurve> pairingFriendlyCurve = new AtomicReference<>();
+
+    /**
+     * Initializes the library.
+     * @implNote This method is only called once.
+     */
+    @Override
+    protected void doInit() {
+        // We force the library loading in the init method
+        ArkBn254Adapter.getInstance();
+        pairingFriendlyCurve.set(new AltBn128());
+    }
+
+    /**
+     * Returns the implemented curve
+     * @return the implemented curve.
+     */
+    @Override
+    public Curve curve() {
+        return Curve.ALT_BN128;
+    }
+
+    /**
+     * The instance of {@link AltBn128}
+     * @return the instance of {@link AltBn128}
+     */
+    @Override
+    public PairingFriendlyCurve pairingFriendlyCurve() {
+        return pairingFriendlyCurve.get();
+    }
+}

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/module-info.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/module-info.java
@@ -1,16 +1,10 @@
-import com.hedera.cryptography.pairings.spi.PairingFriendlyCurveProvider;
-
 /**
  * Alt bn-128 implementation of the pairings api
  */
 module com.hedera.cryptography.altbn128 {
     requires com.hedera.common.nativesupport;
     requires com.hedera.cryptography.pairings.api;
-    requires jdk.jshell;
 
-    uses PairingFriendlyCurveProvider;
-
-// TO add in the future:
-// provides com.hedera.cryptography.pairings.spi.PairingFriendlyCurveProvider with
-//        AltBn128BilinearPairingProvider;
+    provides com.hedera.cryptography.pairings.spi.PairingFriendlyCurveProvider with
+            com.hedera.cryptography.altbn128.spi.AltBn128Provider;
 }

--- a/cryptography/hedera-cryptography-altbn128/src/main/resources/META-INF/services/com.hedera.cryptography.pairings.spi.PairingFriendlyCurveProvider
+++ b/cryptography/hedera-cryptography-altbn128/src/main/resources/META-INF/services/com.hedera.cryptography.pairings.spi.PairingFriendlyCurveProvider
@@ -1,0 +1,1 @@
+com.hedera.cryptography.altbn128.spi.AltBn128Provider

--- a/cryptography/hedera-cryptography-altbn128/src/main/resources/services/com.hedera.cryptography.pairings.spi.BilinearPairingProvider
+++ b/cryptography/hedera-cryptography-altbn128/src/main/resources/services/com.hedera.cryptography.pairings.spi.BilinearPairingProvider
@@ -1,1 +1,0 @@
-com.hedera.cryptography.pairings.altbn128.spi.AltBn128BilinearPairingMockProvider

--- a/cryptography/hedera-cryptography-altbn128/src/test/java/com/hedera/cryptography/altbn128/AltBn128BilinearPairingTest.java
+++ b/cryptography/hedera-cryptography-altbn128/src/test/java/com/hedera/cryptography/altbn128/AltBn128BilinearPairingTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.hedera.cryptography.pairings.api.FieldElement;
 import com.hedera.cryptography.pairings.api.GroupElement;
 import java.util.Random;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class AltBn128BilinearPairingTest {
@@ -40,7 +41,7 @@ class AltBn128BilinearPairingTest {
         GroupElement Q = g2.random(rand);
 
         // e(a×P, b×Q) = e(P, ab×Q)
-        assertTrue(new AltBn128BilinearPairing(P.multiply(a), Q.multiply(b))
+        Assertions.assertTrue(new AltBn128BilinearPairing(P.multiply(a), Q.multiply(b))
                 .compare(new AltBn128BilinearPairing(P, Q.multiply(a.multiply(b)))));
         // e(a×P, b×Q) = e(ab×P, Q)
         assertTrue(new AltBn128BilinearPairing(P.multiply(a), Q.multiply(b))

--- a/cryptography/hedera-cryptography-altbn128/src/test/java/com/hedera/cryptography/altbn128/AltBn128FieldTest.java
+++ b/cryptography/hedera-cryptography-altbn128/src/test/java/com/hedera/cryptography/altbn128/AltBn128FieldTest.java
@@ -16,7 +16,6 @@
 
 package com.hedera.cryptography.altbn128;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -26,13 +25,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.security.SecureRandom;
 import java.util.Random;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class AltBn128FieldTest {
 
     @Test
     void constructionSucceeds() {
-        assertDoesNotThrow(AltBn128Field::new);
+        Assertions.assertDoesNotThrow(AltBn128Field::new);
     }
 
     @Test

--- a/cryptography/hedera-cryptography-altbn128/src/test/java/com/hedera/cryptography/altbn128/AltBn128Test.java
+++ b/cryptography/hedera-cryptography-altbn128/src/test/java/com/hedera/cryptography/altbn128/AltBn128Test.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.cryptography.altbn128;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.hedera.cryptography.pairings.api.FieldElement;
+import com.hedera.cryptography.pairings.api.Group;
+import com.hedera.cryptography.pairings.api.GroupElement;
+import com.hedera.cryptography.pairings.api.curves.KnownCurves;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+
+class AltBn128Test {
+
+    @Test
+    void fullCircuit() {
+
+        final AltBn128 curve = new AltBn128();
+        final var rng = new Random();
+        final Group group2 = curve.group2();
+        final Group group1 = curve.group1();
+        final byte[] msg = new byte[1024];
+        rng.nextBytes(msg);
+
+        FieldElement sk = curve.field().random(rng);
+        GroupElement pk = group2.generator().multiply(sk);
+        GroupElement mk = group1.fromHash(msg);
+
+        assertEquals(KnownCurves.ALT_BN128, curve.curve());
+        assertEquals(group2, curve.getOtherGroup(group1));
+        assertEquals(group1, curve.getOtherGroup(group2));
+        assertTrue(curve.pairingBetween(mk.multiply(sk), group2.generator()).compare(curve.pairingBetween(mk, pk)));
+    }
+}

--- a/cryptography/hedera-cryptography-altbn128/src/test/java/com/hedera/cryptography/altbn128/spi/AltBn128ProviderTest.java
+++ b/cryptography/hedera-cryptography-altbn128/src/test/java/com/hedera/cryptography/altbn128/spi/AltBn128ProviderTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.cryptography.altbn128.spi;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.hedera.cryptography.pairings.api.Curve;
+import com.hedera.cryptography.pairings.api.PairingFriendlyCurves;
+import com.hedera.cryptography.pairings.api.curves.KnownCurves;
+import org.junit.jupiter.api.Test;
+
+class AltBn128ProviderTest {
+
+    @Test
+    void testFindAltBn128Provider() {
+        assertDoesNotThrow(() -> PairingFriendlyCurves.findInstance(KnownCurves.ALT_BN128));
+        assertEquals(
+                KnownCurves.ALT_BN128,
+                PairingFriendlyCurves.findInstance(Curve.ALT_BN128)
+                        .pairingFriendlyCurve()
+                        .curve());
+    }
+}

--- a/cryptography/hedera-cryptography-eckeygen/src/main/java/com/hedera/cryptography/eckeygen/NativeKeyGenerator.java
+++ b/cryptography/hedera-cryptography-eckeygen/src/main/java/com/hedera/cryptography/eckeygen/NativeKeyGenerator.java
@@ -42,6 +42,7 @@ public class NativeKeyGenerator implements KeyGenerator {
     }
 
     /**
+     * Returns the singleton instance of the native key generator.
      * @return the singleton instance of the native key generator.
      */
     public static NativeKeyGenerator getInstance() {

--- a/cryptography/hedera-cryptography-pairings-api/src/main/java/module-info.java
+++ b/cryptography/hedera-cryptography-pairings-api/src/main/java/module-info.java
@@ -1,14 +1,12 @@
-import com.hedera.cryptography.pairings.spi.PairingFriendlyCurveProvider;
-
 /**
  * This API will expose general arithmetic operations to work with Bilinear Pairings and EC curves that implementations must provide.
  */
 module com.hedera.cryptography.pairings.api {
+    uses com.hedera.cryptography.pairings.spi.PairingFriendlyCurveProvider;
+
     exports com.hedera.cryptography.pairings.api;
     exports com.hedera.cryptography.pairings.api.curves;
     exports com.hedera.cryptography.pairings.spi;
-
-    uses PairingFriendlyCurveProvider;
 
     requires static transitive com.github.spotbugs.annotations;
 }

--- a/cryptography/hedera-cryptography-pairings-api/src/test/resources/services/com.hedera.cryptography.pairings.spi.BilinearPairingProvider
+++ b/cryptography/hedera-cryptography-pairings-api/src/test/resources/services/com.hedera.cryptography.pairings.spi.BilinearPairingProvider
@@ -1,2 +1,0 @@
-com.hedera.cryptography.pairings.test.spi.PairingMockFriendlyCurveProvider
-com.hedera.cryptography.pairings.test.spi.FailingPairingFriendlyCurveProvider

--- a/cryptography/hedera-cryptography-pairings-signatures/build.gradle.kts
+++ b/cryptography/hedera-cryptography-pairings-signatures/build.gradle.kts
@@ -19,7 +19,9 @@ plugins {
     id("com.hedera.gradle.hedera-cryptography-publish")
 }
 
-testModuleInfo {
-    // requires("org.junit.jupiter.api")
+mainModuleInfo {
+    runtimeOnly("com.hedera.cryptography.altbn128")
     // requires("org.assertj.core")
 }
+
+testModuleInfo { requires("org.junit.jupiter.api") }

--- a/cryptography/hedera-cryptography-pairings-signatures/src/main/java/module-info.java
+++ b/cryptography/hedera-cryptography-pairings-signatures/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 /**
+ *
  * This module provides cryptography primitives to create EC PublicKeys, EC PrivateKeys, and Signatures.
  */
 module com.hedera.cryptography.pairings.signatures {
@@ -6,4 +7,6 @@ module com.hedera.cryptography.pairings.signatures {
     requires static transitive com.github.spotbugs.annotations;
 
     exports com.hedera.cryptography.pairings.signatures.api;
+
+    uses com.hedera.cryptography.pairings.spi.PairingFriendlyCurveProvider;
 }

--- a/cryptography/hedera-cryptography-pairings-signatures/src/test/java/com/hedera/cryptography/pairings/signatures/api/SignatureSchemaTest.java
+++ b/cryptography/hedera-cryptography-pairings-signatures/src/test/java/com/hedera/cryptography/pairings/signatures/api/SignatureSchemaTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.cryptography.pairings.signatures.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.hedera.cryptography.pairings.api.Curve;
+import com.hedera.cryptography.pairings.api.PairingFriendlyCurves;
+import com.hedera.cryptography.pairings.api.curves.KnownCurves;
+import org.junit.jupiter.api.Test;
+
+class SignatureSchemaTest {
+
+    @Test
+    void testFindBilinearPairingFriendlyCurveProvider() {
+        ModuleLayer layer = ModuleLayer.boot();
+
+        // List all modules in the current layer
+        layer.modules().forEach(module -> {
+            System.out.println("Loaded module: " + module.getName());
+        });
+
+        assertDoesNotThrow(() -> PairingFriendlyCurves.findInstance(KnownCurves.ALT_BN128));
+        assertEquals(
+                KnownCurves.ALT_BN128,
+                PairingFriendlyCurves.findInstance(Curve.ALT_BN128)
+                        .pairingFriendlyCurve()
+                        .curve());
+    }
+}


### PR DESCRIPTION
**Description**:
Exposing PairingsFriendlyCurveProvider for altbn128 implementation with SPI.

**Related issue(s)**:

Fixes [#15185](https://github.com/hashgraph/hedera-services/issues/15185)

**Notes for reviewer**:
Still, binary files are provided until compiling support with Gradle for Rust is completed.

**Checklist**
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
