### PR TITLE
feat: 15025 verify signature

### DIFF
--- a/cryptography/hedera-cryptography-pairings-signatures/src/main/java/com/hedera/cryptography/pairings/signatures/api/PairingPublicKey.java
+++ b/cryptography/hedera-cryptography-pairings-signatures/src/main/java/com/hedera/cryptography/pairings/signatures/api/PairingPublicKey.java
@@ -47,4 +47,16 @@ public record PairingPublicKey(GroupElement publicKey, SignatureSchema signature
     public static PairingPublicKey fromBytes(@NonNull final byte[] bytes) {
         return deserializePairingPublicKey(bytes);
     }
+
+    /**
+     * Verifies a signature out of its byte array representation
+     * @param signature the serialized form of a signature
+     * @param message unsigned message to validate the signature
+     * @return true is the provided signature is a valid signature of the message
+     * @throws IllegalArgumentException if the signature representation is invalid
+     */
+    public boolean verifySignature(@NonNull final byte[] signature, @NonNull final byte[] message) {
+        final PairingSignature pairingSignature = PairingSignature.fromBytes(signature);
+        return pairingSignature.verify(this, message);
+    }
 }

--- a/cryptography/hedera-cryptography-pairings-signatures/src/main/java/com/hedera/cryptography/pairings/signatures/api/PairingSignature.java
+++ b/cryptography/hedera-cryptography-pairings-signatures/src/main/java/com/hedera/cryptography/pairings/signatures/api/PairingSignature.java
@@ -19,7 +19,10 @@ package com.hedera.cryptography.pairings.signatures.api;
 import static com.hedera.cryptography.pairings.signatures.api.ByteArrayConversionUtils.deserializePairingSignature;
 import static com.hedera.cryptography.pairings.signatures.api.ByteArrayConversionUtils.serializePairingSignature;
 
+import com.hedera.cryptography.pairings.api.BilinearPairing;
+import com.hedera.cryptography.pairings.api.Group;
 import com.hedera.cryptography.pairings.api.GroupElement;
+import com.hedera.cryptography.pairings.api.PairingFriendlyCurve;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -66,7 +69,15 @@ public record PairingSignature(@NonNull GroupElement signature, @NonNull Signatu
      * @param message   the message that was signed
      * @return true if the signature is valid, false otherwise
      */
-    public boolean verifySignature(@NonNull final PairingPublicKey publicKey, @NonNull final byte[] message) {
-        return true;
+    public boolean verify(@NonNull final PairingPublicKey publicKey, @NonNull final byte[] message) {
+        if (publicKey.signatureSchema() != signatureSchema) {
+            throw new IllegalArgumentException("PublicKey does not match signatureSchema");
+        }
+        final Group signatureGroup = signatureSchema.getSignatureGroup();
+        final Group publicKeyGroup = signatureSchema.getPublicKeyGroup();
+        final PairingFriendlyCurve curve = signatureSchema.getPairingFriendlyCurve();
+        final BilinearPairing a = curve.pairingBetween(publicKey.publicKey(), signatureGroup.fromHash(message));
+        final BilinearPairing b = curve.pairingBetween(publicKeyGroup.generator(), signature);
+        return a.compare(b);
     }
 }

--- a/cryptography/hedera-cryptography-pairings-signatures/src/test/java/com/hedera/cryptography/pairings/signatures/api/SignaturesLibraryTest.java
+++ b/cryptography/hedera-cryptography-pairings-signatures/src/test/java/com/hedera/cryptography/pairings/signatures/api/SignaturesLibraryTest.java
@@ -24,7 +24,9 @@ import com.hedera.cryptography.pairings.api.curves.KnownCurves;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
 import java.util.Random;
+import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -126,16 +128,12 @@ class SignaturesLibraryTest {
                 () -> PairingPublicKey.fromBytes(invalidKey2),
                 "Invalid key should throw an exception");
 
-        flipEachBitAndCheck(
+        flipEachBitAndConsume(
                 sk.toBytes(),
-                PairingPrivateKey::fromBytes,
-                IllegalArgumentException.class,
-                "Flipped bytes should be an invalid or different key");
-        flipEachBitAndCheck(
+                expected(sk, PairingPrivateKey::fromBytes, "Flipped bytes should be an invalid or different key"));
+        flipEachBitAndConsume(
                 pk.toBytes(),
-                PairingPublicKey::fromBytes,
-                IllegalArgumentException.class,
-                "Flipped bytes should be an invalid or different key");
+                expected(pk, PairingPublicKey::fromBytes, "Flipped bytes should be an invalid or different key"));
     }
 
     @ParameterizedTest
