### PR TITLE
feat: 16481 support participantId as long

### DIFF
--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/api/TssParticipantDirectory.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/api/TssParticipantDirectory.java
@@ -19,7 +19,7 @@ package com.hedera.cryptography.tss.api;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.cryptography.bls.BlsPublicKey;
-import com.hedera.cryptography.tss.extensions.TssEncryptionKeyMap;
+import com.hedera.cryptography.tss.extensions.TssParticipantAssigmentMap;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -64,18 +64,18 @@ public final class TssParticipantDirectory implements TssShareTable<BlsPublicKey
     /**
      * Stores the {@link BlsPublicKey} of each {@code ShareId} in the protocol.
      */
-    private final TssEncryptionKeyMap tssEncryptionTable;
+    private final TssParticipantAssigmentMap tssEncryptionTable;
 
     /**
      * Constructs a {@link TssParticipantDirectory}.
      *
      * @param shareIds            list of participants ids
-     * @param tssEncryptionTable  share to participant public keys table
+     * @param tssEncryptionTable  share to public keys and participant to index table
      * @param threshold           the threshold value for the TSS
      */
     private TssParticipantDirectory(
             @NonNull final List<Integer> shareIds,
-            @NonNull final TssEncryptionKeyMap tssEncryptionTable,
+            @NonNull final TssParticipantAssigmentMap tssEncryptionTable,
             final int threshold) {
         this.shareIds = List.copyOf(shareIds);
         this.tssEncryptionTable = tssEncryptionTable;
@@ -216,22 +216,31 @@ public final class TssParticipantDirectory implements TssShareTable<BlsPublicKey
 
             final List<Integer> shareIds =
                     IntStream.rangeClosed(1, totalShares).boxed().toList();
-            final int[] shareOwnershipTable = new int[totalShares];
+            final int[] shareOwnersTable = new int[totalShares];
+            final int[][] participantShares = new int[participantIds.length][2];
             final BlsPublicKey[] tssEncryptionPublicKeyTable = new BlsPublicKey[participantIds.length];
-
+            final Map<Long, Integer> participantIndexes = new HashMap<>();
             int currentIndex = 0;
             // Iteration of the sorted int representation to make sure we assign the shares deterministically.
             for (int i = 0; i < participantIds.length; i++) {
                 final ParticipantEntry entry = participantEntries.get(participantIds[i]);
                 tssEncryptionPublicKeyTable[i] = entry.tssEncryptionPublicKey;
-                // Add the public encryption key for each participant id in the iteration.
-                Arrays.fill(shareOwnershipTable, currentIndex, currentIndex + entry.shareCount(), i);
+
+                // ParticipantId-->ParticipantIndex
+                participantIndexes.put(participantIds[i], i);
+                // ShareIndex-->ParticipantIndex
+                Arrays.fill(shareOwnersTable, currentIndex, currentIndex + entry.shareCount(), i);
+                // ParticipantIndex-->First Share; Share count
+                participantShares[i][0] = currentIndex + 1; // adds the first share and the last share
+                participantShares[i][1] = entry.shareCount();
+
                 currentIndex += entry.shareCount();
             }
 
             return new TssParticipantDirectory(
                     shareIds,
-                    new TssEncryptionKeyMap(shareOwnershipTable, participantIds, tssEncryptionPublicKeyTable),
+                    new TssParticipantAssigmentMap(
+                            participantShares, shareOwnersTable, participantIndexes, tssEncryptionPublicKeyTable),
                     threshold);
         }
     }

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/api/TssParticipantDirectory.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/api/TssParticipantDirectory.java
@@ -19,13 +19,12 @@ package com.hedera.cryptography.tss.api;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.cryptography.bls.BlsPublicKey;
-import com.hedera.cryptography.tss.extensions.TssParticipantAssigmentMap;
+import com.hedera.cryptography.tss.extensions.TssParticipantAssigmentMapping;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.IntStream;
 
 /**
  * Represents a public directory of participants in a Threshold Signature Scheme (TSS).
@@ -47,11 +46,6 @@ import java.util.stream.IntStream;
  */
 public final class TssParticipantDirectory implements TssShareTable<BlsPublicKey> {
     /**
-     * A list of all assigned {@code shareIds} in the directory. The values are sorted, consecutive and starting from 1.
-     * This contains the numeric value of the share, not the index. ShareId 0 does not exist and is reserved.
-     */
-    private final List<Integer> shareIds;
-    /**
      * In directory used to generate TssMessages, the {@code threshold} defines the number of shares-of-shares that will be created to perform shamir-secret-sharing.
      * In a directory used to validate and latter process TssMessages, the {@code threshold} value is the minimum number of messages that assures the correct recovery of
      * {@link TssPrivateShare} and {@link TssPublicShare}.
@@ -64,21 +58,17 @@ public final class TssParticipantDirectory implements TssShareTable<BlsPublicKey
     /**
      * Stores the {@link BlsPublicKey} of each {@code ShareId} in the protocol.
      */
-    private final TssParticipantAssigmentMap tssEncryptionTable;
+    private final TssParticipantAssigmentMapping participantAssigmentMapping;
 
     /**
      * Constructs a {@link TssParticipantDirectory}.
      *
-     * @param shareIds            list of participants ids
-     * @param tssEncryptionTable  share to public keys and participant to index table
-     * @param threshold           the threshold value for the TSS
+     * @param participantAssigmentMapping different kinds of necessary mappings
+     * @param threshold the threshold value for the TSS
      */
     private TssParticipantDirectory(
-            @NonNull final List<Integer> shareIds,
-            @NonNull final TssParticipantAssigmentMap tssEncryptionTable,
-            final int threshold) {
-        this.shareIds = List.copyOf(shareIds);
-        this.tssEncryptionTable = tssEncryptionTable;
+            @NonNull final TssParticipantAssigmentMapping participantAssigmentMapping, final int threshold) {
+        this.participantAssigmentMapping = participantAssigmentMapping;
         this.threshold = threshold;
     }
 
@@ -111,7 +101,7 @@ public final class TssParticipantDirectory implements TssShareTable<BlsPublicKey
      */
     @NonNull
     public List<Integer> getShareIds() {
-        return shareIds;
+        return participantAssigmentMapping.getShareIds();
     }
 
     /**
@@ -122,7 +112,7 @@ public final class TssParticipantDirectory implements TssShareTable<BlsPublicKey
      */
     @NonNull
     public List<Integer> ownedShares(long participantId) {
-        return tssEncryptionTable.getSharesForParticipantId(participantId);
+        return participantAssigmentMapping.getSharesForParticipantId(participantId);
     }
 
     /**
@@ -134,7 +124,7 @@ public final class TssParticipantDirectory implements TssShareTable<BlsPublicKey
     @NonNull
     @Override
     public BlsPublicKey getForShareId(final int shareId) {
-        return tssEncryptionTable.getForShareId(shareId);
+        return participantAssigmentMapping.tssEncryptionKeyForShareId(shareId);
     }
 
     /**
@@ -214,8 +204,6 @@ public final class TssParticipantDirectory implements TssShareTable<BlsPublicKey
                 throw new IllegalStateException("Threshold exceeds the number of shares");
             }
 
-            final List<Integer> shareIds =
-                    IntStream.rangeClosed(1, totalShares).boxed().toList();
             final int[] shareOwnersTable = new int[totalShares];
             final int[][] participantShares = new int[participantIds.length][2];
             final BlsPublicKey[] tssEncryptionPublicKeyTable = new BlsPublicKey[participantIds.length];
@@ -238,8 +226,7 @@ public final class TssParticipantDirectory implements TssShareTable<BlsPublicKey
             }
 
             return new TssParticipantDirectory(
-                    shareIds,
-                    new TssParticipantAssigmentMap(
+                    new TssParticipantAssigmentMapping(
                             participantShares, shareOwnersTable, participantIndexes, tssEncryptionPublicKeyTable),
                     threshold);
         }

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/api/TssParticipantDirectory.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/api/TssParticipantDirectory.java
@@ -16,15 +16,14 @@
 
 package com.hedera.cryptography.tss.api;
 
-import static java.util.Objects.requireNonNull;
-
 import com.hedera.cryptography.bls.BlsPublicKey;
 import com.hedera.cryptography.tss.extensions.TssParticipantAssigmentMapping;
+import com.hedera.cryptography.tss.extensions.TssParticipantAssigmentMapping.ParticipantMappingEntry;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * Represents a public directory of participants in a Threshold Signature Scheme (TSS).
@@ -131,7 +130,7 @@ public final class TssParticipantDirectory implements TssShareTable<BlsPublicKey
      * A builder for creating {@link TssParticipantDirectory} instances.
      */
     public static class Builder {
-        private final Map<Long, ParticipantEntry> participantEntries = new HashMap<>();
+        private final Map<Long, ParticipantMappingEntry> participantEntries = new HashMap<>();
         private int threshold;
 
         private Builder() {}
@@ -168,9 +167,10 @@ public final class TssParticipantDirectory implements TssShareTable<BlsPublicKey
                 @NonNull final BlsPublicKey tssEncryptionPublicKey) {
             if (participantEntries.containsKey(participantId))
                 throw new IllegalArgumentException(
-                        "Participant with id " + participantId + " was previously added to the directory");
+                        "Participant with participantId " + participantId + " was previously added to the directory");
 
-            participantEntries.put(participantId, new ParticipantEntry(numberOfShares, tssEncryptionPublicKey));
+            participantEntries.put(
+                    participantId, new ParticipantMappingEntry(participantId, numberOfShares, tssEncryptionPublicKey));
             return this;
         }
 
