### PR TITLE
chore: Specify linux target glibc version

### DIFF
--- a/cryptography/hedera-cryptography-altbn128/rust-toolchain.toml
+++ b/cryptography/hedera-cryptography-altbn128/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 channel = "stable"
 components = [ "rustfmt", "rustc-dev" ]
-targets = [ "x86_64-apple-darwin", "aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-gnu" ]
+targets = [ "x86_64-apple-darwin", "aarch64-apple-darwin", "aarch64-unknown-linux-gnu.2.18", "x86_64-unknown-linux-gnu.2.18", "x86_64-pc-windows-gnu" ]
 profile = "minimal"

--- a/cryptography/hedera-cryptography-altbn128/rust-toolchain.toml
+++ b/cryptography/hedera-cryptography-altbn128/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 channel = "stable"
 components = [ "rustfmt", "rustc-dev" ]
-targets = [ "x86_64-apple-darwin", "aarch64-apple-darwin", "aarch64-unknown-linux-gnu.2.18", "x86_64-unknown-linux-gnu.2.18", "x86_64-pc-windows-gnu" ]
+targets = [ "x86_64-apple-darwin", "aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-gnu" ]
 profile = "minimal"

--- a/gradle/plugins/src/main/kotlin/com/hedera/gradle/extensions/CargoToolchain.kt
+++ b/gradle/plugins/src/main/kotlin/com/hedera/gradle/extensions/CargoToolchain.kt
@@ -18,8 +18,8 @@ package com.hedera.gradle.extensions
 
 enum class CargoToolchain(val platform: String, val target: String, val folder: String) {
     aarch64Darwin("darwin-aarch64", "aarch64-apple-darwin", "software/darwin/arm64"),
-    aarch64Linux("linux-aarch64", "aarch64-unknown-linux-gnu", "software/linux/arm64"),
+    aarch64Linux("linux-aarch64", "aarch64-unknown-linux-gnu.2.18", "software/linux/arm64"),
     x86Darwin("darwin-x86-64", "x86_64-apple-darwin", "software/darwin/amd64"),
-    x86Linux("linux-x86-64", "x86_64-unknown-linux-gnu", "software/linux/amd64"),
+    x86Linux("linux-x86-64", "x86_64-unknown-linux-gnu.2.18", "software/linux/amd64"),
     x86Windows("win32-x86-64-msvc", "x86_64-pc-windows-msvc", "software/windows/amd64")
 }

--- a/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/CargoBuildTask.kt
+++ b/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/CargoBuildTask.kt
@@ -71,7 +71,10 @@ abstract class CargoBuildTask : DefaultTask() {
 
         val profile = if (release.get()) "release" else "debug"
         val cargoOutputDir =
-            File(cargoToml.get().asFile.parent, "target/${toolchain.get().target}/${profile}")
+            File(
+                cargoToml.get().asFile.parent,
+                "target/${stripTargetVersion(toolchain.get())}/${profile}"
+            )
 
         files.copy {
             from(cargoOutputDir)
@@ -81,6 +84,17 @@ abstract class CargoBuildTask : DefaultTask() {
             include("lib${libname.get()}.dylib")
             include("${libname.get()}.dll")
         }
+    }
+
+    private fun stripTargetVersion(toolchain: CargoToolchain): String {
+        val re = Regex(pattern = "^([a-zA-Z0-9_\\-]+)(?:\\.[0-9.]+)?$")
+        val mr = re.find(toolchain.target)
+
+        if (mr != null && mr.groupValues.size > 1) {
+            return mr.groupValues[1]
+        }
+
+        return toolchain.target
     }
 
     private fun installCargoCrossCompiler(buildsForWindows: Boolean) {


### PR DESCRIPTION
**Description**:

Sets the desired glibc version to 2.18

**Related Issue(s)**:

Fixes #147