@@ -153,11 +151,12 @@ class SignaturesLibraryTest {
         assertNotNull(signature);
         assertNotNull(signature.toBytes());
         assertEquals(signature, sk.sign(message));
-        flipEachBitAndCheck(
+        flipEachBitAndConsume(
                 signature.toBytes(),
-                PairingSignature::fromBytes,
-                IllegalArgumentException.class,
-                "Flipped bytes should be an invalid or different signature");
+                expected(
+                        signature,
+                        PairingSignature::fromBytes,
+                        "Flipped bytes should be an invalid or different signature"));
 
         assertEquals(
                 signature,
@@ -176,31 +175,58 @@ class SignaturesLibraryTest {
                 "Invalid signature should throw an exception");
     }
 
+    @ParameterizedTest
+    @MethodSource("combinedParameters")
+    void verifySignatureTest(GroupAssignment assignment) {
+        final var schema = SignatureSchema.create(Curve.ALT_BN128, assignment);
+        final var rng = new Random();
+
+        final var sk = PairingPrivateKey.create(schema, rng);
+
+        var message = new byte[256];
+        rng.nextBytes(message);
+
+        final var signature = sk.sign(message);
+        assertNotNull(signature);
+        assertNotNull(signature.toBytes());
+        assertEquals(signature, sk.sign(message));
+
+        final PairingPublicKey publicKey = sk.createPublicKey();
+        assertTrue(signature.verify(publicKey, message), "signature should be valid");
+
+        IntStream.range(0, 256).forEach(i -> {
+            final var pk2 = PairingPrivateKey.create(schema, rng);
+            assertFalse(
+                    signature.verify(pk2.createPublicKey(), message),
+                    "No other public key should verify the signature");
+        });
+
+        flipEachBitAndConsume(signature.toBytes(), signatureFlippedBytes -> {
+            try {
+                // If we did not get an exception, the value should be at least not verifiable against the public key
+                assertFalse(
+                        publicKey.verifySignature(signatureFlippedBytes, message),
+                        "Invalid signature should be identified");
+            } catch (Exception e) {
+                assertEquals(IllegalArgumentException.class, e.getClass(), "Invalid signature should be identified");
+            }
+        });
+    }
+
     /**
      * Flip each bit of a byte original and invoke the consumer on each flip.
-     * Asserts that either throws an exception or that the result of invoking the consumer is not the same as the original value
      * @param original the original with where the flipping will occur. The original is modified
      * @param consumer the consumer to invoke on each flip
-     * @param throwing the expected exception
      */
-    <T, E extends Throwable> void flipEachBitAndCheck(
-            @NonNull final byte[] original,
-            final @NonNull Function<byte[], T> consumer,
-            final Class<E> throwing,
-            final String message) {
+    void flipEachBitAndConsume(@NonNull final byte[] original, final @NonNull Consumer<byte[]> consumer) {
         final byte[] copy = Arrays.copyOf(original, original.length);
-        final T originalValue = consumer.apply(original);
+
         for (int i = 0; i < copy.length - 1; i++) {
             final byte originalByte = copy[i];
             for (int bitPosition = 0; bitPosition < 8; bitPosition++) {
                 final byte flippedByte = (byte) (originalByte ^ (1 << bitPosition));
                 copy[i] = flippedByte;
-                try {
-                    // If we did not get an exception, the value should be at least different than the original
-                    assertNotEquals(originalValue, consumer.apply(copy), message);
-                } catch (Exception e) {
-                    assertEquals(throwing, e.getClass(), message);
-                }
+                consumer.accept(copy);
                 copy[i] = originalByte;
             }
         }
@@ -212,13 +238,30 @@ class SignaturesLibraryTest {
         for (int bitPosition = 0; bitPosition < 7; bitPosition++) {
             final byte flippedByte = (byte) (originalByte ^ (1 << bitPosition));
             copy[copy.length - 1] = flippedByte;
-            try {
-                assertNotEquals(originalValue, consumer.apply(copy), message);
-            } catch (Exception e) {
-                assertEquals(throwing, e.getClass(), message);
-            }
+            consumer.accept(copy);
             copy[copy.length - 1] = originalByte;
         }
+    }
+
+    /**
+     *  Asserts that either throws an IllegalArgumentException or that the result of invoking the consumer is not the same as the original value
+     *
+     * @param originalValue expected value to be different than this one
+     * @param creator the function that creates the elements out of an array
+     * @param message the message to show in case validation fails
+     * @param <T> the type of the comparison object
+     * @return a consumer that performs the check when requested
+     */
+    private <T> Consumer<byte[]> expected(
+            final T originalValue, final Function<byte[], T> creator, final String message) {
+        return bytes -> {
+            try {
+                // If we did not get an exception, the value should be at least different than the original
+                assertNotEquals(originalValue, creator.apply(bytes), message);
+            } catch (Exception e) {
+                assertEquals(IllegalArgumentException.class, e.getClass(), message);
+            }
+        };
     }
 
     private static Stream<GroupAssignment> combinedParameters() {

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/impl/TssServiceImpl.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/impl/TssServiceImpl.java
@@ -38,7 +38,7 @@ import java.util.Random;
 public class TssServiceImpl implements TssService {
     private final SignatureSchema signatureSchema;
     private final Random random;
-    private final PairingPublicKey aggregatedPublicKey;
+    private final PairingPrivateKey aggregatedPrivateKey;
 
     /**
      * Generates a new instance of this prototype implementation.
@@ -49,8 +49,7 @@ public class TssServiceImpl implements TssService {
     public TssServiceImpl(@NonNull final SignatureSchema signatureSchema, @NonNull final Random random) {
         this.signatureSchema = Objects.requireNonNull(signatureSchema, "signatureSchema must not be null");
         this.random = Objects.requireNonNull(random, "random must not be null");
-        this.aggregatedPublicKey =
-                PairingPrivateKey.create(signatureSchema, random).createPublicKey();
+        this.aggregatedPrivateKey = PairingPrivateKey.create(signatureSchema, random);
     }
 
     @NonNull
@@ -102,14 +101,13 @@ public class TssServiceImpl implements TssService {
     @NonNull
     @Override
     public PairingPublicKey aggregatePublicShares(@NonNull final List<TssPublicShare> publicShares) {
-        return aggregatedPublicKey;
+        return aggregatedPrivateKey.createPublicKey();
     }
 
     @NonNull
     @Override
     public TssShareSignature sign(@NonNull final TssPrivateShare privateShare, @NonNull final byte[] message) {
-        return new TssShareSignature(
-                privateShare.shareId(), privateShare.privateKey().sign(message));
+        return new TssShareSignature(privateShare.shareId(), aggregatedPrivateKey.sign(message));
     }
 
     @Override
@@ -123,6 +121,6 @@ public class TssServiceImpl implements TssService {
     @NonNull
     @Override
     public PairingSignature aggregateSignatures(@NonNull final List<TssShareSignature> partialSignatures) {
-        return PairingPrivateKey.create(signatureSchema, random).sign(new byte[partialSignatures.size()]);
+        return partialSignatures.getFirst().signature();
     }
 }

--- a/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/TssTest.java
+++ b/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/TssTest.java
@@ -136,12 +136,15 @@ class TssTest {
                 .build(SIGNATURE_SCHEMA);
 
         final TssService tssService = TssService.create(SIGNATURE_SCHEMA, new Random());
+        final PairingPrivateKey s = PairingPrivateKey.create(SIGNATURE_SCHEMA, new Random());
+        TssPublicShare mockPublic = mock(TssPublicShare.class);
+        when(mockPublic.publicKey()).thenReturn(s.createPublicKey());
         final List<TssPublicShare> publicShares =
                 List.of(mock(TssPublicShare.class), mock(TssPublicShare.class), mock(TssPublicShare.class));
         final PairingPublicKey ledgerID = tssService.aggregatePublicShares(publicShares);
         TssPrivateShare mock = mock(TssPrivateShare.class);
         when(mock.shareId()).thenReturn(mock(TssShareId.class));
-        when(mock.privateKey()).thenReturn(PairingPrivateKey.create(SIGNATURE_SCHEMA, new Random()));
+        when(mock.privateKey()).thenReturn(s);
         final List<TssPrivateShare> privateShares = List.of(mock);
 
         final SecureRandom random = new SecureRandom();
@@ -166,12 +169,12 @@ class TssTest {
         collectedSignatures.addAll(p2Signatures);
 
         final List<TssShareSignature> validSignatures = collectedSignatures.stream()
-                .filter(s -> tssService.verifySignature(p0sDirectory, publicShares, s))
+                .filter(sign -> tssService.verifySignature(p0sDirectory, publicShares, sign))
                 .toList();
 
         final PairingSignature signature = tssService.aggregateSignatures(validSignatures);
 
-        if (!signature.verifySignature(ledgerID, messageToSign)) {
+        if (!signature.verify(ledgerID, messageToSign)) {
             throw new IllegalStateException("Signature verification failed");
         }
     }


### PR DESCRIPTION
**Description**:
Exposing operation to verify the signature of a message

**Related issue(s)**:

Fixes [#15025](https://github.com/hashgraph/hedera-services/issues/15025)

**Notes for reviewer**:
Binary files are provided until compiling support with Gradle for Rust is completed.

**Checklist**
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)