@@ -192,60 +192,20 @@ public final class TssParticipantDirectory implements TssShareTable<BlsPublicKey
 
             // Get the total number of shares of to distribute in the protocol
             final int totalShares = participantEntries.values().stream()
-                    .map(ParticipantEntry::shareCount)
+                    .map(ParticipantMappingEntry::shareCount)
                     .reduce(0, Integer::sum);
-
-            final var participantIds = participantEntries.keySet().stream()
-                    .sorted(Long::compareTo)
-                    .mapToLong(Long::longValue)
-                    .toArray();
 
             if (threshold > totalShares) {
                 throw new IllegalStateException("Threshold exceeds the number of shares");
             }
 
-            final int[] shareOwnersTable = new int[totalShares];
-            final int[][] participantShares = new int[participantIds.length][2];
-            final BlsPublicKey[] tssEncryptionPublicKeyTable = new BlsPublicKey[participantIds.length];
-            final Map<Long, Integer> participantIndexes = new HashMap<>();
-            int currentIndex = 0;
-            // Iteration of the sorted int representation to make sure we assign the shares deterministically.
-            for (int i = 0; i < participantIds.length; i++) {
-                final ParticipantEntry entry = participantEntries.get(participantIds[i]);
-                tssEncryptionPublicKeyTable[i] = entry.tssEncryptionPublicKey;
-
-                // ParticipantId-->ParticipantIndex
-                participantIndexes.put(participantIds[i], i);
-                // ShareIndex-->ParticipantIndex
-                Arrays.fill(shareOwnersTable, currentIndex, currentIndex + entry.shareCount(), i);
-                // ParticipantIndex-->First Share; Share count
-                participantShares[i][0] = currentIndex + 1; // adds the first share and the last share
-                participantShares[i][1] = entry.shareCount();
-
-                currentIndex += entry.shareCount();
-            }
+            final ParticipantMappingEntry[] sortedEntries = participantEntries.entrySet().stream()
+                    .sorted(Entry.comparingByKey())
+                    .map(Entry::getValue)
+                    .toArray(ParticipantMappingEntry[]::new);
 
             return new TssParticipantDirectory(
-                    new TssParticipantAssigmentMapping(
-                            participantShares, shareOwnersTable, participantIndexes, tssEncryptionPublicKeyTable),
-                    threshold);
-        }
-    }
-
-    /**
-     * Represents an entry for a participant, containing the ID, share count, and public key.
-     * @param shareCount number of shares owned by the participant represented by this record
-     * @param tssEncryptionPublicKey the pairing public key used to encrypt tss share portions designated to the participant represented by this record
-     */
-    private record ParticipantEntry(int shareCount, @NonNull BlsPublicKey tssEncryptionPublicKey) {
-        /**
-         * Constructor
-         *
-         * @param shareCount number of shares owned by the participant represented by this record
-         * @param tssEncryptionPublicKey the pairing public key used to encrypt tss share portions designated to the participant represented by this record
-         */
-        public ParticipantEntry {
-            requireNonNull(tssEncryptionPublicKey, "tssEncryptionPublicKey must not be null");
+                    new TssParticipantAssigmentMapping(totalShares, sortedEntries), threshold);
         }
     }
 }

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/api/TssParticipantDirectory.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/api/TssParticipantDirectory.java
@@ -61,7 +61,6 @@ public final class TssParticipantDirectory implements TssShareTable<BlsPublicKey
      * In any case, to which of those of this property refers to, depends on whether the directory represents a candidate directory or an adopted one.
      */
     private final int threshold;
