### PR TITLE
build: resolve gradle nexus publish issues for non-snapshot releases

### DIFF
--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.hedera-common-publish.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.hedera-common-publish.gradle.kts
@@ -21,14 +21,19 @@ plugins {
 
 // Publishing tasks are only enabled if we publish to the matching group.
 // Otherwise, Nexus configuration and credentials do not fit.
-val publishingPackageGroup = providers.gradleProperty("publishingPackageGroup").getOrElse("")
+//val publishingPackageGroup = providers.gradleProperty("publishingPackageGroup").getOrElse("")
 
 tasks.withType<PublishToMavenRepository>().configureEach {
-    enabled = publishingPackageGroup == "com.hedera.common"
+    // Not required since both common and cryptography modules are published under the same com.hedera prefix which
+    // is the same configured Nexus profile on maven central.
+    // enabled = publishingPackageGroup == "com.hedera.common"
 }
 
 publishing {
     publications.named<MavenPublication>("maven") {
+        // Explicitly set the package group to com.hedera.common since the cryptograph module is published under
+        // the same com.hedera Nexus profile.
+        group = "com.hedera.common"
         pom.description =
             "Swirlds is a software platform designed to build fully-distributed " +
                 "applications that harness the power of the cloud without servers. " +

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.hedera-common-publish.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.hedera-common-publish.gradle.kts
@@ -21,17 +21,19 @@ plugins {
 
 // Publishing tasks are only enabled if we publish to the matching group.
 // Otherwise, Nexus configuration and credentials do not fit.
-//val publishingPackageGroup = providers.gradleProperty("publishingPackageGroup").getOrElse("")
+// val publishingPackageGroup = providers.gradleProperty("publishingPackageGroup").getOrElse("")
 
 tasks.withType<PublishToMavenRepository>().configureEach {
-    // Not required since both common and cryptography modules are published under the same com.hedera prefix which
+    // Not required since both common and cryptography modules are published under the same
+    // com.hedera prefix which
     // is the same configured Nexus profile on maven central.
     // enabled = publishingPackageGroup == "com.hedera.common"
 }
 
 publishing {
     publications.named<MavenPublication>("maven") {
-        // Explicitly set the package group to com.hedera.common since the cryptograph module is published under
+        // Explicitly set the package group to com.hedera.common since the cryptograph module is
+        // published under
         // the same com.hedera Nexus profile.
         group = "com.hedera.common"
         pom.description =

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.hedera-cryptography-publish.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.hedera-cryptography-publish.gradle.kts
@@ -21,17 +21,19 @@ plugins {
 
 // Publishing tasks are only enabled if we publish to the matching group.
 // Otherwise, Nexus configuration and credentials do not fit.
-//val publishingPackageGroup = providers.gradleProperty("publishingPackageGroup").getOrElse("")
+// val publishingPackageGroup = providers.gradleProperty("publishingPackageGroup").getOrElse("")
 
 tasks.withType<PublishToMavenRepository>().configureEach {
-    // Not required since both common and cryptography modules are published under the same com.hedera prefix which
+    // Not required since both common and cryptography modules are published under the same
+    // com.hedera prefix which
     // is the same configured Nexus profile on maven central.
     // enabled = publishingPackageGroup == "com.hedera.cryptography"
 }
 
 publishing {
     publications.named<MavenPublication>("maven") {
-        // Explicitly set the package group to com.hedera.cryptography since the common module is published under
+        // Explicitly set the package group to com.hedera.cryptography since the common module is
+        // published under
         // the same com.hedera Nexus profile.
         group = "com.hedera.cryptography"
         pom.description =

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.hedera-cryptography-publish.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.hedera-cryptography-publish.gradle.kts
@@ -21,14 +21,19 @@ plugins {
 
 // Publishing tasks are only enabled if we publish to the matching group.
 // Otherwise, Nexus configuration and credentials do not fit.
-val publishingPackageGroup = providers.gradleProperty("publishingPackageGroup").getOrElse("")
+//val publishingPackageGroup = providers.gradleProperty("publishingPackageGroup").getOrElse("")
 
 tasks.withType<PublishToMavenRepository>().configureEach {
-    enabled = publishingPackageGroup == "com.hedera.cryptography"
+    // Not required since both common and cryptography modules are published under the same com.hedera prefix which
+    // is the same configured Nexus profile on maven central.
+    // enabled = publishingPackageGroup == "com.hedera.cryptography"
 }
 
 publishing {
     publications.named<MavenPublication>("maven") {
+        // Explicitly set the package group to com.hedera.cryptography since the common module is published under
+        // the same com.hedera Nexus profile.
+        group = "com.hedera.cryptography"
         pom.description =
             "Swirlds is a software platform designed to build fully-distributed " +
                 "applications that harness the power of the cloud without servers. " +

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.maven-publish.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.maven-publish.gradle.kts
@@ -79,9 +79,5 @@ if (publishSigningEnabled) {
     signing {
         sign(maven)
         useGpgCmd()
-        useInMemoryPgpKeys(
-            providers.environmentVariable("SIGNING_KEY").get(),
-            providers.environmentVariable("SIGNING_PASSPHRASE").get()
-        )
     }
 }

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.nexus-publish.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.nexus-publish.gradle.kts
@@ -66,8 +66,10 @@ tasks.named("closeSonatypeStagingRepository") {
 tasks.named("releaseMavenCentral") {
     group = "release"
     // For initial release and testing builds, we should use the closeSonatypeStagingRepository task
-    // instead of the closeAndReleaseStagingRepository task. Left in for testing and the first release.
-    // Once automation has been tested and the initial release manually completed, this should be reverted
+    // instead of the closeAndReleaseStagingRepository task. Left in for testing and the first
+    // release.
+    // Once automation has been tested and the initial release manually completed, this should be
+    // reverted
     // to the closeAndReleaseStagingRepository task.
 
     // dependsOn(tasks.closeAndReleaseStagingRepository)

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.nexus-publish.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.nexus-publish.gradle.kts
@@ -38,7 +38,7 @@ plugins {
 }
 
 val publishingPackageGroup =
-    providers.gradleProperty("publishingPackageGroup").getOrElse("org.hedera")
+    providers.gradleProperty("publishingPackageGroup").getOrElse("com.hedera")
 
 version =
     providers.fileContents(rootProject.layout.projectDirectory.versionTxt()).asText.get().trim()
@@ -65,7 +65,13 @@ tasks.named("closeSonatypeStagingRepository") {
 
 tasks.named("releaseMavenCentral") {
     group = "release"
-    dependsOn(tasks.closeAndReleaseStagingRepository)
+    // For initial release and testing builds, we should use the closeSonatypeStagingRepository task
+    // instead of the closeAndReleaseStagingRepository task. Left in for testing and the first release.
+    // Once automation has been tested and the initial release manually completed, this should be reverted
+    // to the closeAndReleaseStagingRepository task.
+
+    // dependsOn(tasks.closeAndReleaseStagingRepository)
+    dependsOn(tasks.named("closeSonatypeStagingRepository"))
 }
 
 tasks.register("releaseMavenCentralSnapshot") {


### PR DESCRIPTION
## Description

This pull request changes the following:

- Resolves issues preventing publishing non-snapshot builds to maven central.

### Related Issues

- Closes #120