### PR TITLE
chore: 16438 Reoganizing code

### DIFF
--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/AltBn128Group.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/AltBn128Group.java
@@ -126,7 +126,7 @@ public class AltBn128Group implements Group {
      */
     @NonNull
     @Override
-    public GroupElement batchAdd(@NonNull final Collection<GroupElement> elements) {
+    public GroupElement add(@NonNull final Collection<GroupElement> elements) {
         Objects.requireNonNull(elements, "elements must not be null");
         List<AltBn128GroupElement> elems = elements.stream()
                 .map(e -> AltBn128GroupElement.isSameAltBn128GroupElement(this, e))

--- a/cryptography/hedera-cryptography-altbn128/src/test/java/com/hedera/cryptography/altbn128/AltBn128GroupElementTest.java
+++ b/cryptography/hedera-cryptography-altbn128/src/test/java/com/hedera/cryptography/altbn128/AltBn128GroupElementTest.java
@@ -58,7 +58,7 @@ class AltBn128GroupElementTest {
         var group = new AltBn128Group(gr);
         var field = new AltBn128Field();
         assertEquals(
-                group.batchAdd(List.of(group.generator(), group.generator(), group.generator(), group.generator())),
+                group.add(List.of(group.generator(), group.generator(), group.generator(), group.generator())),
                 group.generator().multiply(field.fromLong(4)));
     }
 
@@ -68,7 +68,7 @@ class AltBn128GroupElementTest {
         var group = new AltBn128Group(gr);
         var field = new AltBn128Field();
         assertEquals(
-                group.batchAdd(List.of(
+                group.add(List.of(
                         group.zero(),
                         group.generator(),
                         group.generator(),

--- a/cryptography/hedera-cryptography-altbn128/src/test/java/com/hedera/cryptography/altbn128/AltBn128GroupTest.java
+++ b/cryptography/hedera-cryptography-altbn128/src/test/java/com/hedera/cryptography/altbn128/AltBn128GroupTest.java
@@ -119,7 +119,6 @@ class AltBn128GroupTest {
         assertThrows(
                 IllegalArgumentException.class,
                 () -> group.batchMultiply(List.of(field.zero(), mock(FieldElement.class))));
-        assertThrows(
-                IllegalArgumentException.class, () -> group.batchAdd(List.of(group.zero(), mock(GroupElement.class))));
+        assertThrows(IllegalArgumentException.class, () -> group.add(List.of(group.zero(), mock(GroupElement.class))));
     }
 }

--- a/cryptography/hedera-cryptography-bls/src/main/java/com/hedera/cryptography/bls/BlsPublicKey.java
+++ b/cryptography/hedera-cryptography-bls/src/main/java/com/hedera/cryptography/bls/BlsPublicKey.java
@@ -102,7 +102,7 @@ public record BlsPublicKey(@NonNull GroupElement element, @NonNull SignatureSche
         final SignatureSchema schema = publicKeys.getFirst().signatureSchema();
         final List<GroupElement> elements =
                 publicKeys.stream().map(BlsPublicKey::element).toList();
-        final GroupElement aggregatedElement = schema.getPublicKeyGroup().batchAdd(elements);
+        final GroupElement aggregatedElement = schema.getPublicKeyGroup().add(elements);
         return new BlsPublicKey(aggregatedElement, schema);
     }
 

--- a/cryptography/hedera-cryptography-bls/src/main/java/com/hedera/cryptography/bls/BlsSignature.java
+++ b/cryptography/hedera-cryptography-bls/src/main/java/com/hedera/cryptography/bls/BlsSignature.java
@@ -104,7 +104,7 @@ public record BlsSignature(@NonNull GroupElement element, @NonNull SignatureSche
         final SignatureSchema schema = signatures.getFirst().signatureSchema();
         final List<GroupElement> elements =
                 signatures.stream().map(BlsSignature::element).toList();
-        final GroupElement aggregatedElement = schema.getSignatureGroup().batchAdd(elements);
+        final GroupElement aggregatedElement = schema.getSignatureGroup().add(elements);
         return new BlsSignature(aggregatedElement, schema);
     }
 

--- a/cryptography/hedera-cryptography-pairings-api/src/main/java/com/hedera/cryptography/pairings/api/Group.java
+++ b/cryptography/hedera-cryptography-pairings-api/src/main/java/com/hedera/cryptography/pairings/api/Group.java
@@ -106,7 +106,7 @@ public interface Group {
      * @return a new group element which is the sum the collection of elements
      */
     @NonNull
-    GroupElement batchAdd(@NonNull Collection<GroupElement> elements);
+    GroupElement add(@NonNull Collection<GroupElement> elements);
 
     /**
      * Creates a group element from its serialized encoding

--- a/cryptography/hedera-cryptography-pairings-api/src/main/java/com/hedera/cryptography/pairings/extensions/EcPolynomial.java
+++ b/cryptography/hedera-cryptography-pairings-api/src/main/java/com/hedera/cryptography/pairings/extensions/EcPolynomial.java
@@ -23,10 +23,8 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * A polynomial where the coefficients are points on the elliptic curve group.
- * /**
  * A polynomial, represented as a list of coefficients over the one of the groups of a defined EllipticCurve
- *  where each {@code coefficients[i]} is an element of that field, and corresponds to the coefficient for {@code x^i}.
+ * where each {@code coefficients[i]} is an element of that field, and corresponds to the coefficient for {@code x^i}.
  *<p>
  * The degree of the polynomial is the size of the coefficients +1 such that: <br/>
  *{@code p(x) = a_0 + a_1 * x + a_2 * x^2 + ... + a_d * x^d}

--- a/cryptography/hedera-cryptography-pairings-api/src/main/java/com/hedera/cryptography/pairings/extensions/EcPolynomial.java
+++ b/cryptography/hedera-cryptography-pairings-api/src/main/java/com/hedera/cryptography/pairings/extensions/EcPolynomial.java
@@ -17,21 +17,29 @@
 package com.hedera.cryptography.pairings.extensions;
 
 import com.hedera.cryptography.pairings.api.FieldElement;
-import com.hedera.cryptography.pairings.api.Group;
 import com.hedera.cryptography.pairings.api.GroupElement;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
 /**
  * A polynomial where the coefficients are points on the elliptic curve group.
+ * /**
+ * A polynomial, represented as a list of coefficients over the one of the groups of a defined EllipticCurve
+ *  where each {@code coefficients[i]} is an element of that field, and corresponds to the coefficient for {@code x^i}.
+ *<p>
+ * The degree of the polynomial is the size of the coefficients +1 such that: <br/>
+ *{@code p(x) = a_0 + a_1 * x + a_2 * x^2 + ... + a_d * x^d}
  *
- * @param coefficients the polynomial coefficients.
+ * @implNote it is responsibility of the user that the {@link GroupElement} instances are compatible with each-other.
+ *  Otherwise, it might fail on the {@link #evaluate(FieldElement)} method depending on the implementation
+ *  of {@link GroupElement} addition
+ * @param coefficients {@code a_0, a_1, ..., a_d} the coefficients of the polynomial.
  */
 public record EcPolynomial(@NonNull List<GroupElement> coefficients) {
     /**
-     * Constructor.
+     * Creates a polynomial that is represented as a list of {@link GroupElement} coefficients,
+     *  where {@code coefficients[i]} corresponds to the coefficient for {@code x^i}.
      *
      * @param coefficients The commitment coefficients.
      */
@@ -42,25 +50,12 @@ public record EcPolynomial(@NonNull List<GroupElement> coefficients) {
     }
 
     /**
-     * Creates a FeldmanCommitment which is a {@link EcPolynomial} where every
-     * coefficient consists of the group generator, raised to the power of a coefficient of the {@link FiniteFieldPolynomial} being committed to.
+     * Returns the degree of the polynomial.
      *
-     * @param group      the group that elements of the commitment are in
-     * @param finiteFieldPolynomial the polynomial to commit to
-     * @return the FeldmanCommitment
+     * @return the degree of the polynomial.
      */
-    @NonNull
-    public static EcPolynomial create(
-            @NonNull final Group group, @NonNull final FiniteFieldPolynomial finiteFieldPolynomial) {
-        final GroupElement generator = Objects.requireNonNull(group).generator();
-
-        final List<GroupElement> commitmentCoefficients = new ArrayList<>();
-        for (final FieldElement polynomialCoefficient :
-                Objects.requireNonNull(finiteFieldPolynomial).coefficients()) {
-            commitmentCoefficients.add(generator.multiply(polynomialCoefficient));
-        }
-
-        return new EcPolynomial(commitmentCoefficients);
+    public int degree() {
+        return coefficients.size() - 1;
     }
 
     /**

--- a/cryptography/hedera-cryptography-pairings-api/src/main/java/com/hedera/cryptography/pairings/extensions/EcPolynomial.java
+++ b/cryptography/hedera-cryptography-pairings-api/src/main/java/com/hedera/cryptography/pairings/extensions/EcPolynomial.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hedera.cryptography.tss.extensions;
+package com.hedera.cryptography.pairings.extensions;
 
 import com.hedera.cryptography.pairings.api.FieldElement;
 import com.hedera.cryptography.pairings.api.Group;
@@ -25,39 +25,42 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * A Feldman polynomial commitment.
+ * A polynomial where the coefficients are points on the elliptic curve group.
  *
- * @param commitmentCoefficients the commitment coefficients. Each privateKey in this list consists of the group generator,
- *                               raised to the power of a coefficient of the polynomial being committed to.
+ * @param coefficients the polynomial coefficients.
  */
-public record FeldmanCommitment(@NonNull List<GroupElement> commitmentCoefficients) {
+public record EcPolynomial(@NonNull List<GroupElement> coefficients) {
     /**
      * Constructor.
      *
-     * @param commitmentCoefficients The commitment coefficients.
+     * @param coefficients The commitment coefficients.
      */
-    public FeldmanCommitment {
-        if (commitmentCoefficients.isEmpty()) {
-            throw new IllegalArgumentException("Coefficient commitments must not be empty");
+    public EcPolynomial {
+        if (Objects.requireNonNull(coefficients).isEmpty()) {
+            throw new IllegalArgumentException("coefficients must not be empty");
         }
     }
 
     /**
-     * Creates a Feldman commitment.
+     * Creates a FeldmanCommitment which is a {@link EcPolynomial} where every
+     * coefficient consists of the group generator, raised to the power of a coefficient of the {@link FiniteFieldPolynomial} being committed to.
      *
      * @param group      the group that elements of the commitment are in
-     * @param polynomial the polynomial to commit to
-     * @return the Feldman commitment
+     * @param finiteFieldPolynomial the polynomial to commit to
+     * @return the FeldmanCommitment
      */
-    public static FeldmanCommitment create(@NonNull final Group group, @NonNull final Polynomial polynomial) {
-        final GroupElement generator = group.generator();
+    @NonNull
+    public static EcPolynomial create(
+            @NonNull final Group group, @NonNull final FiniteFieldPolynomial finiteFieldPolynomial) {
+        final GroupElement generator = Objects.requireNonNull(group).generator();
 
         final List<GroupElement> commitmentCoefficients = new ArrayList<>();
-        for (final FieldElement polynomialCoefficient : polynomial.coefficients()) {
+        for (final FieldElement polynomialCoefficient :
+                Objects.requireNonNull(finiteFieldPolynomial).coefficients()) {
             commitmentCoefficients.add(generator.multiply(polynomialCoefficient));
         }
 
-        return new FeldmanCommitment(commitmentCoefficients);
+        return new EcPolynomial(commitmentCoefficients);
     }
 
     /**
@@ -70,12 +73,11 @@ public record FeldmanCommitment(@NonNull List<GroupElement> commitmentCoefficien
     public GroupElement evaluate(@NonNull final FieldElement x) {
 
         Objects.requireNonNull(x, "x must not be null");
-        GroupElement result = commitmentCoefficients.getFirst();
-        for (int i = 1; i < commitmentCoefficients.size(); i++) {
-            final FieldElement exponentialShareId = x.power(i);
-            result = result.add(commitmentCoefficients.get(i).multiply(exponentialShareId));
+        int n = coefficients.size() - 1;
+        GroupElement result = coefficients.get(n);
+        for (int i = n - 1; i >= 0; i--) {
+            result = result.multiply(x).add(coefficients.get(i));
         }
-
         return result;
     }
 }

--- a/cryptography/hedera-cryptography-pairings-api/src/main/java/com/hedera/cryptography/pairings/extensions/FiniteFieldPolynomial.java
+++ b/cryptography/hedera-cryptography-pairings-api/src/main/java/com/hedera/cryptography/pairings/extensions/FiniteFieldPolynomial.java
@@ -19,18 +19,19 @@ package com.hedera.cryptography.pairings.extensions;
 import com.hedera.cryptography.pairings.api.Field;
 import com.hedera.cryptography.pairings.api.FieldElement;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Random;
 
 /**
- * A polynomial, represented as a list of coefficients over the field (such as 𝐹𝑝 or 𝑍𝑞, where 𝑝 or 𝑞 are prime)
+ * A polynomial, represented as a list of coefficients over the field (𝐹𝑝 or 𝑍𝑞, where 𝑝 or 𝑞 are prime)
  *  where each {@code coefficients[i]} is an element of that field, and corresponds to the coefficient for {@code x^i}.
+ *<p>
+ * The degree of the polynomial is the size of the coefficients +1 such that: <br/>
+ *{@code p(x) = a_0 + a_1 * x + a_2 * x^2 + ... + a_d * x^d}
  *
  * @implNote it is responsibility of the user that the {@link FieldElement} instances are compatible with each-other.
- *  Otherwise, it might fail on the {@link #evaluate(long)} method depending on the implementation of {@link FieldElement}
- * @param coefficients the coefficients of the polynomial.
+ *  Otherwise, it might fail on the {@link #evaluate(long)} method depending on the implementation of {@link FieldElement} addition.
+ * @param coefficients {@code a_0, a_1, ..., a_d} the coefficients of the polynomial.
  */
 public record FiniteFieldPolynomial(@NonNull List<FieldElement> coefficients) {
 
@@ -53,40 +54,6 @@ public record FiniteFieldPolynomial(@NonNull List<FieldElement> coefficients) {
      */
     public int degree() {
         return coefficients.size() - 1;
-    }
-
-    /**
-     * Creates a random degree d polynomial with a fixed point at x = 0.
-     * The polynomial generated here has d+1 number of coefficients: {@code a_0, a_1, ..., a_d} such that: <br/>
-     * {@code p(x) = a_0 + a_1 * x + a_2 * x^2 + ... + a_d * x^d}
-     *
-     * @param random    a source of randomness
-     * @param fixedValue the fixedValue to embed in the polynomial
-     * @param degree    the degree of the polynomial.
-     * @return a random polynomial of the given degree, with the given fixedValue embedded at x = 0
-     * @throws NullPointerException if any of the parameters is null
-     * @throws IllegalArgumentException if the degree is not a positive number
-     */
-    @NonNull
-    public static FiniteFieldPolynomial fromValue(
-            @NonNull final Random random, @NonNull final FieldElement fixedValue, final int degree) {
-
-        Objects.requireNonNull(random, "random must not be null");
-        final Field field = Objects.requireNonNull(fixedValue, "fixedValue must not be null")
-                .field();
-        if (degree <= 0) {
-            throw new IllegalArgumentException("degree must be positive");
-        }
-        final List<FieldElement> coefficients = new ArrayList<>(degree + 1);
-
-        // the fixedValue is embedded at x = 0
-        coefficients.add(fixedValue);
-
-        for (int i = 0; i < degree; i++) {
-            coefficients.add(field.random(random));
-        }
-
-        return new FiniteFieldPolynomial(coefficients);
     }
 
     /**

--- a/cryptography/hedera-cryptography-pairings-api/src/main/java/com/hedera/cryptography/pairings/extensions/FiniteFieldPolynomial.java
+++ b/cryptography/hedera-cryptography-pairings-api/src/main/java/com/hedera/cryptography/pairings/extensions/FiniteFieldPolynomial.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hedera.cryptography.tss.extensions;
+package com.hedera.cryptography.pairings.extensions;
 
 import com.hedera.cryptography.pairings.api.Field;
 import com.hedera.cryptography.pairings.api.FieldElement;
@@ -25,12 +25,14 @@ import java.util.Objects;
 import java.util.Random;
 
 /**
- * A polynomial, represented as a list of coefficients where each {@code coefficients[i]} corresponds to the coefficient for {@code x^i}.
+ * A polynomial, represented as a list of coefficients over the field (such as 𝐹𝑝 or 𝑍𝑞, where 𝑝 or 𝑞 are prime)
+ *  where each {@code coefficients[i]} is an element of that field, and corresponds to the coefficient for {@code x^i}.
+ *
  * @implNote it is responsibility of the user that the {@link FieldElement} instances are compatible with each-other.
  *  Otherwise, it might fail on the {@link #evaluate(long)} method depending on the implementation of {@link FieldElement}
  * @param coefficients the coefficients of the polynomial.
  */
-public record Polynomial(@NonNull List<FieldElement> coefficients) {
+public record FiniteFieldPolynomial(@NonNull List<FieldElement> coefficients) {
 
     /**
      * Creates a polynomial that is represented as a list of {@link FieldElement} coefficients,
@@ -39,7 +41,7 @@ public record Polynomial(@NonNull List<FieldElement> coefficients) {
      * @throws NullPointerException if {@code coefficients} parameter is null
      * @throws IllegalArgumentException if {@code coefficients} parameter is empty
      */
-    public Polynomial {
+    public FiniteFieldPolynomial {
         if (Objects.requireNonNull(coefficients).isEmpty())
             throw new IllegalArgumentException("coefficients cannot be empty");
     }
@@ -66,7 +68,7 @@ public record Polynomial(@NonNull List<FieldElement> coefficients) {
      * @throws IllegalArgumentException if the degree is not a positive number
      */
     @NonNull
-    public static Polynomial fromValue(
+    public static FiniteFieldPolynomial fromValue(
             @NonNull final Random random, @NonNull final FieldElement fixedValue, final int degree) {
 
         Objects.requireNonNull(random, "random must not be null");
@@ -84,7 +86,7 @@ public record Polynomial(@NonNull List<FieldElement> coefficients) {
             coefficients.add(field.random(random));
         }
 
-        return new Polynomial(coefficients);
+        return new FiniteFieldPolynomial(coefficients);
     }
 
     /**
@@ -95,13 +97,13 @@ public record Polynomial(@NonNull List<FieldElement> coefficients) {
      */
     @NonNull
     public FieldElement evaluate(final long value) {
+        int n = coefficients.size() - 1;
         final Field field = coefficients.getFirst().field();
-        final FieldElement fieldElement = field.fromLong(value);
-        FieldElement result = field.fromLong(0L);
-        for (int i = 0; i < coefficients.size(); i++) {
-            result = result.add(coefficients.get(i).multiply(fieldElement.power(i)));
+        final FieldElement x = field.fromLong(value);
+        FieldElement result = coefficients.get(n);
+        for (int i = n - 1; i >= 0; i--) {
+            result = result.multiply(x).add(coefficients.get(i));
         }
-
         return result;
     }
 }

--- a/cryptography/hedera-cryptography-pairings-api/src/main/java/module-info.java
+++ b/cryptography/hedera-cryptography-pairings-api/src/main/java/module-info.java
@@ -5,6 +5,7 @@ module com.hedera.cryptography.pairings.api {
     uses com.hedera.cryptography.pairings.spi.PairingFriendlyCurveProvider;
 
     exports com.hedera.cryptography.pairings.api;
+    exports com.hedera.cryptography.pairings.extensions;
     exports com.hedera.cryptography.pairings.api.curves;
     exports com.hedera.cryptography.pairings.spi;
 

--- a/cryptography/hedera-cryptography-pairings-api/src/test/java/com/hedera/cryptography/pairings/test/extensions/FiniteFieldPolynomialTest.java
+++ b/cryptography/hedera-cryptography-pairings-api/src/test/java/com/hedera/cryptography/pairings/test/extensions/FiniteFieldPolynomialTest.java
@@ -21,9 +21,11 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.hedera.cryptography.pairings.api.Curve;
 import com.hedera.cryptography.pairings.api.Field;
 import com.hedera.cryptography.pairings.api.FieldElement;
+import com.hedera.cryptography.pairings.api.PairingFriendlyCurve;
 import com.hedera.cryptography.pairings.api.PairingFriendlyCurves;
 import com.hedera.cryptography.pairings.extensions.FiniteFieldPolynomial;
 import com.hedera.cryptography.utils.test.fixtures.rng.WithRng;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.IntStream;
@@ -35,27 +37,8 @@ import org.junit.jupiter.api.Test;
 // possibly investigate: https://github.com/PoslavskySV/rings
 @WithRng
 class FiniteFieldPolynomialTest {
-
-    @Test
-    void testNegativeOrZeroDegreeThrowsException() {
-        var field = PairingFriendlyCurves.findInstance(Curve.ALT_BN128)
-                .pairingFriendlyCurve()
-                .field();
-        assertThrows(
-                IllegalArgumentException.class, () -> FiniteFieldPolynomial.fromValue(ROOT_RNG, field.fromLong(0), -1));
-        assertThrows(
-                IllegalArgumentException.class, () -> FiniteFieldPolynomial.fromValue(ROOT_RNG, field.fromLong(0), 0));
-    }
-
-    @SuppressWarnings("DataFlowIssue")
-    @Test
-    void testNullRandomOrSecretThrowsException() {
-        var field = PairingFriendlyCurves.findInstance(Curve.ALT_BN128)
-                .pairingFriendlyCurve()
-                .field();
-        assertThrows(NullPointerException.class, () -> FiniteFieldPolynomial.fromValue(null, field.fromLong(0), 10));
-        assertThrows(NullPointerException.class, () -> FiniteFieldPolynomial.fromValue(ROOT_RNG, null, 10));
-    }
+    private static final PairingFriendlyCurve CURVE =
+            PairingFriendlyCurves.findInstance(Curve.ALT_BN128).pairingFriendlyCurve();
 
     @Test
     void testEmptyCoefficientsThrowsException() {
@@ -64,26 +47,28 @@ class FiniteFieldPolynomialTest {
 
     @Test
     void testEvaluationReturnsNonNull(final Random rng) {
-        var curve = PairingFriendlyCurves.findInstance(Curve.ALT_BN128).pairingFriendlyCurve();
-        final Field field = curve.field();
-        var poly = FiniteFieldPolynomial.fromValue(rng, field.random(rng), 10);
-
-        var values = IntStream.range(0, 100).boxed().toList();
-
-        for (var value : values) {
-            assertNotNull(poly.evaluate(value));
-        }
+        var array = new byte[32];
+        rng.nextBytes(array);
+        var field = CURVE.field();
+        var coeff = IntStream.rangeClosed(0, array.length)
+                .mapToObj(i -> field.fromLong(array[i]))
+                .toList();
+        var poly = new FiniteFieldPolynomial(coeff);
+        IntStream.range(0, 100).forEach(i -> assertNotNull(poly.evaluate(i)));
     }
 
     @Test
-    void testEvaluationKnownResults() {
-        System.out.println();
-        var curve = PairingFriendlyCurves.findInstance(Curve.ALT_BN128).pairingFriendlyCurve();
-        final Field field = curve.field();
+    void testEvaluationKnownResults(final Random rng) {
+        final Field field = CURVE.field();
+        var degree = rng.nextInt(0, Integer.MAX_VALUE);
         final FieldElement freeCoeff = field.fromLong(1);
-        var poly =
-                new FiniteFieldPolynomial(List.of(freeCoeff, field.fromLong(1), field.fromLong(1), field.fromLong(1)));
+        final List<FieldElement> freeCoeff1 = Collections.nCopies(degree, freeCoeff);
+        var poly = new FiniteFieldPolynomial(freeCoeff1);
         assertEquals(freeCoeff, poly.evaluate(0));
-        assertEquals(field.fromLong(1).multiply(field.fromLong(poly.degree() + 1)), poly.evaluate(1));
+        var result = poly.evaluate(1);
+        for (int i = 0; i < degree; i++) {
+            result = result.subtract(freeCoeff);
+        }
+        assertEquals(freeCoeff, result);
     }
 }

--- a/cryptography/hedera-cryptography-pairings-api/src/test/java/com/hedera/cryptography/pairings/test/extensions/FiniteFieldPolynomialTest.java
+++ b/cryptography/hedera-cryptography-pairings-api/src/test/java/com/hedera/cryptography/pairings/test/extensions/FiniteFieldPolynomialTest.java
@@ -50,7 +50,7 @@ class FiniteFieldPolynomialTest {
         var array = new byte[32];
         rng.nextBytes(array);
         var field = CURVE.field();
-        var coeff = IntStream.rangeClosed(0, array.length)
+        var coeff = IntStream.range(0, array.length)
                 .mapToObj(i -> field.fromLong(array[i]))
                 .toList();
         var poly = new FiniteFieldPolynomial(coeff);

--- a/cryptography/hedera-cryptography-pairings-api/src/test/java/com/hedera/cryptography/pairings/test/extensions/FiniteFieldPolynomialTest.java
+++ b/cryptography/hedera-cryptography-pairings-api/src/test/java/com/hedera/cryptography/pairings/test/extensions/FiniteFieldPolynomialTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hedera.cryptography.tss.extensions;
+package com.hedera.cryptography.pairings.test.extensions;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -22,48 +22,51 @@ import com.hedera.cryptography.pairings.api.Curve;
 import com.hedera.cryptography.pairings.api.Field;
 import com.hedera.cryptography.pairings.api.FieldElement;
 import com.hedera.cryptography.pairings.api.PairingFriendlyCurves;
+import com.hedera.cryptography.pairings.extensions.FiniteFieldPolynomial;
 import com.hedera.cryptography.utils.test.fixtures.rng.WithRng;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 // FUTURE work:Given that the polynomial is defined for a finite field, it is not possible to easily test it.
 // By using an alternative finite field implementation, we can calculate a reference polynomial with the second library
 // and contrast the result of the two of them as a testing mechanism.
 // possibly investigate: https://github.com/PoslavskySV/rings
 @WithRng
-class PolynomialTest {
+class FiniteFieldPolynomialTest {
 
     @Test
     void testNegativeOrZeroDegreeThrowsException() {
+        var field = PairingFriendlyCurves.findInstance(Curve.ALT_BN128)
+                .pairingFriendlyCurve()
+                .field();
         assertThrows(
-                IllegalArgumentException.class,
-                () -> Polynomial.fromValue(Mockito.mock(Random.class), Mockito.mock(FieldElement.class), -1));
+                IllegalArgumentException.class, () -> FiniteFieldPolynomial.fromValue(ROOT_RNG, field.fromLong(0), -1));
         assertThrows(
-                IllegalArgumentException.class,
-                () -> Polynomial.fromValue(Mockito.mock(Random.class), Mockito.mock(FieldElement.class), 0));
+                IllegalArgumentException.class, () -> FiniteFieldPolynomial.fromValue(ROOT_RNG, field.fromLong(0), 0));
     }
 
     @SuppressWarnings("DataFlowIssue")
     @Test
     void testNullRandomOrSecretThrowsException() {
-        assertThrows(
-                NullPointerException.class, () -> Polynomial.fromValue(null, Mockito.mock(FieldElement.class), 10));
-        assertThrows(NullPointerException.class, () -> Polynomial.fromValue(Mockito.mock(Random.class), null, 10));
+        var field = PairingFriendlyCurves.findInstance(Curve.ALT_BN128)
+                .pairingFriendlyCurve()
+                .field();
+        assertThrows(NullPointerException.class, () -> FiniteFieldPolynomial.fromValue(null, field.fromLong(0), 10));
+        assertThrows(NullPointerException.class, () -> FiniteFieldPolynomial.fromValue(ROOT_RNG, null, 10));
     }
 
     @Test
     void testEmptyCoefficientsThrowsException() {
-        assertThrows(IllegalArgumentException.class, () -> new Polynomial(List.of()));
+        assertThrows(IllegalArgumentException.class, () -> new FiniteFieldPolynomial(List.of()));
     }
 
     @Test
     void testEvaluationReturnsNonNull(final Random rng) {
         var curve = PairingFriendlyCurves.findInstance(Curve.ALT_BN128).pairingFriendlyCurve();
         final Field field = curve.field();
-        var poly = Polynomial.fromValue(rng, field.random(rng), 10);
+        var poly = FiniteFieldPolynomial.fromValue(rng, field.random(rng), 10);
 
         var values = IntStream.range(0, 100).boxed().toList();
 
@@ -78,7 +81,8 @@ class PolynomialTest {
         var curve = PairingFriendlyCurves.findInstance(Curve.ALT_BN128).pairingFriendlyCurve();
         final Field field = curve.field();
         final FieldElement freeCoeff = field.fromLong(1);
-        var poly = new Polynomial(List.of(freeCoeff, field.fromLong(1), field.fromLong(1), field.fromLong(1)));
+        var poly =
+                new FiniteFieldPolynomial(List.of(freeCoeff, field.fromLong(1), field.fromLong(1), field.fromLong(1)));
         assertEquals(freeCoeff, poly.evaluate(0));
         assertEquals(field.fromLong(1).multiply(field.fromLong(poly.degree() + 1)), poly.evaluate(1));
     }

--- a/cryptography/hedera-cryptography-pairings-api/src/test/java/com/hedera/cryptography/pairings/test/spi/PairingMockFriendlyCurveProvider.java
+++ b/cryptography/hedera-cryptography-pairings-api/src/test/java/com/hedera/cryptography/pairings/test/spi/PairingMockFriendlyCurveProvider.java
@@ -331,7 +331,7 @@ public class PairingMockFriendlyCurveProvider extends PairingFriendlyCurveProvid
         /** {@inheritDoc} */
         @NonNull
         @Override
-        public GroupElement batchAdd(@NonNull final Collection<GroupElement> elements) {
+        public GroupElement add(@NonNull final Collection<GroupElement> elements) {
             return new TestGroupElement(this);
         }
 

--- a/cryptography/hedera-cryptography-pairings-api/src/test/java/module-info.java
+++ b/cryptography/hedera-cryptography-pairings-api/src/test/java/module-info.java
@@ -4,6 +4,7 @@ import com.hedera.cryptography.pairings.test.spi.PairingMockFriendlyCurveProvide
 
 open module com.hedera.cryptography.pairings.test {
     requires transitive com.hedera.cryptography.pairings.api;
+    requires com.hedera.cryptography.utils.test.fixtures;
     requires org.junit.jupiter.api;
 
     uses PairingFriendlyCurveProvider;

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/api/TssParticipantDirectory.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/api/TssParticipantDirectory.java
@@ -22,7 +22,7 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.cryptography.bls.BlsPrivateKey;
 import com.hedera.cryptography.bls.BlsPublicKey;
 import com.hedera.cryptography.bls.SignatureSchema;
-import com.hedera.cryptography.tss.extensions.TssKeyTableImpl;
+import com.hedera.cryptography.tss.extensions.TssEncryptionKeyMap;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -55,7 +55,7 @@ import java.util.stream.IntStream;
  * }</pre>
  *
  */
-public final class TssParticipantDirectory implements TssKeyTable<BlsPublicKey> {
+public final class TssParticipantDirectory implements TssShareTable<BlsPublicKey> {
     /**
      * Stores the ID of the {@code participant} owning this directory.
      */
@@ -85,7 +85,7 @@ public final class TssParticipantDirectory implements TssKeyTable<BlsPublicKey> 
     /**
      * Stores the {@link BlsPublicKey} of each {@code ShareId} in the protocol.
      */
-    private final TssKeyTable<BlsPublicKey> tssEncryptionTable;
+    private final TssShareTable<BlsPublicKey> tssEncryptionTable;
 
     /**
      * Constructs a {@link TssParticipantDirectory}.
@@ -101,7 +101,7 @@ public final class TssParticipantDirectory implements TssKeyTable<BlsPublicKey> 
             final int participantId,
             @NonNull final List<Integer> shareIds,
             @NonNull final List<Integer> ownedShareIds,
-            @NonNull final TssKeyTable<BlsPublicKey> tssEncryptionTable,
+            @NonNull final TssShareTable<BlsPublicKey> tssEncryptionTable,
             @NonNull final BlsPrivateKey tssDecryptionPrivateKey,
             final int threshold) {
         this.participantId = participantId;
@@ -171,8 +171,8 @@ public final class TssParticipantDirectory implements TssKeyTable<BlsPublicKey> 
      */
     @NonNull
     @Override
-    public BlsPublicKey resolveKeyForShare(final int shareId) {
-        return tssEncryptionTable.resolveKeyForShare(shareId);
+    public BlsPublicKey getForShareId(final int shareId) {
+        return tssEncryptionTable.getForShareId(shareId);
     }
 
     /**
@@ -315,7 +315,7 @@ public final class TssParticipantDirectory implements TssKeyTable<BlsPublicKey> 
                     selfEntry.participantId,
                     shareIds,
                     ownedShares,
-                    new TssKeyTableImpl<>(shareOwnershipTable, tssEncryptionPublicKeyTable),
+                    new TssEncryptionKeyMap(shareOwnershipTable, tssEncryptionPublicKeyTable),
                     selfEntry.tssEncryptionPrivateKey,
                     threshold);
         }

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/api/TssPrivateShare.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/api/TssPrivateShare.java
@@ -47,21 +47,6 @@ public record TssPrivateShare(@NonNull Integer shareId, @NonNull BlsPrivateKey p
     }
 
     /**
-     * Creates a new instance.
-     *
-     * @param id id
-     * @param privateKey the private key
-     * @return a new {@link TssPrivateShare}
-     */
-    public static TssPrivateShare of(final int id, @NonNull final BlsPrivateKey privateKey) {
-        requireNonNull(privateKey, "privateKey must not be null");
-        if (id <= 0) {
-            throw new IllegalArgumentException("id must be greater than 0");
-        }
-        return new TssPrivateShare(id, privateKey);
-    }
-
-    /**
      * Sign a message using the private share's key.
      * @param message the message to sign
      * @return the {@link TssShareSignature}

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/api/TssPublicShare.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/api/TssPublicShare.java
@@ -49,33 +49,6 @@ public record TssPublicShare(@NonNull Integer shareId, @NonNull BlsPublicKey pub
     }
 
     /**
-     * Creates a new instance.
-     *
-     * @param id id
-     * @param publicKey the private key
-     * @return a new {@link TssPublicShare}
-     */
-    public static TssPublicShare of(final int id, @NonNull final BlsPublicKey publicKey) {
-        requireNonNull(publicKey, "publicKey must not be null");
-        if (id <= 0) {
-            throw new IllegalArgumentException("id must be greater than 0");
-        }
-        return new TssPublicShare(id, publicKey);
-    }
-
-    /**
-     * verifies a signature using.
-     *
-     * @param signature the signature to verify
-     * @param message the signed message
-     * @return if the signature is valid.
-     */
-    boolean verifySignature(@NonNull TssShareSignature signature, final @NonNull byte[] message) {
-        requireNonNull(signature, "signature must not be null");
-        return signature.signature().verify(this.publicKey(), message);
-    }
-
-    /**
      * Aggregate a threshold number of {@link TssPublicShare}s.
      * It is the responsibility of the caller to ensure that the list of public shares meets the required threshold.
      * If the threshold is not met, the public key returned by this method will be invalid.

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/api/TssShareSignature.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/api/TssShareSignature.java
@@ -49,21 +49,6 @@ public record TssShareSignature(@NonNull Integer shareId, @NonNull BlsSignature 
     }
 
     /**
-     * Creates a new instance.
-     *
-     * @param id id
-     * @param signature the private key
-     * @return a new {@link TssShareSignature}
-     */
-    public static TssShareSignature of(final int id, @NonNull final BlsSignature signature) {
-        requireNonNull(signature, "signature must not be null");
-        if (id <= 0) {
-            throw new IllegalArgumentException("id must be greater than 0");
-        }
-        return new TssShareSignature(id, signature);
-    }
-
-    /**
      * verifies a signature using.
      *
      * @param publicShare the publicShare to verify the signature represented by this instance

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/api/TssShareTable.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/api/TssShareTable.java
@@ -16,21 +16,20 @@
 
 package com.hedera.cryptography.tss.api;
 
-import com.hedera.cryptography.bls.BlsPublicKey;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * Allows to obtain a {@link BlsPublicKey} given a shareId
- * T The type of the key
+ * Allows to obtain a {@code T} element given a shareId
+ * @param <T>  The type of the element being mapped to a shareId
  */
-public interface TssKeyTable<T> {
+public interface TssShareTable<T> {
     /**
-     * Obtains a {@link BlsPublicKey} given a shareId.
-     * Null if the shareId is not present or its owner cannot be found.
-     * @param tssShareId an integer representing the shareId starting in 1.
-     * @return the BlsPublicKey of the participant that owns the tssShareId.
+     * Allows to obtain a {@code T} element given a shareId
+     * Null if the shareId cannot be associated to an element.
+     * @param shareId an integer representing the shareId starting in 1. 0 is not a valid shareId
+     * @return the T associated to a shareId.
      * @throws IllegalArgumentException if the shareId less or equals to 0 or if it is higher than the total assigned shares
      */
     @NonNull
-    T resolveKeyForShare(int tssShareId);
+    T getForShareId(int shareId);
 }

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/Lagrange.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/Lagrange.java
@@ -92,7 +92,7 @@ public class Lagrange {
                 .boxed()
                 .map(i -> ys.get(i).multiply(coefficient(xs, i)))
                 .toList();
-        return group.batchAdd(weightedElements);
+        return group.add(weightedElements);
     }
 
     /**

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/Shamir.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/Shamir.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.cryptography.tss.extensions;
+
+import com.hedera.cryptography.pairings.api.Field;
+import com.hedera.cryptography.pairings.api.FieldElement;
+import com.hedera.cryptography.pairings.api.Group;
+import com.hedera.cryptography.pairings.api.GroupElement;
+import com.hedera.cryptography.pairings.extensions.EcPolynomial;
+import com.hedera.cryptography.pairings.extensions.FiniteFieldPolynomial;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+
+/**
+ * This class uses allows creating an interpolation polynomial as used in shamir-secret-sharing.
+ * And a commitment to that polynomial
+ */
+public class Shamir {
+
+    private Shamir() {}
+
+    /**
+     * Creates a random degree d polynomial with a fixed point at x = 0.
+     * The polynomial generated here has d+1 number of coefficients: {@code a_0, a_1, ..., a_d} such that: <br/>
+     * {@code p(x) = a_0 + a_1 * x + a_2 * x^2 + ... + a_d * x^d}
+     *
+     * @param random    a source of randomness
+     * @param fixedValue the fixedValue to embed in the polynomial
+     * @param degree    the degree of the polynomial.
+     * @return a random polynomial of the given degree, with the given fixedValue embedded at x = 0
+     * @throws NullPointerException if any of the parameters is null
+     * @throws IllegalArgumentException if the degree is not a positive number
+     */
+    @NonNull
+    public static FiniteFieldPolynomial interpolationPolynomial(
+            @NonNull final Random random, @NonNull final FieldElement fixedValue, final int degree) {
+
+        Objects.requireNonNull(random, "random must not be null");
+        final Field field = Objects.requireNonNull(fixedValue, "fixedValue must not be null")
+                .field();
+        if (degree <= 0) {
+            throw new IllegalArgumentException("degree must be positive");
+        }
+        final List<FieldElement> coefficients = new ArrayList<>(degree + 1);
+
+        // the fixedValue is embedded at x = 0
+        coefficients.add(fixedValue);
+
+        for (int i = 0; i < degree; i++) {
+            coefficients.add(field.random(random));
+        }
+
+        return new FiniteFieldPolynomial(coefficients);
+    }
+
+    /**
+     * Creates a FeldmanCommitment which is a {@link EcPolynomial} where every
+     * coefficient consists of the group generator, raised to the power of a coefficient of the {@link FiniteFieldPolynomial} being committed to.
+     *
+     * @param group the group that elements of the commitment are in
+     * @param finiteFieldPolynomial the polynomial to commit to
+     * @return the FeldmanCommitment
+     */
+    @NonNull
+    public static EcPolynomial feldmanCommitment(
+            @NonNull final Group group, @NonNull final FiniteFieldPolynomial finiteFieldPolynomial) {
+        final GroupElement generator = Objects.requireNonNull(group).generator();
+
+        final List<GroupElement> commitmentCoefficients = new ArrayList<>();
+        for (final FieldElement polynomialCoefficient :
+                Objects.requireNonNull(finiteFieldPolynomial).coefficients()) {
+            commitmentCoefficients.add(generator.multiply(polynomialCoefficient));
+        }
+
+        return new EcPolynomial(commitmentCoefficients);
+    }
+}

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/ShamirUtils.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/ShamirUtils.java
@@ -32,9 +32,9 @@ import java.util.Random;
  * This class uses allows creating an interpolation polynomial as used in shamir-secret-sharing.
  * And a commitment to that polynomial
  */
-public class Shamir {
+public class ShamirUtils {
 
-    private Shamir() {}
+    private ShamirUtils() {}
 
     /**
      * Creates a random degree d polynomial with a fixed point at x = 0.
@@ -82,10 +82,9 @@ public class Shamir {
     public static EcPolynomial feldmanCommitment(
             @NonNull final Group group, @NonNull final FiniteFieldPolynomial finiteFieldPolynomial) {
         final GroupElement generator = Objects.requireNonNull(group).generator();
-
+        Objects.requireNonNull(finiteFieldPolynomial, "finiteFieldPolynomial must not be null");
         final List<GroupElement> commitmentCoefficients = new ArrayList<>();
-        for (final FieldElement polynomialCoefficient :
-                Objects.requireNonNull(finiteFieldPolynomial).coefficients()) {
+        for (final FieldElement polynomialCoefficient : finiteFieldPolynomial.coefficients()) {
             commitmentCoefficients.add(generator.multiply(polynomialCoefficient));
         }
 

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/TssEncryptionKeyMap.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/TssEncryptionKeyMap.java
@@ -17,14 +17,13 @@
 package com.hedera.cryptography.tss.extensions;
 
 import com.hedera.cryptography.bls.BlsPublicKey;
-import com.hedera.cryptography.tss.api.TssKeyTable;
+import com.hedera.cryptography.tss.api.TssShareTable;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * An TssEncryptionEncryption Table.
- * It maps a shareId to its participants {@link BlsPublicKey} for encryption.
+ * A {@link TssShareTable} that maps a shareId to its participants {@link BlsPublicKey} for encryption.
  */
-public class TssKeyTableImpl<T> implements TssKeyTable<T> {
+public class TssEncryptionKeyMap implements TssShareTable<BlsPublicKey> {
 
     /**
      * Stores the {@code participant} that is the owner of each shareId in the protocol.
@@ -37,7 +36,7 @@ public class TssKeyTableImpl<T> implements TssKeyTable<T> {
      * Stores the {@link BlsPublicKey} of each {@code participant} in the protocol.
      * There is one BlsPublicKey per participant
      */
-    private final T[] tssKeyTable;
+    private final BlsPublicKey[] tssKeyTable;
 
     /**
      * Constructor
@@ -45,7 +44,7 @@ public class TssKeyTableImpl<T> implements TssKeyTable<T> {
      * @param shareAllocationTable  Stores the {@code participant} that is the owner of each shareId in the protocol.
      * @param tssKeyTable Stores the {@link BlsPublicKey} of each {@code participant} in the protocol.
      */
-    public TssKeyTableImpl(final int[] shareAllocationTable, final T[] tssKeyTable) {
+    public TssEncryptionKeyMap(final int[] shareAllocationTable, final BlsPublicKey[] tssKeyTable) {
         this.shareAllocationTable = shareAllocationTable;
         this.tssKeyTable = tssKeyTable;
     }
@@ -58,7 +57,7 @@ public class TssKeyTableImpl<T> implements TssKeyTable<T> {
      */
     @NonNull
     @Override
-    public T resolveKeyForShare(final int shareId) {
+    public BlsPublicKey getForShareId(final int shareId) {
         if (shareId > shareAllocationTable.length || shareId <= 0) {
             throw new IllegalArgumentException("Invalid ShareId");
         }

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/elgamal/CiphertextTable.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/elgamal/CiphertextTable.java
@@ -41,7 +41,7 @@ public record CiphertextTable(@NonNull List<GroupElement> sharedRandomness, @Non
     public CombinedCiphertext combine(@NonNull final FieldElement base) {
         final GroupElement randomness = new EcPolynomial(sharedRandomness()).evaluate(base);
 
-        final List<GroupElement> values = Arrays.stream(this.shareCiphertexts())
+        final List<GroupElement> values = Arrays.stream(shareCiphertexts)
                 .map(cipherText -> new EcPolynomial(cipherText.cipherText()))
                 .map(poly -> poly.evaluate(base))
                 .toList();

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/elgamal/CiphertextTable.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/elgamal/CiphertextTable.java
@@ -18,8 +18,9 @@ package com.hedera.cryptography.tss.extensions.elgamal;
 
 import com.hedera.cryptography.pairings.api.FieldElement;
 import com.hedera.cryptography.pairings.api.GroupElement;
+import com.hedera.cryptography.pairings.extensions.EcPolynomial;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -38,24 +39,12 @@ public record CiphertextTable(@NonNull List<GroupElement> sharedRandomness, @Non
      */
     @NonNull
     public CombinedCiphertext combine(@NonNull final FieldElement base) {
-        final List<GroupElement> toCombineRandomness = new ArrayList<>();
+        final GroupElement randomness = new EcPolynomial(sharedRandomness()).evaluate(base);
 
-        for (int i = 0; i < this.sharedRandomness().size(); i++) {
-            toCombineRandomness.add(this.sharedRandomness().get(i).multiply(base.power(i)));
-        }
-        final GroupElement randomness =
-                toCombineRandomness.getFirst().getGroup().batchAdd(toCombineRandomness);
-
-        final List<GroupElement> values = new ArrayList<>();
-        for (int i = 0; i < this.shareCiphertexts().length; i++) {
-            final List<GroupElement> iValue = this.shareCiphertexts()[i].cipherText();
-            final List<GroupElement> toCombineIthValue = new ArrayList<>();
-            for (int j = 0; j < iValue.size(); j++) {
-                final GroupElement ijValue = iValue.get(j);
-                toCombineIthValue.add(ijValue.multiply(base.power(j)));
-            }
-            values.add(toCombineIthValue.getFirst().getGroup().batchAdd(toCombineIthValue));
-        }
+        final List<GroupElement> values = Arrays.stream(this.shareCiphertexts())
+                .map(cipherText -> new EcPolynomial(cipherText.cipherText()))
+                .map(poly -> poly.evaluate(base))
+                .toList();
         return new CombinedCiphertext(randomness, values);
     }
 }

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/elgamal/CiphertextTable.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/elgamal/CiphertextTable.java
@@ -39,7 +39,7 @@ public record CiphertextTable(@NonNull List<GroupElement> sharedRandomness, @Non
      */
     @NonNull
     public CombinedCiphertext combine(@NonNull final FieldElement base) {
-        final GroupElement randomness = new EcPolynomial(sharedRandomness()).evaluate(base);
+        final GroupElement randomness = new EcPolynomial(sharedRandomness).evaluate(base);
 
         final List<GroupElement> values = Arrays.stream(shareCiphertexts)
                 .map(cipherText -> new EcPolynomial(cipherText.cipherText()))

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/elgamal/CombinedCiphertext.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/elgamal/CombinedCiphertext.java
@@ -17,6 +17,7 @@
 package com.hedera.cryptography.tss.extensions.elgamal;
 
 import com.hedera.cryptography.pairings.api.GroupElement;
+import com.hedera.cryptography.tss.api.TssShareTable;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 
@@ -25,4 +26,11 @@ import java.util.List;
  * @param randomness a compressed shared randomness value
  * @param values a combined representation of all the elements in a {@link CiphertextTable}
  */
-public record CombinedCiphertext(@NonNull GroupElement randomness, @NonNull List<GroupElement> values) {}
+public record CombinedCiphertext(@NonNull GroupElement randomness, @NonNull List<GroupElement> values)
+        implements TssShareTable<GroupElement> {
+    @NonNull
+    @Override
+    public GroupElement getForShareId(final int shareId) {
+        return values().get(shareId - 1);
+    }
+}

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/elgamal/ElGamalUtils.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/elgamal/ElGamalUtils.java
@@ -23,7 +23,7 @@ import com.hedera.cryptography.pairings.api.Field;
 import com.hedera.cryptography.pairings.api.FieldElement;
 import com.hedera.cryptography.pairings.api.Group;
 import com.hedera.cryptography.pairings.api.GroupElement;
-import com.hedera.cryptography.tss.api.TssKeyTable;
+import com.hedera.cryptography.tss.api.TssShareTable;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.ArrayList;
@@ -228,7 +228,7 @@ public class ElGamalUtils {
     public static CiphertextTable ciphertextTable(
             @NonNull final SignatureSchema signatureSchema,
             @NonNull final List<FieldElement> randomness,
-            @NonNull final TssKeyTable<BlsPublicKey> tssEncryptionKeyResolver,
+            @NonNull final TssShareTable<BlsPublicKey> tssEncryptionKeyResolver,
             @NonNull final List<FieldElement> secrets) {
 
         final Group publicKeyGroup = Objects.requireNonNull(signatureSchema, "signatureSchema must not be null")
@@ -246,7 +246,7 @@ public class ElGamalUtils {
         CipherText[] multiEncryptedValues = new CipherText[secrets.size()];
         for (int i = 0; i < secrets.size(); i++) {
             final FieldElement secret = secrets.get(i);
-            final BlsPublicKey pk = tssEncryptionKeyResolver.resolveKeyForShare(i + 1);
+            final BlsPublicKey pk = tssEncryptionKeyResolver.getForShareId(i + 1);
             multiEncryptedValues[i] = createCipherText(pk, elGamalSubstitutionTable, randomness, secret.toBytes());
         }
         return new CiphertextTable(List.copyOf(chunkRandomness), multiEncryptedValues);

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/nizk/NizkProof.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/nizk/NizkProof.java
@@ -21,6 +21,7 @@ import com.hedera.cryptography.pairings.api.Field;
 import com.hedera.cryptography.pairings.api.FieldElement;
 import com.hedera.cryptography.pairings.api.Group;
 import com.hedera.cryptography.pairings.api.GroupElement;
+import com.hedera.cryptography.tss.api.TssShareTable;
 import com.hedera.cryptography.utils.HashUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
@@ -104,14 +105,14 @@ public record NizkProof(
                 statement.tssShareIds().stream().map(x::power).toList();
         // the list of shares is stored in a way where index 0 belongs to shareId=1,
         // so to retrieve x^1 we need to access shareId-1 index.
-        final Function<Integer, FieldElement> xPowerShareIndex = shareId -> xPowerId.get(shareId - 1);
+        final TssShareTable<FieldElement> xPowerShareIndex = shareId -> xPowerId.get(shareId - 1);
 
         // compute Y = Π_{i=1}^{n} (y_i)^x^i
         GroupElement yAggregator = publicKeyGroup.zero();
         for (int shareId : statement.tssShareIds()) {
             final GroupElement yi =
-                    statement.tssEncryptionKeys().resolveKeyForShare(shareId).element();
-            yAggregator = yAggregator.add(yi.multiply(xPowerShareIndex.apply(shareId)));
+                    statement.tssEncryptionKeys().getForShareId(shareId).element();
+            yAggregator = yAggregator.add(yi.multiply(xPowerShareIndex.getForShareId(shareId)));
         }
         final GroupElement y = yAggregator.multiply(rho).add(a);
 
@@ -127,7 +128,7 @@ public record NizkProof(
         FieldElement sigma = field.fromLong(0L);
         for (int shareId : statement.tssShareIds()) {
             final FieldElement si = secretPerShareIndex.apply(shareId);
-            sigma = sigma.add(si.multiply(xPowerShareIndex.apply(shareId)));
+            sigma = sigma.add(si.multiply(xPowerShareIndex.getForShareId(shareId)));
         }
         // compute z_a = x' * Sigma_{i=1}^{n} (s_i)*x^i + alpha
         final FieldElement z_a = xPrime.multiply(sigma).add(alpha);
@@ -168,13 +169,13 @@ public record NizkProof(
                 statement.tssShareIds().stream().map(x::power).toList();
         // the list of shares is stored in a way where index 0 belongs to shareId=1,
         // so to retrieve x^1 we need to access shareId-1 index.
-        final Function<Integer, FieldElement> xPowerShareIndex = shareId -> xPowerId.get(shareId - 1);
+        final TssShareTable<FieldElement> xPowerShareIndex = shareId -> xPowerId.get(shareId - 1);
         final List<Entry<FieldElement, FieldElement>> idxPowerId = statement.tssShareIds().stream()
-                .map(id -> Map.entry(field.fromLong(id), xPowerShareIndex.apply(id)))
+                .map(id -> Map.entry(field.fromLong(id), xPowerShareIndex.getForShareId(id)))
                 .toList();
         final List<GroupElement> results = new ArrayList<>();
         final List<GroupElement> polyCoefficients =
-                statement.polynomialCommitment().commitmentCoefficients();
+                statement.polynomialCommitment().coefficients();
         for (int k = 0; k < polyCoefficients.size(); k++) {
             final GroupElement kthCoefficients = polyCoefficients.get(k);
             final List<FieldElement> list = new ArrayList<>();
@@ -185,7 +186,7 @@ public record NizkProof(
             results.add(kthCoefficients.multiply(fold));
         }
 
-        GroupElement inner = publicKeyGroup.batchAdd(results);
+        GroupElement inner = publicKeyGroup.add(results);
         lhs = inner.multiply(xPrime).add(this.a);
         rhs = publicKeyGroup.generator().multiply(this.zA);
         if (!lhs.equals(rhs)) {
@@ -193,12 +194,10 @@ public record NizkProof(
         }
 
         // CombinedCipherText are stored per index, so to retrieve them by shareId we need to decrease the value by 1
-        final Function<Integer, GroupElement> shareToGroupElement =
-                shareId -> statement.combinedCiphertext().values().get(shareId - 1);
         inner = publicKeyGroup.zero();
         for (int shareId : statement.tssShareIds()) {
-            final GroupElement ci = shareToGroupElement.apply(shareId);
-            inner = inner.add(ci.multiply(xPowerShareIndex.apply(shareId)));
+            final GroupElement ci = statement.combinedCiphertext().getForShareId(shareId);
+            inner = inner.add(ci.multiply(xPowerShareIndex.getForShareId(shareId)));
         }
 
         lhs = inner.multiply(xPrime).add(this.y);
@@ -206,8 +205,8 @@ public record NizkProof(
         inner = publicKeyGroup.zero();
         for (int shareId : statement.tssShareIds()) {
             GroupElement yi =
-                    statement.tssEncryptionKeys().resolveKeyForShare(shareId).element();
-            inner = inner.add(yi.multiply(this.zR.multiply(xPowerShareIndex.apply(shareId))));
+                    statement.tssEncryptionKeys().getForShareId(shareId).element();
+            inner = inner.add(yi.multiply(this.zR.multiply(xPowerShareIndex.getForShareId(shareId))));
         }
 
         rhs = inner.add(publicKeyGroup.generator().multiply(this.zA));

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/nizk/NizkStatement.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/nizk/NizkStatement.java
@@ -18,8 +18,8 @@ package com.hedera.cryptography.tss.extensions.nizk;
 
 import com.hedera.cryptography.bls.BlsPublicKey;
 import com.hedera.cryptography.pairings.api.GroupElement;
-import com.hedera.cryptography.tss.api.TssKeyTable;
-import com.hedera.cryptography.tss.extensions.FeldmanCommitment;
+import com.hedera.cryptography.pairings.extensions.EcPolynomial;
+import com.hedera.cryptography.tss.api.TssShareTable;
 import com.hedera.cryptography.tss.extensions.elgamal.CombinedCiphertext;
 import com.hedera.cryptography.utils.HashUtils;
 import com.hedera.cryptography.utils.HashUtils.HashCalculator;
@@ -32,13 +32,13 @@ import java.util.Objects;
  *
  * @param tssShareIds a list of tssIds, should be consecutive and each id value should match the index in the list.
  * @param tssEncryptionKeys a Map to retrieve the corresponding tssEncryptionKey of the participant owning the share
- * @param polynomialCommitment a {@link FeldmanCommitment}
+ * @param polynomialCommitment a {@link EcPolynomial}
  * @param combinedCiphertext a {@link CombinedCiphertext}
  */
 public record NizkStatement(
         @NonNull List<Integer> tssShareIds,
-        @NonNull TssKeyTable<BlsPublicKey> tssEncryptionKeys,
-        @NonNull FeldmanCommitment polynomialCommitment,
+        @NonNull TssShareTable<BlsPublicKey> tssEncryptionKeys,
+        @NonNull EcPolynomial polynomialCommitment,
         @NonNull CombinedCiphertext combinedCiphertext) {
     /**
      * Constructor.
@@ -59,10 +59,10 @@ public record NizkStatement(
         final HashCalculator calculator = HashUtils.getHashCalculator(HashUtils.SHA256);
         for (Integer shareIds : tssShareIds) {
             calculator.append(shareIds);
-            final BlsPublicKey publicKey = tssEncryptionKeys.resolveKeyForShare(shareIds);
+            final BlsPublicKey publicKey = tssEncryptionKeys.getForShareId(shareIds);
             calculator.append(publicKey.element().toBytes());
         }
-        for (GroupElement coefficient : polynomialCommitment.commitmentCoefficients()) {
+        for (GroupElement coefficient : polynomialCommitment.coefficients()) {
             calculator.append(coefficient.toBytes());
         }
         for (GroupElement cv : combinedCiphertext.values()) {

--- a/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/TssParticipantDirectoryTest.java
+++ b/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/TssParticipantDirectoryTest.java
@@ -160,11 +160,11 @@ class TssParticipantDirectoryTest {
         assertEquals(List.of(1, 2, 3, 4, 5, 6, 7), directory.getShareIds());
         var keys =
                 new BlsPublicKey[] {publicKey1, publicKey1, publicKey1, publicKey1, publicKey1, publicKey2, publicKey2};
-        IntStream.range(0, keys.length).forEach(k -> assertEquals(keys[k], directory.resolveKeyForShare(k + 1)));
+        IntStream.range(0, keys.length).forEach(k -> assertEquals(keys[k], directory.getForShareId(k + 1)));
     }
 
     @Test
-    void testResolveKeyForShare() {
+    void testGetForShareId() {
         final BlsPrivateKey privateKey = mock(BlsPrivateKey.class);
         final BlsPublicKey publicKey1 = mock(BlsPublicKey.class);
         final BlsPublicKey publicKey2 = mock(BlsPublicKey.class);
@@ -175,12 +175,12 @@ class TssParticipantDirectoryTest {
                 .withThreshold(1)
                 .build(signatureSchema);
 
-        assertEquals(publicKey1, directory.resolveKeyForShare(1));
-        assertEquals(publicKey1, directory.resolveKeyForShare(5));
-        assertEquals(publicKey2, directory.resolveKeyForShare(6));
-        assertEquals(publicKey2, directory.resolveKeyForShare(7));
-        assertThrows(IllegalArgumentException.class, () -> directory.resolveKeyForShare(8));
-        assertThrows(IllegalArgumentException.class, () -> directory.resolveKeyForShare(0));
-        assertThrows(IllegalArgumentException.class, () -> directory.resolveKeyForShare(-1));
+        assertEquals(publicKey1, directory.getForShareId(1));
+        assertEquals(publicKey1, directory.getForShareId(5));
+        assertEquals(publicKey2, directory.getForShareId(6));
+        assertEquals(publicKey2, directory.getForShareId(7));
+        assertThrows(IllegalArgumentException.class, () -> directory.getForShareId(8));
+        assertThrows(IllegalArgumentException.class, () -> directory.getForShareId(0));
+        assertThrows(IllegalArgumentException.class, () -> directory.getForShareId(-1));
     }
 }

--- a/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/TssTest.java
+++ b/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/TssTest.java
@@ -164,7 +164,7 @@ class TssTest {
         var signatures = privateShares.stream().map(p -> p.sign(messageToSign)).toList();
 
         // After signing, it will collect all other participant signatures
-        final List<TssShareSignature> p1Signatures = List.of(TssShareSignature.of(
+        final List<TssShareSignature> p1Signatures = List.of(new TssShareSignature(
                 2,
                 new BlsPrivateKey(
                                 SIGNATURE_SCHEMA
@@ -173,7 +173,7 @@ class TssTest {
                                         .fromLong(2),
                                 SIGNATURE_SCHEMA)
                         .sign(messageToSign)));
-        final List<TssShareSignature> p2Signatures = List.of(TssShareSignature.of(
+        final List<TssShareSignature> p2Signatures = List.of(new TssShareSignature(
                 3,
                 new BlsPrivateKey(
                                 SIGNATURE_SCHEMA

--- a/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/extensions/AggregationTest.java
+++ b/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/extensions/AggregationTest.java
@@ -29,8 +29,6 @@ import com.hedera.cryptography.bls.SignatureSchema;
 import com.hedera.cryptography.pairings.api.Curve;
 import com.hedera.cryptography.pairings.api.GroupElement;
 import com.hedera.cryptography.utils.test.fixtures.rng.WithRng;
-import com.hedera.cryptography.pairings.extensions.EcPolynomial;
-import com.hedera.cryptography.pairings.extensions.FiniteFieldPolynomial;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Random;
@@ -144,11 +142,11 @@ public class AggregationTest {
                 .map(BlsPrivateKey::element)
                 .toList();
         final var polynomials = privateKeys.stream()
-                .map(s -> FiniteFieldPolynomial.fromValue(random, s, currentThreshold - 1))
+                .map(s -> Shamir.interpolationPolynomial(random, s, currentThreshold - 1))
                 .limit(previousThreshold)
                 .toList();
         final var polynomialsCommitments = polynomials.stream()
-                .map(poly -> EcPolynomial.create(schema.getPublicKeyGroup(), poly))
+                .map(poly -> Shamir.feldmanCommitment(schema.getPublicKeyGroup(), poly))
                 .toList();
         final var polynomialPrivatesPoints = polynomials.stream()
                 .map(poly -> receiverIds.stream()

--- a/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/extensions/AggregationTest.java
+++ b/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/extensions/AggregationTest.java
@@ -29,6 +29,8 @@ import com.hedera.cryptography.bls.SignatureSchema;
 import com.hedera.cryptography.pairings.api.Curve;
 import com.hedera.cryptography.pairings.api.GroupElement;
 import com.hedera.cryptography.utils.test.fixtures.rng.WithRng;
+import com.hedera.cryptography.pairings.extensions.EcPolynomial;
+import com.hedera.cryptography.pairings.extensions.FiniteFieldPolynomial;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Random;
@@ -142,11 +144,11 @@ public class AggregationTest {
                 .map(BlsPrivateKey::element)
                 .toList();
         final var polynomials = privateKeys.stream()
-                .map(s -> Polynomial.fromValue(random, s, currentThreshold - 1))
+                .map(s -> FiniteFieldPolynomial.fromValue(random, s, currentThreshold - 1))
                 .limit(previousThreshold)
                 .toList();
         final var polynomialsCommitments = polynomials.stream()
-                .map(poly -> FeldmanCommitment.create(schema.getPublicKeyGroup(), poly))
+                .map(poly -> EcPolynomial.create(schema.getPublicKeyGroup(), poly))
                 .toList();
         final var polynomialPrivatesPoints = polynomials.stream()
                 .map(poly -> receiverIds.stream()

--- a/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/extensions/AggregationTest.java
+++ b/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/extensions/AggregationTest.java
@@ -142,11 +142,11 @@ public class AggregationTest {
                 .map(BlsPrivateKey::element)
                 .toList();
         final var polynomials = privateKeys.stream()
-                .map(s -> Shamir.interpolationPolynomial(random, s, currentThreshold - 1))
+                .map(s -> ShamirUtils.interpolationPolynomial(random, s, currentThreshold - 1))
                 .limit(previousThreshold)
                 .toList();
         final var polynomialsCommitments = polynomials.stream()
-                .map(poly -> Shamir.feldmanCommitment(schema.getPublicKeyGroup(), poly))
+                .map(poly -> ShamirUtils.feldmanCommitment(schema.getPublicKeyGroup(), poly))
                 .toList();
         final var polynomialPrivatesPoints = polynomials.stream()
                 .map(poly -> receiverIds.stream()

--- a/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/extensions/LagrangeTests.java
+++ b/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/extensions/LagrangeTests.java
@@ -16,7 +16,7 @@
 
 package com.hedera.cryptography.tss.extensions;
 
-import static com.hedera.cryptography.tss.extensions.LagrangeTests.Pair.p;
+import static com.hedera.cryptography.tss.extensions.LagrangeTests.Point.p;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -118,9 +118,9 @@ public class LagrangeTests {
         return inputs.stream().map(i -> group.generator().multiply(i)).toList();
     }
 
-    private Result inputs(final Field field, final Pair... points) {
-        var ys = Stream.of(points).map(Pair::y).map(field::fromLong).toList();
-        var xs = Stream.of(points).map(Pair::x).map(field::fromLong).toList();
+    private Result inputs(final Field field, final Point... points) {
+        var ys = Stream.of(points).map(Point::y).map(field::fromLong).toList();
+        var xs = Stream.of(points).map(Point::x).map(field::fromLong).toList();
         return new Result(xs, ys);
     }
 
@@ -130,9 +130,9 @@ public class LagrangeTests {
         return new Result(xs, ys);
     }
 
-    record Pair(int x, int y) {
-        static Pair p(final int x, final int y) {
-            return new Pair(x, y);
+    record Point(int x, int y) {
+        static Point p(final int x, final int y) {
+            return new Point(x, y);
         }
     }
 

--- a/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/extensions/ShamirTest.java
+++ b/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/extensions/ShamirTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.cryptography.tss.extensions;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.hedera.cryptography.pairings.api.Curve;
+import com.hedera.cryptography.pairings.api.PairingFriendlyCurves;
+import java.security.SecureRandom;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+
+class ShamirTest {
+    private static final Random ROOT_RNG = new SecureRandom();
+
+    @Test
+    void testNegativeOrZeroDegreeThrowsException() {
+        var field = PairingFriendlyCurves.findInstance(Curve.ALT_BN128)
+                .pairingFriendlyCurve()
+                .field();
+        assertThrows(
+                IllegalArgumentException.class, () -> Shamir.interpolationPolynomial(ROOT_RNG, field.fromLong(0), -1));
+        assertThrows(
+                IllegalArgumentException.class, () -> Shamir.interpolationPolynomial(ROOT_RNG, field.fromLong(0), 0));
+    }
+
+    @Test
+    void testNullRandomOrSecretThrowsException() {
+        var field = PairingFriendlyCurves.findInstance(Curve.ALT_BN128)
+                .pairingFriendlyCurve()
+                .field();
+        assertThrows(NullPointerException.class, () -> Shamir.interpolationPolynomial(null, field.fromLong(0), 10));
+        assertThrows(NullPointerException.class, () -> Shamir.interpolationPolynomial(ROOT_RNG, null, 10));
+    }
+}

--- a/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/extensions/ShamirTest.java
+++ b/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/extensions/ShamirTest.java
@@ -20,30 +20,28 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.hedera.cryptography.pairings.api.Curve;
 import com.hedera.cryptography.pairings.api.PairingFriendlyCurves;
-import java.security.SecureRandom;
+import com.hedera.cryptography.utils.test.fixtures.rng.WithRng;
 import java.util.Random;
 import org.junit.jupiter.api.Test;
 
+@WithRng
 class ShamirTest {
-    private static final Random ROOT_RNG = new SecureRandom();
 
     @Test
-    void testNegativeOrZeroDegreeThrowsException() {
+    void testNegativeOrZeroDegreeThrowsException(Random rng) {
         var field = PairingFriendlyCurves.findInstance(Curve.ALT_BN128)
                 .pairingFriendlyCurve()
                 .field();
-        assertThrows(
-                IllegalArgumentException.class, () -> Shamir.interpolationPolynomial(ROOT_RNG, field.fromLong(0), -1));
-        assertThrows(
-                IllegalArgumentException.class, () -> Shamir.interpolationPolynomial(ROOT_RNG, field.fromLong(0), 0));
+        assertThrows(IllegalArgumentException.class, () -> Shamir.interpolationPolynomial(rng, field.fromLong(0), -1));
+        assertThrows(IllegalArgumentException.class, () -> Shamir.interpolationPolynomial(rng, field.fromLong(0), 0));
     }
 
     @Test
-    void testNullRandomOrSecretThrowsException() {
+    void testNullRandomOrSecretThrowsException(Random rng) {
         var field = PairingFriendlyCurves.findInstance(Curve.ALT_BN128)
                 .pairingFriendlyCurve()
                 .field();
         assertThrows(NullPointerException.class, () -> Shamir.interpolationPolynomial(null, field.fromLong(0), 10));
-        assertThrows(NullPointerException.class, () -> Shamir.interpolationPolynomial(ROOT_RNG, null, 10));
+        assertThrows(NullPointerException.class, () -> Shamir.interpolationPolynomial(rng, null, 10));
     }
 }

--- a/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/extensions/ShamirUtilsTest.java
+++ b/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/extensions/ShamirUtilsTest.java
@@ -25,15 +25,17 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 
 @WithRng
-class ShamirTest {
+class ShamirUtilsTest {
 
     @Test
     void testNegativeOrZeroDegreeThrowsException(Random rng) {
         var field = PairingFriendlyCurves.findInstance(Curve.ALT_BN128)
                 .pairingFriendlyCurve()
                 .field();
-        assertThrows(IllegalArgumentException.class, () -> Shamir.interpolationPolynomial(rng, field.fromLong(0), -1));
-        assertThrows(IllegalArgumentException.class, () -> Shamir.interpolationPolynomial(rng, field.fromLong(0), 0));
+        assertThrows(
+                IllegalArgumentException.class, () -> ShamirUtils.interpolationPolynomial(rng, field.fromLong(0), -1));
+        assertThrows(
+                IllegalArgumentException.class, () -> ShamirUtils.interpolationPolynomial(rng, field.fromLong(0), 0));
     }
 
     @Test
@@ -41,7 +43,8 @@ class ShamirTest {
         var field = PairingFriendlyCurves.findInstance(Curve.ALT_BN128)
                 .pairingFriendlyCurve()
                 .field();
-        assertThrows(NullPointerException.class, () -> Shamir.interpolationPolynomial(null, field.fromLong(0), 10));
-        assertThrows(NullPointerException.class, () -> Shamir.interpolationPolynomial(rng, null, 10));
+        assertThrows(
+                NullPointerException.class, () -> ShamirUtils.interpolationPolynomial(null, field.fromLong(0), 10));
+        assertThrows(NullPointerException.class, () -> ShamirUtils.interpolationPolynomial(rng, null, 10));
     }
 }

--- a/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/extensions/elgamal/ElGamalUtilsTest.java
+++ b/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/extensions/elgamal/ElGamalUtilsTest.java
@@ -23,7 +23,7 @@ import com.hedera.cryptography.bls.BlsPublicKey;
 import com.hedera.cryptography.bls.GroupAssignment;
 import com.hedera.cryptography.bls.SignatureSchema;
 import com.hedera.cryptography.pairings.api.*;
-import com.hedera.cryptography.tss.api.TssKeyTable;
+import com.hedera.cryptography.tss.api.TssShareTable;
 import com.hedera.cryptography.utils.test.fixtures.rng.WithRng;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -157,7 +157,7 @@ public class ElGamalUtilsTest {
                 ids.stream().map(i -> BlsPrivateKey.create(schema, random)).toList();
 
         final var pks = sks.stream().map(BlsPrivateKey::createPublicKey).toList();
-        final TssKeyTable<BlsPublicKey> elGamalEncryptionKeys =
+        final TssShareTable<BlsPublicKey> elGamalEncryptionKeys =
                 shareId -> pks.stream().toList().get(shareId - 1);
         final var secrets = Collections.nCopies(ids.size(), secret);
         final List<FieldElement> randomness = ElGamalUtils.generateEntropy(random, field.elementSize(), schema);

--- a/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/extensions/nizk/NizkProofTest.java
+++ b/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/extensions/nizk/NizkProofTest.java
@@ -24,9 +24,9 @@ import com.hedera.cryptography.bls.BlsPublicKey;
 import com.hedera.cryptography.bls.GroupAssignment;
 import com.hedera.cryptography.bls.SignatureSchema;
 import com.hedera.cryptography.pairings.api.Curve;
-import com.hedera.cryptography.tss.api.TssKeyTable;
-import com.hedera.cryptography.tss.extensions.FeldmanCommitment;
-import com.hedera.cryptography.tss.extensions.Polynomial;
+import com.hedera.cryptography.pairings.extensions.EcPolynomial;
+import com.hedera.cryptography.pairings.extensions.FiniteFieldPolynomial;
+import com.hedera.cryptography.tss.api.TssShareTable;
 import com.hedera.cryptography.tss.extensions.elgamal.ElGamalUtils;
 import java.security.SecureRandom;
 import java.util.Random;
@@ -53,18 +53,18 @@ public class NizkProofTest {
                 ids.stream().map(i -> BlsPrivateKey.create(schema, random)).toList();
         final var publicKeys =
                 privateKeys.stream().map(BlsPrivateKey::createPublicKey).toList();
-        final TssKeyTable<BlsPublicKey> elGamalEncryptionKeys = share -> publicKeys.get(share - 1);
+        final TssShareTable<BlsPublicKey> elGamalEncryptionKeys = share -> publicKeys.get(share - 1);
 
         // A d degree polynomial is defined by d + 1 coefficients: a_0, a_1, ..., a_d
         // such that p(x) = a_0 + a_1 * x + a_2 * x^2 + ... + a_d * x^d
         // here we want d = threshold - 1, so threshold of points can identify this polynomial
-        final var polynomial = Polynomial.fromValue(random, secret, threshold - 1);
+        final var polynomial = FiniteFieldPolynomial.fromValue(random, secret, threshold - 1);
         final var secrets = ids.stream().map(polynomial::evaluate).toList();
 
         final var entropy = ElGamalUtils.generateEntropy(random, field.elementSize(), schema);
         final var cipherTable = ElGamalUtils.ciphertextTable(schema, entropy, elGamalEncryptionKeys, secrets);
         final var combinedCipher = cipherTable.combine(field.fromLong(ElGamalUtils.TOTAL_NUMBER_OF_ELEMENTS));
-        final var polyCommitment = FeldmanCommitment.create(group, polynomial);
+        final var polyCommitment = EcPolynomial.create(group, polynomial);
         final var statement = new NizkStatement(ids, elGamalEncryptionKeys, polyCommitment, combinedCipher);
         final var witness = NizkWitness.create(entropy, secrets);
         final var proof = NizkProof.prove(schema, random, statement, witness);
@@ -77,15 +77,15 @@ public class NizkProofTest {
                 .boxed()
                 .map(i -> new BlsPublicKey(group.generator().multiply(field.fromLong(i)), schema))
                 .toList();
-        final TssKeyTable<BlsPublicKey> wrongTssEncryptionKeyResolver =
+        final TssShareTable<BlsPublicKey> wrongTssEncryptionKeyResolver =
                 tssShareId -> elGamalEncryptionWrongKeys.get(tssShareId - 1);
         assertFalse(proof.verify(
                 schema, new NizkStatement(ids, wrongTssEncryptionKeyResolver, polyCommitment, combinedCipher)));
         // Try wrong commitment
-        final var wrongCommitmentCoefficients = polyCommitment.commitmentCoefficients().stream()
+        final var wrongCommitmentCoefficients = polyCommitment.coefficients().stream()
                 .map(e -> e.add(group.generator()))
                 .toList();
-        final var wrongCommitment = new FeldmanCommitment(wrongCommitmentCoefficients);
+        final var wrongCommitment = new EcPolynomial(wrongCommitmentCoefficients);
         assertFalse(
                 proof.verify(schema, new NizkStatement(ids, elGamalEncryptionKeys, wrongCommitment, combinedCipher)));
         // Try wrong combinedCipher

--- a/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/extensions/nizk/NizkProofTest.java
+++ b/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/extensions/nizk/NizkProofTest.java
@@ -25,8 +25,8 @@ import com.hedera.cryptography.bls.GroupAssignment;
 import com.hedera.cryptography.bls.SignatureSchema;
 import com.hedera.cryptography.pairings.api.Curve;
 import com.hedera.cryptography.pairings.extensions.EcPolynomial;
-import com.hedera.cryptography.pairings.extensions.FiniteFieldPolynomial;
 import com.hedera.cryptography.tss.api.TssShareTable;
+import com.hedera.cryptography.tss.extensions.Shamir;
 import com.hedera.cryptography.tss.extensions.elgamal.ElGamalUtils;
 import java.security.SecureRandom;
 import java.util.Random;
@@ -58,13 +58,13 @@ public class NizkProofTest {
         // A d degree polynomial is defined by d + 1 coefficients: a_0, a_1, ..., a_d
         // such that p(x) = a_0 + a_1 * x + a_2 * x^2 + ... + a_d * x^d
         // here we want d = threshold - 1, so threshold of points can identify this polynomial
-        final var polynomial = FiniteFieldPolynomial.fromValue(random, secret, threshold - 1);
+        final var polynomial = Shamir.interpolationPolynomial(random, secret, threshold - 1);
         final var secrets = ids.stream().map(polynomial::evaluate).toList();
 
         final var entropy = ElGamalUtils.generateEntropy(random, field.elementSize(), schema);
         final var cipherTable = ElGamalUtils.ciphertextTable(schema, entropy, elGamalEncryptionKeys, secrets);
         final var combinedCipher = cipherTable.combine(field.fromLong(ElGamalUtils.TOTAL_NUMBER_OF_ELEMENTS));
-        final var polyCommitment = EcPolynomial.create(group, polynomial);
+        final var polyCommitment = Shamir.feldmanCommitment(group, polynomial);
         final var statement = new NizkStatement(ids, elGamalEncryptionKeys, polyCommitment, combinedCipher);
         final var witness = NizkWitness.create(entropy, secrets);
         final var proof = NizkProof.prove(schema, random, statement, witness);

--- a/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/extensions/nizk/NizkProofTest.java
+++ b/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/extensions/nizk/NizkProofTest.java
@@ -26,7 +26,7 @@ import com.hedera.cryptography.bls.SignatureSchema;
 import com.hedera.cryptography.pairings.api.Curve;
 import com.hedera.cryptography.pairings.extensions.EcPolynomial;
 import com.hedera.cryptography.tss.api.TssShareTable;
-import com.hedera.cryptography.tss.extensions.Shamir;
+import com.hedera.cryptography.tss.extensions.ShamirUtils;
 import com.hedera.cryptography.tss.extensions.elgamal.ElGamalUtils;
 import java.security.SecureRandom;
 import java.util.Random;
@@ -58,13 +58,13 @@ public class NizkProofTest {
         // A d degree polynomial is defined by d + 1 coefficients: a_0, a_1, ..., a_d
         // such that p(x) = a_0 + a_1 * x + a_2 * x^2 + ... + a_d * x^d
         // here we want d = threshold - 1, so threshold of points can identify this polynomial
-        final var polynomial = Shamir.interpolationPolynomial(random, secret, threshold - 1);
+        final var polynomial = ShamirUtils.interpolationPolynomial(random, secret, threshold - 1);
         final var secrets = ids.stream().map(polynomial::evaluate).toList();
 
         final var entropy = ElGamalUtils.generateEntropy(random, field.elementSize(), schema);
         final var cipherTable = ElGamalUtils.ciphertextTable(schema, entropy, elGamalEncryptionKeys, secrets);
         final var combinedCipher = cipherTable.combine(field.fromLong(ElGamalUtils.TOTAL_NUMBER_OF_ELEMENTS));
-        final var polyCommitment = Shamir.feldmanCommitment(group, polynomial);
+        final var polyCommitment = ShamirUtils.feldmanCommitment(group, polynomial);
         final var statement = new NizkStatement(ids, elGamalEncryptionKeys, polyCommitment, combinedCipher);
         final var witness = NizkWitness.create(entropy, secrets);
         final var proof = NizkProof.prove(schema, random, statement, witness);

--- a/cryptography/hedera-cryptography-utils/src/main/java/com/hedera/cryptography/utils/ByteArrayUtils.java
+++ b/cryptography/hedera-cryptography-utils/src/main/java/com/hedera/cryptography/utils/ByteArrayUtils.java
@@ -270,7 +270,7 @@ public class ByteArrayUtils {
          * @param bytes The byte array containing serialized data.
          */
         public Deserializer(@NonNull byte[] bytes) {
-            ByteArrayInputStream buffer = new ByteArrayInputStream(bytes);
+            final ByteArrayInputStream buffer = new ByteArrayInputStream(bytes);
             this.is = new DataInputStream(buffer);
         }
 

--- a/cryptography/hedera-cryptography-utils/src/main/java/com/hedera/cryptography/utils/ByteArrayUtils.java
+++ b/cryptography/hedera-cryptography-utils/src/main/java/com/hedera/cryptography/utils/ByteArrayUtils.java
@@ -262,7 +262,6 @@ public class ByteArrayUtils {
      * A utility class for deserializing data from a byte array.
      */
     public static class Deserializer {
-        private final ByteArrayInputStream buffer;
         private final DataInputStream is;
 
         /**
@@ -271,7 +270,7 @@ public class ByteArrayUtils {
          * @param bytes The byte array containing serialized data.
          */
         public Deserializer(@NonNull byte[] bytes) {
-            this.buffer = new ByteArrayInputStream(bytes);
+            ByteArrayInputStream buffer = new ByteArrayInputStream(bytes);
             this.is = new DataInputStream(buffer);
         }
 


### PR DESCRIPTION
**Description**:
This code is part of the effort in the creation of TssMessages in the Genesis stage.
This includes some code reorganization and re-utilization that was done while benchmarking and testing the code.
Includes:
 * Group batchAdd operation is called add for consistency with FieldElement operation
 * FeldmanCommitment is now a ECPolynomial to foster reuse.
 * Polynomial is now a FiniteFieldPolynomial to foster reuse.
 * Both previous classes are part of the extension package of the Pairings API, as they do not depend on any curve and are not specific to BLS or TSS.
 * Polynomial evaluation uses fewer steps
 * TssKeyTable is now a TssShareIdTable to foster rehuse, all functions transforming a shared to a value are now instances of this functional interface.
 * removed some unnecessary code not used and not covered by testing
 * Use of the polynomial classes where applicable
 
The following ticket depends on this one:
https://github.com/hashgraph/hedera-cryptography/pull/117

**Related issue(s)**:
Fixes: [#16438](https://github.com/hashgraph/hedera-services/issues/16438)
Part of:  [#15497](https://github.com/hashgraph/hedera-services/issues/15497)

**Notes for reviewer**:
This Pull request extracts some code reorganization while implementing the tss service logic.
It was extracted from the specific PR handling the cryptography protocol details to create a more manageable reviewable pull request.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