-
     /**
      * Stores the {@link BlsPublicKey} of each {@code ShareId} in the protocol.
      */
@@ -70,9 +69,9 @@ public final class TssParticipantDirectory implements TssShareTable<BlsPublicKey
     /**
      * Constructs a {@link TssParticipantDirectory}.
      *
-     * @param shareIds list of participants ids
-     * @param tssEncryptionTable share to participant public keys table
-     * @param threshold  the threshold value for the TSS
+     * @param shareIds            list of participants ids
+     * @param tssEncryptionTable  share to participant public keys table
+     * @param threshold           the threshold value for the TSS
      */
     private TssParticipantDirectory(
             @NonNull final List<Integer> shareIds,
@@ -123,19 +122,7 @@ public final class TssParticipantDirectory implements TssShareTable<BlsPublicKey
      */
     @NonNull
     public List<Integer> ownedShares(long participantId) {
-        int pi = getParticipantIndex(participantId);
-        return tssEncryptionTable.getSharesForParticipantId(pi);
-    }
-
-    /**
-     * Given that participantId are long based, and we want to map it to a sequential index, to save storage
-     * @param participantId the participant that wants to know the ids of its shares.
-     * @return the shares owned by the participant {@code participantId}.
-     */
-    private int getParticipantIndex(final long participantId) {
-        return (int)
-                participantId; // FUTURE-WORK: #16481 strengthen this mapping of participantId to a sequential index, to
-        // save storage
+        return tssEncryptionTable.getSharesForParticipantId(participantId);
     }
 
     /**
@@ -154,7 +141,7 @@ public final class TssParticipantDirectory implements TssShareTable<BlsPublicKey
      * A builder for creating {@link TssParticipantDirectory} instances.
      */
     public static class Builder {
-        private final Map<Integer, ParticipantEntry> participantEntries = new HashMap<>();
+        private final Map<Long, ParticipantEntry> participantEntries = new HashMap<>();
         private int threshold;
 
         private Builder() {}
@@ -186,7 +173,7 @@ public final class TssParticipantDirectory implements TssShareTable<BlsPublicKey
          */
         @NonNull
         public Builder withParticipant(
-                final Integer participantId,
+                final long participantId,
                 final int numberOfShares,
                 @NonNull final BlsPublicKey tssEncryptionPublicKey) {
             if (participantEntries.containsKey(participantId))
@@ -218,10 +205,11 @@ public final class TssParticipantDirectory implements TssShareTable<BlsPublicKey
                     .map(ParticipantEntry::shareCount)
                     .reduce(0, Integer::sum);
 
-            final List<Integer> participantIds =
-                    participantEntries.keySet().stream().sorted().toList();
-            final Integer maxId =
-                    participantIds.stream().max(Integer::compareTo).orElse(participantEntries.size());
+            final var participantIds = participantEntries.keySet().stream()
+                    .sorted(Long::compareTo)
+                    .mapToLong(Long::longValue)
+                    .toArray();
+
             if (threshold > totalShares) {
                 throw new IllegalStateException("Threshold exceeds the number of shares");
             }
@@ -229,20 +217,22 @@ public final class TssParticipantDirectory implements TssShareTable<BlsPublicKey
             final List<Integer> shareIds =
                     IntStream.rangeClosed(1, totalShares).boxed().toList();
             final int[] shareOwnershipTable = new int[totalShares];
-            final BlsPublicKey[] tssEncryptionPublicKeyTable = new BlsPublicKey[maxId + 1];
+            final BlsPublicKey[] tssEncryptionPublicKeyTable = new BlsPublicKey[participantIds.length];
 
             int currentIndex = 0;
             // Iteration of the sorted int representation to make sure we assign the shares deterministically.
-            for (int participantId : participantIds) {
-                final ParticipantEntry entry = participantEntries.get(participantId);
-                tssEncryptionPublicKeyTable[participantId] = entry.tssEncryptionPublicKey;
+            for (int i = 0; i < participantIds.length; i++) {
+                final ParticipantEntry entry = participantEntries.get(participantIds[i]);
+                tssEncryptionPublicKeyTable[i] = entry.tssEncryptionPublicKey;
                 // Add the public encryption key for each participant id in the iteration.
-                Arrays.fill(shareOwnershipTable, currentIndex, currentIndex + entry.shareCount(), participantId);
+                Arrays.fill(shareOwnershipTable, currentIndex, currentIndex + entry.shareCount(), i);
                 currentIndex += entry.shareCount();
             }
 
             return new TssParticipantDirectory(
-                    shareIds, new TssEncryptionKeyMap(shareOwnershipTable, tssEncryptionPublicKeyTable), threshold);
+                    shareIds,
+                    new TssEncryptionKeyMap(shareOwnershipTable, participantIds, tssEncryptionPublicKeyTable),
+                    threshold);
         }
     }
 

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/api/TssParticipantPrivateInfo.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/api/TssParticipantPrivateInfo.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 
 /**
  * Represents the private information of the participant executing the protocol.
- * Containing its id and the private key to decrypt {@link TssMessage} CipherTexts intended for the {@code participantId}.
+ * Containing its participantId and the private key to decrypt {@link TssMessage} CipherTexts intended for the {@code participantId}.
  *
  * @param participantId the ID of the {@code participant} owning this directory.
  * @param tssDecryptPrivateKey the key to decrypt {@link TssMessage} CipherTexts intended for the {@code participantId}.

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/TssEncryptionKeyMap.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/TssEncryptionKeyMap.java
@@ -20,35 +20,43 @@ import com.hedera.cryptography.bls.BlsPublicKey;
 import com.hedera.cryptography.tss.api.TssShareTable;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
  * A {@link TssShareTable} that maps a shareId to its participants {@link BlsPublicKey} for encryption.
  */
 public class TssEncryptionKeyMap implements TssShareTable<BlsPublicKey> {
-
     /**
      * Stores the {@code participant} that is the owner of each shareId in the protocol.
      * Index 0 represents shareId 1 and so on.
      * Shares are assigned sequentially.
      */
     private final int[] shareAllocationTable;
-
     /**
      * Stores the {@link BlsPublicKey} of each {@code participant} in the protocol.
      * There is one BlsPublicKey per participant
      */
     private final BlsPublicKey[] tssKeyTable;
+    /**
+     *Sorted by value array of participantIds
+     */
+    private final long[] participantIds;
 
     /**
      * Constructor
      *
      * @param shareAllocationTable  Stores the {@code participant} that is the owner of each shareId in the protocol.
+     * @param participantIds list of sorted by value participant ids
      * @param tssKeyTable Stores the {@link BlsPublicKey} of each {@code participant} in the protocol.
      */
-    public TssEncryptionKeyMap(final int[] shareAllocationTable, final BlsPublicKey[] tssKeyTable) {
+    public TssEncryptionKeyMap(
+            @NonNull final int[] shareAllocationTable,
+            @NonNull final long[] participantIds,
+            @NonNull final BlsPublicKey[] tssKeyTable) {
         this.shareAllocationTable = shareAllocationTable;
         this.tssKeyTable = tssKeyTable;
+        this.participantIds = participantIds;
     }
 
     /**
@@ -68,16 +76,26 @@ public class TssEncryptionKeyMap implements TssShareTable<BlsPublicKey> {
     }
 
     /**
+     * Given that participantId are long based, and we want to map it to a sequential index, to save storage
+     * @param participantId the participant that wants to know the ids of its shares.
+     * @return the shares owned by the participant {@code participantId}.
+     */
+    private int getParticipantIndex(final long participantId) {
+        return Arrays.binarySearch(participantIds, participantId);
+    }
+
+    /**
      * Returns the shares owned by the participant {@code participantId }
      * @param participantId the participant querying for the info
      * @return the list of shares owned by the participant
      */
     @NonNull
-    public List<Integer> getSharesForParticipantId(final int participantId) {
+    public List<Integer> getSharesForParticipantId(final long participantId) {
         List<Integer> shares = new ArrayList<>();
         int i = 0;
+        final int participantIndex = getParticipantIndex(participantId);
         while (i < shareAllocationTable.length) {
-            if (shareAllocationTable[i] == participantId) {
+            if (shareAllocationTable[i] == participantIndex) {
                 shares.add(i + 1);
             }
             i++;

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/TssParticipantAssigmentMap.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/TssParticipantAssigmentMap.java
@@ -19,14 +19,28 @@ package com.hedera.cryptography.tss.extensions;
 import com.hedera.cryptography.bls.BlsPublicKey;
 import com.hedera.cryptography.tss.api.TssShareTable;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
 
 /**
- * A {@link TssShareTable} that maps a shareId to its participants {@link BlsPublicKey} for encryption.
+ * Contains mappings useful for the {@link com.hedera.cryptography.tss.api.TssParticipantDirectory}:
+ * <ul>
+ *  <li> Maps {@code ParticipantId}s to owned {@code shareId}s</li>
+ *  <li> Maps {@code shareId}s to participant's {@code tssEncryptionPublicKey}s</li>
+ *  </ul>
  */
-public class TssEncryptionKeyMap implements TssShareTable<BlsPublicKey> {
+public class TssParticipantAssigmentMap implements TssShareTable<BlsPublicKey> {
+    /**
+     * Each index represents a participant.
+     * Two values are stored per index:
+     * <ul>
+     *  <li>the first shareId belonging to the participant</li>
+     *  <li>the number of shares assigned to that participant</li>
+     *  </ul>
+     */
+    private final int[][] participantsShares;
+
     /**
      * Stores the {@code participant} that is the owner of each shareId in the protocol.
      * Index 0 represents shareId 1 and so on.
@@ -39,36 +53,41 @@ public class TssEncryptionKeyMap implements TssShareTable<BlsPublicKey> {
      */
     private final BlsPublicKey[] tssKeyTable;
     /**
-     *Sorted by value array of participantIds
+     * A map that assigns an index to each participant in the directory
      */
-    private final long[] participantIds;
+    private final Map<Long, Integer> participantIds;
 
     /**
      * Constructor
      *
+     * @param participantsShares  a table where each index is a participant and each value the first share assigned to it, and the second value the number-of-shares
      * @param shareAllocationTable  Stores the {@code participant} that is the owner of each shareId in the protocol.
      * @param participantIds list of sorted by value participant ids
      * @param tssKeyTable Stores the {@link BlsPublicKey} of each {@code participant} in the protocol.
      */
-    public TssEncryptionKeyMap(
+    public TssParticipantAssigmentMap(
+            @NonNull final int[][] participantsShares,
             @NonNull final int[] shareAllocationTable,
-            @NonNull final long[] participantIds,
+            @NonNull final Map<Long, Integer> participantIds,
             @NonNull final BlsPublicKey[] tssKeyTable) {
+        this.participantsShares = participantsShares;
+        ;
         this.shareAllocationTable = shareAllocationTable;
         this.tssKeyTable = tssKeyTable;
         this.participantIds = participantIds;
     }
 
     /**
-     * Returns a tssShareId owner's {@link BlsPublicKey}.
-     * If null, the participant does not belong to the directory.
+     * Returns the {@code share} owner's {@link BlsPublicKey}.
+     *
      * @param shareId the numeric value of the share, not the index.
      * @return a BlsPublicKey belonging to the owner of the share.
+     * @throws IllegalArgumentException if the share is higher than the number of shares assigned or if is less or equals to 0
      */
     @NonNull
     @Override
     public BlsPublicKey getForShareId(final int shareId) {
-        if (shareId > shareAllocationTable.length || shareId <= 0) {
+        if (shareId <= 0 || shareId > shareAllocationTable.length) {
             throw new IllegalArgumentException("Invalid ShareId");
         }
         var shareOwner = shareAllocationTable[shareId - 1];
@@ -76,30 +95,20 @@ public class TssEncryptionKeyMap implements TssShareTable<BlsPublicKey> {
     }
 
     /**
-     * Given that participantId are long based, and we want to map it to a sequential index, to save storage
-     * @param participantId the participant that wants to know the ids of its shares.
-     * @return the shares owned by the participant {@code participantId}.
-     */
-    private int getParticipantIndex(final long participantId) {
-        return Arrays.binarySearch(participantIds, participantId);
-    }
-
-    /**
      * Returns the shares owned by the participant {@code participantId }
-     * @param participantId the participant querying for the info
-     * @return the list of shares owned by the participant
+     * @param participantId the participant querying for the info.
+     * @return the list of shares owned by the participant if it owns any share, an empty list if it doesn't or is not a participant in the scheme.
      */
     @NonNull
     public List<Integer> getSharesForParticipantId(final long participantId) {
-        List<Integer> shares = new ArrayList<>();
-        int i = 0;
-        final int participantIndex = getParticipantIndex(participantId);
-        while (i < shareAllocationTable.length) {
-            if (shareAllocationTable[i] == participantIndex) {
-                shares.add(i + 1);
-            }
-            i++;
+        final Integer participantIndex = participantIds.get(participantId);
+        if (participantIndex == null) {
+            return List.of();
         }
-        return shares;
+        return IntStream.range(
+                        participantsShares[participantIndex][0],
+                        participantsShares[participantIndex][0] + participantsShares[participantIndex][1])
+                .boxed()
+                .toList();
     }
 }

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/TssParticipantAssigmentMapping.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/TssParticipantAssigmentMapping.java
@@ -66,7 +66,8 @@ public class TssParticipantAssigmentMapping {
      * @param totalShares total assigned shares.
      * @param sortedParticipantEntries a sorted array of entries per participant
      */
-    public TssParticipantAssigmentMapping(final int totalShares, final ParticipantMappingEntry... sortedParticipantEntries) {
+    public TssParticipantAssigmentMapping(
+            final int totalShares, @NonNull final ParticipantMappingEntry... sortedParticipantEntries) {
         final int[] shareOwnersTable = new int[totalShares];
         final int[][] participantShares = new int[sortedParticipantEntries.length][2];
         final BlsPublicKey[] tssEncryptionPublicKeyTable = new BlsPublicKey[sortedParticipantEntries.length];
@@ -145,7 +146,8 @@ public class TssParticipantAssigmentMapping {
      * @param shareCount number of shares owned by the participant represented by this record
      * @param tssEncryptionPublicKey the pairing public key used to encrypt tss share portions designated to the participant represented by this record
      */
-    public record ParticipantMappingEntry(long participantId, int shareCount, @NonNull BlsPublicKey tssEncryptionPublicKey) {
+    public record ParticipantMappingEntry(
+            long participantId, int shareCount, @NonNull BlsPublicKey tssEncryptionPublicKey) {
         /**
          * Constructor
          *

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/TssParticipantAssigmentMapping.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/TssParticipantAssigmentMapping.java
@@ -16,8 +16,12 @@
 
 package com.hedera.cryptography.tss.extensions;
 
+import static java.util.Objects.requireNonNull;
+
 import com.hedera.cryptography.bls.BlsPublicKey;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
@@ -59,21 +63,35 @@ public class TssParticipantAssigmentMapping {
     /**
      * Constructor
      *
-     * @param participantsShares  a table where each index is a participant and each value the first share assigned to it, and the second value the number-of-shares
-     * @param shareAllocationTable  Stores the {@code participant} that is the owner of each shareId in the protocol.
-     * @param participantIds list of sorted by value participant ids
-     * @param tssKeyTable Stores the {@link BlsPublicKey} of each {@code participant} in the protocol.
+     * @param totalShares total assigned shares.
+     * @param sortedParticipantEntries a sorted array of entries per participant
      */
-    public TssParticipantAssigmentMapping(
-            @NonNull final int[][] participantsShares,
-            @NonNull final int[] shareAllocationTable,
-            @NonNull final Map<Long, Integer> participantIds,
-            @NonNull final BlsPublicKey[] tssKeyTable) {
-        this.participantsShares = participantsShares;
-        ;
-        this.shareAllocationTable = shareAllocationTable;
-        this.tssKeyTable = tssKeyTable;
-        this.participantIds = participantIds;
+    public TssParticipantAssigmentMapping(final int totalShares, final ParticipantMappingEntry... sortedParticipantEntries) {
+        final int[] shareOwnersTable = new int[totalShares];
+        final int[][] participantShares = new int[sortedParticipantEntries.length][2];
+        final BlsPublicKey[] tssEncryptionPublicKeyTable = new BlsPublicKey[sortedParticipantEntries.length];
+        final Map<Long, Integer> participantIndexes = new HashMap<>(sortedParticipantEntries.length);
+        int currentIndex = 0;
+        // Iteration of the sorted int representation to make sure we assign the shares deterministically.
+        for (int i = 0; i < sortedParticipantEntries.length; i++) {
+            final ParticipantMappingEntry entry = sortedParticipantEntries[i];
+            tssEncryptionPublicKeyTable[i] = entry.tssEncryptionPublicKey;
+
+            // ParticipantId-->ParticipantIndex
+            participantIndexes.put(entry.participantId, i);
+            // ShareIndex-->ParticipantIndex
+            Arrays.fill(shareOwnersTable, currentIndex, currentIndex + entry.shareCount(), i);
+            // ParticipantIndex-->First Share; Share count
+            participantShares[i][0] = currentIndex + 1;
+            participantShares[i][1] = entry.shareCount();
+
+            currentIndex += entry.shareCount();
+        }
+
+        this.participantsShares = participantShares;
+        this.shareAllocationTable = shareOwnersTable;
+        this.tssKeyTable = tssEncryptionPublicKeyTable;
+        this.participantIds = participantIndexes;
     }
 
     /**
@@ -119,5 +137,23 @@ public class TssParticipantAssigmentMapping {
     @NonNull
     public List<Integer> getShareIds() {
         return IntStream.rangeClosed(1, shareAllocationTable.length).boxed().toList();
+    }
+
+    /**
+     * Represents an entry for a participant, containing the ID, share count, and public key.
+     * @param participantId identification of the participant
+     * @param shareCount number of shares owned by the participant represented by this record
+     * @param tssEncryptionPublicKey the pairing public key used to encrypt tss share portions designated to the participant represented by this record
+     */
+    public record ParticipantMappingEntry(long participantId, int shareCount, @NonNull BlsPublicKey tssEncryptionPublicKey) {
+        /**
+         * Constructor
+         *
+         * @param shareCount number of shares owned by the participant represented by this record
+         * @param tssEncryptionPublicKey the pairing public key used to encrypt tss share portions designated to the participant represented by this record
+         */
+        public ParticipantMappingEntry {
+            requireNonNull(tssEncryptionPublicKey, "tssEncryptionPublicKey must not be null");
+        }
     }
 }

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/TssParticipantAssigmentMapping.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/TssParticipantAssigmentMapping.java
@@ -17,7 +17,6 @@
 package com.hedera.cryptography.tss.extensions;
 
 import com.hedera.cryptography.bls.BlsPublicKey;
-import com.hedera.cryptography.tss.api.TssShareTable;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Map;
@@ -30,7 +29,7 @@ import java.util.stream.IntStream;
  *  <li> Maps {@code shareId}s to participant's {@code tssEncryptionPublicKey}s</li>
  *  </ul>
  */
-public class TssParticipantAssigmentMap implements TssShareTable<BlsPublicKey> {
+public class TssParticipantAssigmentMapping {
     /**
      * Each index represents a participant.
      * Two values are stored per index:
@@ -42,7 +41,7 @@ public class TssParticipantAssigmentMap implements TssShareTable<BlsPublicKey> {
     private final int[][] participantsShares;
 
     /**
-     * Stores the {@code participant} that is the owner of each shareId in the protocol.
+     * Stores the {@code participant} index that is the owner of each shareId in the protocol.
      * Index 0 represents shareId 1 and so on.
      * Shares are assigned sequentially.
      */
@@ -65,7 +64,7 @@ public class TssParticipantAssigmentMap implements TssShareTable<BlsPublicKey> {
      * @param participantIds list of sorted by value participant ids
      * @param tssKeyTable Stores the {@link BlsPublicKey} of each {@code participant} in the protocol.
      */
-    public TssParticipantAssigmentMap(
+    public TssParticipantAssigmentMapping(
             @NonNull final int[][] participantsShares,
             @NonNull final int[] shareAllocationTable,
             @NonNull final Map<Long, Integer> participantIds,
@@ -85,8 +84,7 @@ public class TssParticipantAssigmentMap implements TssShareTable<BlsPublicKey> {
      * @throws IllegalArgumentException if the share is higher than the number of shares assigned or if is less or equals to 0
      */
     @NonNull
-    @Override
-    public BlsPublicKey getForShareId(final int shareId) {
+    public BlsPublicKey tssEncryptionKeyForShareId(final int shareId) {
         if (shareId <= 0 || shareId > shareAllocationTable.length) {
             throw new IllegalArgumentException("Invalid ShareId");
         }
@@ -110,5 +108,16 @@ public class TssParticipantAssigmentMap implements TssShareTable<BlsPublicKey> {
                         participantsShares[participantIndex][0] + participantsShares[participantIndex][1])
                 .boxed()
                 .toList();
+    }
+
+    /**
+     * Return the list of all the shareIds.
+     * In this list, the first share has value of 1.
+     * This returns the numeric value of the share, not the index.
+     * @return the list of all the shareIds
+     */
+    @NonNull
+    public List<Integer> getShareIds() {
+        return IntStream.rangeClosed(1, shareAllocationTable.length).boxed().toList();
     }
 }

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/nizk/NizkStatement.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/extensions/nizk/NizkStatement.java
@@ -30,7 +30,7 @@ import java.util.Objects;
 /**
  * The public part of a Nizk proof.
  *
- * @param tssShareIds a list of tssIds, should be consecutive and each id value should match the index in the list.
+ * @param tssShareIds a list of tssIds, should be consecutive and each participantId value should match the index in the list.
  * @param tssEncryptionKeys a Map to retrieve the corresponding tssEncryptionKey of the participant owning the share
  * @param polynomialCommitment a {@link EcPolynomial}
  * @param combinedCiphertext a {@link CombinedCiphertext}

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/groth21/Groth21Stage.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/groth21/Groth21Stage.java
@@ -83,7 +83,8 @@ public abstract class Groth21Stage {
         // The value in the free coefficient is the secret that we want to share.
         final FiniteFieldPolynomial finiteFieldPolynomial =
                 ShamirUtils.interpolationPolynomial(random, secret, participantDirectory.getThreshold() - 1);
-        // The secrets we will end up sharing are the result of evaluating the polynomial with x= receiving-share-participantId
+        // The secrets we will end up sharing are the result of evaluating the polynomial with x=
+        // receiving-share-participantId
         final List<FieldElement> secrets =
                 receivingShareIds.stream().map(finiteFieldPolynomial::evaluate).toList();
         // Generating some shared entropy for ElGamal encryption algorithm. The randomness is reused for efficiency.

--- a/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/groth21/Groth21Stage.java
+++ b/cryptography/hedera-cryptography-tss/src/main/java/com/hedera/cryptography/tss/groth21/Groth21Stage.java
@@ -83,7 +83,7 @@ public abstract class Groth21Stage {
         // The value in the free coefficient is the secret that we want to share.
         final FiniteFieldPolynomial finiteFieldPolynomial =
                 ShamirUtils.interpolationPolynomial(random, secret, participantDirectory.getThreshold() - 1);
-        // The secrets we will end up sharing are the result of evaluating the polynomial with x= receiving-share-id
+        // The secrets we will end up sharing are the result of evaluating the polynomial with x= receiving-share-participantId
         final List<FieldElement> secrets =
                 receivingShareIds.stream().map(finiteFieldPolynomial::evaluate).toList();
         // Generating some shared entropy for ElGamal encryption algorithm. The randomness is reused for efficiency.

--- a/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/TssParticipantDirectoryTest.java
+++ b/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/TssParticipantDirectoryTest.java
@@ -81,7 +81,7 @@ class TssParticipantDirectoryTest {
     }
 
     @Test
-    void testValidConstructionHasValidPrivateSharesSize() {
+    void testValidConstructionHasValidOwnedSharesSize() {
         final BlsPublicKey publicKey1 = mock(BlsPublicKey.class);
         final BlsPublicKey publicKey2 = mock(BlsPublicKey.class);
         final TssParticipantDirectory directory = TssParticipantDirectory.createBuilder()
@@ -99,29 +99,52 @@ class TssParticipantDirectoryTest {
     }
 
     @Test
-    void testGetForShareId() {
+    void testValidShareAssignment() {
         final BlsPublicKey publicKey1 = mock(BlsPublicKey.class);
         final BlsPublicKey publicKey2 = mock(BlsPublicKey.class);
         final BlsPublicKey publicKey3 = mock(BlsPublicKey.class);
         final BlsPublicKey publicKey4 = mock(BlsPublicKey.class);
+        final BlsPublicKey publicKey5 = mock(BlsPublicKey.class);
         final TssParticipantDirectory directory = TssParticipantDirectory.createBuilder()
                 .withParticipant(1, 5, publicKey1)
                 .withParticipant(2, 2, publicKey2)
-                .withParticipant(Long.MAX_VALUE / 2, 1, publicKey3)
-                .withParticipant(Long.MAX_VALUE, 2, publicKey4)
+                .withParticipant(3, 0, publicKey3) // a participant that doesn't get any share
+                .withParticipant(
+                        Long.MAX_VALUE / 2,
+                        1,
+                        publicKey4) // there is a big gap between the last participant id and this one
+                .withParticipant(Long.MAX_VALUE - 2, 2, publicKey5) // there are 2 remaining possible ids not assigned
                 .withThreshold(1)
                 .build();
 
         assertEquals(publicKey1, directory.getForShareId(1));
+        assertEquals(publicKey1, directory.getForShareId(2));
+        assertEquals(publicKey1, directory.getForShareId(3));
+        assertEquals(publicKey1, directory.getForShareId(4));
         assertEquals(publicKey1, directory.getForShareId(5));
         assertEquals(publicKey2, directory.getForShareId(6));
-        assertEquals(publicKey3, directory.getForShareId(8));
-        assertEquals(publicKey4, directory.getForShareId(10));
+        assertEquals(publicKey2, directory.getForShareId(7));
+        assertEquals(
+                publicKey4,
+                directory.getForShareId(
+                        8)); // shareIds are given sequentially, so there should not be any assigned to publicKey3
+        assertEquals(publicKey5, directory.getForShareId(9));
+        assertEquals(publicKey5, directory.getForShareId(10));
+        assertThrows(IllegalArgumentException.class, () -> directory.getForShareId(Integer.MIN_VALUE));
         assertThrows(IllegalArgumentException.class, () -> directory.getForShareId(0));
         assertThrows(IllegalArgumentException.class, () -> directory.getForShareId(-1));
+        assertThrows(IllegalArgumentException.class, () -> directory.getForShareId(11));
         assertThrows(IllegalArgumentException.class, () -> directory.getForShareId(12));
+        assertThrows(IllegalArgumentException.class, () -> directory.getForShareId(Integer.MAX_VALUE));
 
-        assertEquals(1, directory.ownedShares(Long.MAX_VALUE / 2).size());
-        assertEquals(2, directory.ownedShares(Long.MAX_VALUE).size());
+        assertEquals(List.of(1, 2, 3, 4, 5), directory.ownedShares(1));
+        assertEquals(List.of(6, 7), directory.ownedShares(2));
+        assertEquals(List.of(), directory.ownedShares(3)); // ParticipantId 3 does not have any shares
+        assertEquals(List.of(8), directory.ownedShares(Long.MAX_VALUE / 2));
+        assertEquals(List.of(9, 10), directory.ownedShares(Long.MAX_VALUE - 2));
+        assertEquals(List.of(), directory.ownedShares(8)); // ParticipantId:8 is not part of the dealing
+        assertEquals(
+                List.of(),
+                directory.ownedShares(Long.MAX_VALUE)); // ParticipantId:Long.MAX_VALUE is not part of the dealing
     }
 }

--- a/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/TssParticipantDirectoryTest.java
+++ b/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/TssParticipantDirectoryTest.java
@@ -53,7 +53,7 @@ class TssParticipantDirectoryTest {
 
         exception = assertThrows(IllegalArgumentException.class, () -> builder.withParticipant(1, 1, publicKey));
         assertTrue(
-                exception.getMessage().contains("Participant with id 1 was previously added to the directory"),
+                exception.getMessage().contains("Participant with participantId 1 was previously added to the directory"),
                 "participant check did not work");
     }
 
@@ -112,7 +112,7 @@ class TssParticipantDirectoryTest {
                 .withParticipant(
                         Long.MAX_VALUE / 2,
                         1,
-                        publicKey4) // there is a big gap between the last participant id and this one
+                        publicKey4) // there is a big gap between the last participant participantId and this one
                 .withParticipant(Long.MAX_VALUE - 2, 2, publicKey5) // there are 2 remaining possible ids not assigned
                 .withThreshold(1)
                 .build();

--- a/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/TssParticipantDirectoryTest.java
+++ b/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/TssParticipantDirectoryTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-import com.hedera.cryptography.bls.BlsPrivateKey;
 import com.hedera.cryptography.bls.BlsPublicKey;
 import com.hedera.cryptography.tss.api.TssParticipantDirectory;
 import java.util.List;
@@ -39,7 +38,6 @@ class TssParticipantDirectoryTest {
         builder.withParticipant(1, 1, publicKey);
 
         // Test threshold too low
-
         Exception exception = assertThrows(IllegalArgumentException.class, () -> builder.withThreshold(0));
         assertTrue(exception.getMessage().contains("Invalid threshold: 0"), "threshold check did not work");
 
@@ -84,7 +82,6 @@ class TssParticipantDirectoryTest {
 
     @Test
     void testValidConstructionHasValidPrivateSharesSize() {
-        final BlsPrivateKey privateKey = mock(BlsPrivateKey.class);
         final BlsPublicKey publicKey1 = mock(BlsPublicKey.class);
         final BlsPublicKey publicKey2 = mock(BlsPublicKey.class);
         final TssParticipantDirectory directory = TssParticipantDirectory.createBuilder()
@@ -103,21 +100,28 @@ class TssParticipantDirectoryTest {
 
     @Test
     void testGetForShareId() {
-        final BlsPrivateKey privateKey = mock(BlsPrivateKey.class);
         final BlsPublicKey publicKey1 = mock(BlsPublicKey.class);
         final BlsPublicKey publicKey2 = mock(BlsPublicKey.class);
+        final BlsPublicKey publicKey3 = mock(BlsPublicKey.class);
+        final BlsPublicKey publicKey4 = mock(BlsPublicKey.class);
         final TssParticipantDirectory directory = TssParticipantDirectory.createBuilder()
                 .withParticipant(1, 5, publicKey1)
                 .withParticipant(2, 2, publicKey2)
+                .withParticipant(Long.MAX_VALUE / 2, 1, publicKey3)
+                .withParticipant(Long.MAX_VALUE, 2, publicKey4)
                 .withThreshold(1)
                 .build();
 
         assertEquals(publicKey1, directory.getForShareId(1));
         assertEquals(publicKey1, directory.getForShareId(5));
         assertEquals(publicKey2, directory.getForShareId(6));
-        assertEquals(publicKey2, directory.getForShareId(7));
-        assertThrows(IllegalArgumentException.class, () -> directory.getForShareId(8));
+        assertEquals(publicKey3, directory.getForShareId(8));
+        assertEquals(publicKey4, directory.getForShareId(10));
         assertThrows(IllegalArgumentException.class, () -> directory.getForShareId(0));
         assertThrows(IllegalArgumentException.class, () -> directory.getForShareId(-1));
+        assertThrows(IllegalArgumentException.class, () -> directory.getForShareId(12));
+
+        assertEquals(1, directory.ownedShares(Long.MAX_VALUE / 2).size());
+        assertEquals(2, directory.ownedShares(Long.MAX_VALUE).size());
     }
 }

--- a/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/TssParticipantDirectoryTest.java
+++ b/cryptography/hedera-cryptography-tss/src/test/java/com/hedera/cryptography/tss/TssParticipantDirectoryTest.java
@@ -53,7 +53,9 @@ class TssParticipantDirectoryTest {
 
         exception = assertThrows(IllegalArgumentException.class, () -> builder.withParticipant(1, 1, publicKey));
         assertTrue(
-                exception.getMessage().contains("Participant with participantId 1 was previously added to the directory"),
+                exception
+                        .getMessage()
+                        .contains("Participant with participantId 1 was previously added to the directory"),
                 "participant check did not work");
     }
 

--- a/cryptography/hedera-cryptography-tss/src/testFixtures/java/com/hedera/cryptography/tss/test/fixtures/TestTssServiceImpl.java
+++ b/cryptography/hedera-cryptography-tss/src/testFixtures/java/com/hedera/cryptography/tss/test/fixtures/TestTssServiceImpl.java
@@ -55,6 +55,7 @@ public class TestTssServiceImpl implements TssService {
     public TssServiceGenesisStage genesisStage() {
         return new TssServiceGenesisStage() {
 
+            @NonNull
             @Override
             public TssMessage generateTssMessage(@NonNull final TssParticipantDirectory participantDirectory) {
                 return TssTestUtils.testTssMessage(

--- a/cryptography/hedera-cryptography-tss/src/testFixtures/java/com/hedera/cryptography/tss/test/fixtures/TssTestCommittee.java
+++ b/cryptography/hedera-cryptography-tss/src/testFixtures/java/com/hedera/cryptography/tss/test/fixtures/TssTestCommittee.java
@@ -63,7 +63,7 @@ public record TssTestCommittee(int size, int sharesPerParticipant, @NonNull BlsP
 
     /**
      *
-     * @param participantId participant id
+     * @param participantId participant participantId
      * @return the private info of {@code participantId}
      */
     @NonNull


### PR DESCRIPTION
**Description**:
This pull request allows us to completely support Long values as participant ids, while keeping the storage of the information in an array.
**Related issue(s)**: 
this PR depends on: https://github.com/hashgraph/hedera-cryptography/pull/121

Fixes https://github.com/hashgraph/hedera-services/issues/16481
