### PR TITLE
ci: Update setup-zig to set use-cache to false

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Setup Zig (Linux/Mac cross-compile)
         uses: mlugg/setup-zig@a67e68dc5c8281d9608136d3d7ca1b282213e4ac  # v1.2.1
+        with:
+          use-cache: 'false'
 
       - name: Setup lld (Windows cross-compile)
         run: |


### PR DESCRIPTION
**Description**:

Set the use-cache option to false to prevent cache conflicts

**Related Issue(s)**:

Fixes #115
