### PR TITLE
build: rework setup of Rust toolchains

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,22 +50,6 @@ jobs:
           distribution: temurin
           java-version: 21.0.4
 
-      - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10.1
-        with:
-          cache: false
-          target: x86_64-pc-windows-msvc # additional target, Linux/Mac targets are configured as default
-
-      - name: Setup Zig (Linux/Mac cross-compile)
-        uses: mlugg/setup-zig@a67e68dc5c8281d9608136d3d7ca1b282213e4ac  # v1.2.1
-        with:
-          use-cache: 'false'
-
-      - name: Setup lld (Windows cross-compile)
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install lld
-
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4.2.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,9 +77,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        # os: [windows-2022, macos-13, macos-14]
-        # temporarily disable mac compilation because it's failing on GitHub actions
-        os: [windows-2022]
+        os: [windows-2022, macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Harden Runner
@@ -109,7 +107,7 @@ jobs:
           cache-read-only: false
 
       - name: Gradle Unit Test
-        run: ./gradlew test --scan --continue
+        run: ./gradlew test -PskipInstallRustToolchains=true --scan --continue
 
   analyze:
     name: Analyze

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,7 @@ jobs:
           cache-read-only: false
 
       - name: Gradle Unit Test
+        # We do -PskipInstallRustToolchains=true, because all cargoBuild task results are taken FROM-CACHE
         run: ./gradlew test -PskipInstallRustToolchains=true --scan --continue
 
   analyze:

--- a/README.md
+++ b/README.md
@@ -22,15 +22,6 @@ For the proposal that originated the work in this repository see:
 ## Build
 The project is built with Gradle.
 
-### Requirements
-
-For the rust (cross-)compilation, you need to install `rustup`, `zig` and `lld`. On Mac, you can do that via:
-
-```
-brew install rustup zig lld
-rustup target add x86_64-pc-windows-msvc
-```
-
 ### Build the project
 
 ```

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.feature.rust.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.feature.rust.gradle.kts
@@ -22,3 +22,8 @@ plugins { id("java") }
 val cargo = project.extensions.create<CargoExtension>("cargo")
 
 cargo.targets(*CargoToolchain.values())
+
+if (System.getenv().containsKey("CI")) {
+    // Disable, due to 'Could not load entry ... from remote build cache: Read timed out'
+    tasks.named("installRustToolchains") { outputs.cacheIf { false } }
+}

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.feature.rust.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.feature.rust.gradle.kts
@@ -16,20 +16,9 @@
 
 import com.hedera.gradle.extensions.CargoExtension
 import com.hedera.gradle.extensions.CargoToolchain
-import com.hedera.gradle.extensions.CargoToolchain.aarch64Linux
-import com.hedera.gradle.extensions.CargoToolchain.x86Linux
-import com.hedera.gradle.extensions.CargoToolchain.x86Windows
-import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins { id("java") }
 
 val cargo = project.extensions.create<CargoExtension>("cargo")
 
-// TODO: https://github.com/hashgraph/hedera-cryptography/issues/94
-// Remove the conditional compilation once the ticket is addressed.
-// It seems to be a problem with llc liker when zig is executed in the github runners
-if (Os.isFamily(Os.FAMILY_MAC)) {
-    cargo.targets(*CargoToolchain.values())
-} else {
-    cargo.targets(aarch64Linux, x86Linux, x86Windows)
-}
+cargo.targets(*CargoToolchain.values())

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.feature.rust.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.feature.rust.gradle.kts
@@ -15,9 +15,10 @@
  */
 
 import com.hedera.gradle.extensions.CargoExtension
-import com.hedera.gradle.extensions.CargoToolchain.*
-import com.hedera.gradle.services.TaskLockService
-import com.hedera.gradle.tasks.CargoBuildTask
+import com.hedera.gradle.extensions.CargoToolchain
+import com.hedera.gradle.extensions.CargoToolchain.aarch64Linux
+import com.hedera.gradle.extensions.CargoToolchain.x86Linux
+import com.hedera.gradle.extensions.CargoToolchain.x86Windows
 import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins { id("java") }
@@ -28,16 +29,7 @@ val cargo = project.extensions.create<CargoExtension>("cargo")
 // Remove the conditional compilation once the ticket is addressed.
 // It seems to be a problem with llc liker when zig is executed in the github runners
 if (Os.isFamily(Os.FAMILY_MAC)) {
-    cargo.targets(aarch64Darwin, aarch64Linux, x86Darwin, x86Linux, x86Windows)
+    cargo.targets(*CargoToolchain.values())
 } else {
     cargo.targets(aarch64Linux, x86Linux, x86Windows)
-}
-
-// Cargo might do installation work, do not run in parallel:
-tasks.withType<CargoBuildTask>().configureEach {
-    usesService(
-        gradle.sharedServices.registerIfAbsent("lock", TaskLockService::class) {
-            maxParallelUsages = 1
-        }
-    )
 }

--- a/gradle/plugins/src/main/kotlin/com/hedera/gradle/extensions/CargoExtension.kt
+++ b/gradle/plugins/src/main/kotlin/com/hedera/gradle/extensions/CargoExtension.kt
@@ -17,12 +17,16 @@
 package com.hedera.gradle.extensions
 
 import com.hedera.gradle.tasks.CargoBuildTask
+import com.hedera.gradle.tasks.RustToolchainInstallTask
+import java.util.Properties
 import javax.inject.Inject
 import org.gradle.api.Project
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskContainer
+import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
 
 @Suppress("LeakingThis")
@@ -37,12 +41,49 @@ abstract class CargoExtension {
 
     @get:Inject protected abstract val tasks: TaskContainer
 
+    @get:Inject protected abstract val providers: ProviderFactory
+
     @get:Inject protected abstract val sourceSets: SourceSetContainer
 
     init {
         cargoBin.convention(System.getProperty("user.home") + "/.cargo/bin")
         libname.convention(project.name)
         release.convention(true)
+
+
+        @Suppress("UnstableApiUsage")
+        val versionsFile =
+            project.isolated.rootProject.projectDirectory.file(
+                "gradle/toolchain-versions.properties"
+            )
+        val versions = Properties()
+        versions.load(
+            providers
+                .fileContents(versionsFile)
+                .asText
+                .orElse(
+                    providers.provider {
+                        throw RuntimeException("${versionsFile.asFile} does not exist")
+                    }
+                )
+                .get()
+                .reader()
+        )
+
+        // Rust toolchain installation
+        tasks.register<RustToolchainInstallTask>("installRustToolchain") {
+            // Track host system as input as the task output differs between operating systems
+            hostOperatingSystem.set(readHostOperatingSystem())
+            hostArchitecture.set(System.getProperty("os.arch"))
+
+            rustVersion.convention(versions.getValue("rust") as String)
+            cargoZigbuildVersion.convention(versions.getValue("cargo-zigbuild") as String)
+            zigVersion.convention(versions.getValue("zig") as String)
+            xwinVersion.convention(versions.getValue("xwin") as String)
+
+            toolchains.convention(CargoToolchain.values().asList())
+            destinationDirectory.convention(layout.buildDirectory.dir("rust-toolchains"))
+        }
 
         // Lifecycle task to only do all carg build tasks (mainly for testing)
         project.tasks.register("cargoBuild") {
@@ -51,7 +92,19 @@ abstract class CargoExtension {
         }
     }
 
+    private fun readHostOperatingSystem() =
+        System.getProperty("os.name").lowercase().let {
+            if (it.contains("windows")) {
+                "windows"
+            } else if (it.contains("mac")) {
+                "macos"
+            } else {
+                "linux"
+            }
+        }
+
     fun targets(vararg targets: CargoToolchain) {
+        val installTask = tasks.named<RustToolchainInstallTask>("installRustToolchain")
         targets.forEach { target ->
             val targetBuildTask =
                 tasks.register<CargoBuildTask>(
@@ -68,13 +121,8 @@ abstract class CargoExtension {
                     this.cargoToml.convention(layout.projectDirectory.file("Cargo.toml"))
                     this.libname.convention(this@CargoExtension.libname)
                     this.release.convention(this@CargoExtension.release)
-                    this.cargoBin.convention(this@CargoExtension.cargoBin)
-                    @Suppress("UnstableApiUsage")
-                    this.xwinFolder.convention(
-                        project.isolated.rootProject.projectDirectory
-                            .dir(".gradle/xwin")
-                            .asFile
-                            .absolutePath
+                    this.rustInstallFolder.convention(
+                        installTask.flatMap { it.destinationDirectory }
                     )
                 }
 

--- a/gradle/plugins/src/main/kotlin/com/hedera/gradle/extensions/CargoExtension.kt
+++ b/gradle/plugins/src/main/kotlin/com/hedera/gradle/extensions/CargoExtension.kt
@@ -71,6 +71,9 @@ abstract class CargoExtension {
 
         // Rust toolchain installation
         tasks.register<RustToolchainInstallTask>("installRustToolchain") {
+            group = "rust"
+            description = "Installs Rust and toolchain components required for cross-compilation"
+
             // Track host system as input as the task output differs between operating systems
             hostOperatingSystem.set(readHostOperatingSystem())
             hostArchitecture.set(System.getProperty("os.arch"))

--- a/gradle/plugins/src/main/kotlin/com/hedera/gradle/extensions/CargoExtension.kt
+++ b/gradle/plugins/src/main/kotlin/com/hedera/gradle/extensions/CargoExtension.kt
@@ -84,11 +84,6 @@ abstract class CargoExtension {
             hostOperatingSystem.set(readHostOperatingSystem())
             hostArchitecture.set(System.getProperty("os.arch"))
 
-            rustVersion.convention(versions.getValue("rust") as String)
-            cargoZigbuildVersion.convention(versions.getValue("cargo-zigbuild") as String)
-            zigVersion.convention(versions.getValue("zig") as String)
-            xwinVersion.convention(versions.getValue("xwin") as String)
-
             toolchains.convention(CargoToolchain.values().asList())
             destinationDirectory.convention(layout.buildDirectory.dir("rust-toolchains"))
         }

--- a/gradle/plugins/src/main/kotlin/com/hedera/gradle/extensions/CargoExtension.kt
+++ b/gradle/plugins/src/main/kotlin/com/hedera/gradle/extensions/CargoExtension.kt
@@ -28,10 +28,10 @@ import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.withType
 
 @Suppress("LeakingThis")
 abstract class CargoExtension {
-    abstract val cargoBin: Property<String>
     abstract val libname: Property<String>
     abstract val release: Property<Boolean>
 
@@ -46,10 +46,6 @@ abstract class CargoExtension {
     @get:Inject protected abstract val sourceSets: SourceSetContainer
 
     init {
-        cargoBin.convention(System.getProperty("user.home") + "/.cargo/bin")
-        libname.convention(project.name)
-        release.convention(true)
-
         @Suppress("UnstableApiUsage")
         val versionsFile =
             project.isolated.rootProject.projectDirectory.file(
@@ -69,8 +65,18 @@ abstract class CargoExtension {
                 .reader()
         )
 
+        tasks.withType<CargoVersions>().configureEach {
+            rustVersion.convention(versions.getValue("rust") as String)
+            cargoZigbuildVersion.convention(versions.getValue("cargo-zigbuild") as String)
+            zigVersion.convention(versions.getValue("zig") as String)
+            xwinVersion.convention(versions.getValue("xwin") as String)
+        }
+
+        libname.convention(project.name)
+        release.convention(true)
+
         // Rust toolchain installation
-        tasks.register<RustToolchainInstallTask>("installRustToolchain") {
+        tasks.register<RustToolchainInstallTask>("installRustToolchains") {
             group = "rust"
             description = "Installs Rust and toolchain components required for cross-compilation"
 
@@ -106,7 +112,10 @@ abstract class CargoExtension {
         }
 
     fun targets(vararg targets: CargoToolchain) {
-        val installTask = tasks.named<RustToolchainInstallTask>("installRustToolchain")
+        val installTask = tasks.named<RustToolchainInstallTask>("installRustToolchains")
+        val skipInstall =
+            providers.gradleProperty("skipInstallRustToolchains").getOrElse("false").toBoolean()
+
         targets.forEach { target ->
             val targetBuildTask =
                 tasks.register<CargoBuildTask>(
@@ -114,18 +123,21 @@ abstract class CargoExtension {
                 ) {
                     group = "rust"
                     description = "Build library ($target)"
+
+                    if (!skipInstall) {
+                        dependsOn(installTask)
+                    }
+
                     toolchain.convention(target)
                     sourcesDirectory.convention(layout.projectDirectory.dir("src/main/rust"))
                     destinationDirectory.convention(
                         layout.buildDirectory.dir("rustJniLibs/${target.platform}")
                     )
 
-                    this.cargoToml.convention(layout.projectDirectory.file("Cargo.toml"))
-                    this.libname.convention(this@CargoExtension.libname)
-                    this.release.convention(this@CargoExtension.release)
-                    this.rustInstallFolder.convention(
-                        installTask.flatMap { it.destinationDirectory }
-                    )
+                    cargoToml.convention(layout.projectDirectory.file("Cargo.toml"))
+                    libname.convention(this@CargoExtension.libname)
+                    release.convention(this@CargoExtension.release)
+                    rustInstallFolder.convention(installTask.flatMap { it.destinationDirectory })
                 }
 
             tasks.named("cargoBuild") { dependsOn(targetBuildTask) }

--- a/gradle/plugins/src/main/kotlin/com/hedera/gradle/extensions/CargoExtension.kt
+++ b/gradle/plugins/src/main/kotlin/com/hedera/gradle/extensions/CargoExtension.kt
@@ -50,7 +50,6 @@ abstract class CargoExtension {
         libname.convention(project.name)
         release.convention(true)
 
-
         @Suppress("UnstableApiUsage")
         val versionsFile =
             project.isolated.rootProject.projectDirectory.file(

--- a/gradle/plugins/src/main/kotlin/com/hedera/gradle/extensions/CargoVersions.kt
+++ b/gradle/plugins/src/main/kotlin/com/hedera/gradle/extensions/CargoVersions.kt
@@ -1,0 +1,12 @@
+package com.hedera.gradle.extensions
+
+import org.gradle.api.Task
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+
+interface CargoVersions : Task {
+    @get:Input val rustVersion: Property<String>
+    @get:Input val cargoZigbuildVersion: Property<String>
+    @get:Input val zigVersion: Property<String>
+    @get:Input val xwinVersion: Property<String>
+}

--- a/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/CargoBuildTask.kt
+++ b/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/CargoBuildTask.kt
@@ -112,6 +112,9 @@ abstract class CargoBuildTask : DefaultTask() {
             if (buildsForWindows) {
                 // See https://github.com/Jake-Shadle/xwin/blob/main/xwin.dockerfile
                 val xwinFolder = rustInstallFolder.dir("xwin").get().asFile.absolutePath
+                val rustupToolchains = rustInstallFolder.dir("rustup/toolchains").get().asFile
+                val rustLld = rustupToolchains.walk().filter { it.name == "rust-lld" }.single()
+
                 val clFlags =
                     "-Wno-unused-command-line-argument -fuse-ld=lld-link /vctoolsdir $xwinFolder/crt /winsdkdir $xwinFolder/sdk"
                 environment("CC_x86_64_pc_windows_msvc", "clang-cl")
@@ -122,7 +125,7 @@ abstract class CargoBuildTask : DefaultTask() {
                 environment("CL_FLAGS", clFlags)
                 environment("CFLAGS_x86_64_pc_windows_msvc", clFlags)
                 environment("CXXFLAGS_x86_64_pc_windows_msvc", clFlags)
-                environment("CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER", "lld-link")
+                environment("CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER", rustLld.absolutePath)
                 environment(
                     "RUSTFLAGS",
                     "-Lnative=$xwinFolder/crt/lib/x86_64 -Lnative=$xwinFolder/sdk/lib/um/x86_64 -Lnative=$xwinFolder/sdk/lib/ucrt/x86_64"

--- a/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/CargoBuildTask.kt
+++ b/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/CargoBuildTask.kt
@@ -17,6 +17,7 @@
 package com.hedera.gradle.tasks
 
 import com.hedera.gradle.extensions.CargoToolchain
+import com.hedera.gradle.extensions.CargoVersions
 import java.io.File
 import javax.inject.Inject
 import org.gradle.api.DefaultTask
@@ -29,6 +30,7 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -36,15 +38,15 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
 
 @CacheableTask
-abstract class CargoBuildTask : DefaultTask() {
+abstract class CargoBuildTask : CargoVersions, DefaultTask() {
+
     @get:Input abstract val libname: Property<String>
 
     @get:Input abstract val release: Property<Boolean>
 
     @get:Input abstract val toolchain: Property<CargoToolchain>
 
-    @get:InputDirectory
-    @get:PathSensitive(PathSensitivity.NONE)
+    @get:Internal // the toolchain versions are tracked as input
     abstract val rustInstallFolder: DirectoryProperty
 
     @get:InputFile
@@ -74,7 +76,7 @@ abstract class CargoBuildTask : DefaultTask() {
                 "target/${stripTargetVersion(toolchain.get())}/${profile}"
             )
 
-        files.copy {
+        files.sync {
             from(cargoOutputDir)
             into(destinationDirectory.dir(toolchain.get().folder))
 
@@ -85,29 +87,29 @@ abstract class CargoBuildTask : DefaultTask() {
     }
 
     private fun stripTargetVersion(toolchain: CargoToolchain): String {
-        val re = Regex(pattern = "^([a-zA-Z0-9_\\-]+)(?:\\.[0-9.]+)?$")
-        val mr = re.find(toolchain.target)
-
-        if (mr != null && mr.groupValues.size > 1) {
-            return mr.groupValues[1]
-        }
-
-        return toolchain.target
+        return toolchain.target.replaceAfter(".", "").replace(".", "")
     }
 
     private fun buildForTarget(buildsForWindows: Boolean) {
         exec.exec {
+            val rustupHome = rustInstallFolder.dir("rustup").get().asFile.absolutePath
             val cargoHome = rustInstallFolder.dir("cargo").get().asFile.absolutePath
             val zigPath = rustInstallFolder.file("zig/zig").get().asFile.absolutePath
             val buildCommand = if (buildsForWindows) "build" else "zigbuild"
 
             workingDir = cargoToml.get().asFile.parentFile
 
+            environment("RUSTUP_HOME", rustupHome)
             environment("CARGO_HOME", cargoHome)
             environment("CARGO_ZIGBUILD_ZIG_PATH", zigPath)
 
             commandLine =
-                listOf("$cargoHome/bin/cargo", buildCommand, "--target=${toolchain.get().target}")
+                listOf(
+                    "$cargoHome/bin/cargo",
+                    "+${rustVersion.get()}",
+                    buildCommand,
+                    "--target=${toolchain.get().target}"
+                )
 
             if (buildsForWindows) {
                 // See https://github.com/Jake-Shadle/xwin/blob/main/xwin.dockerfile

--- a/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/CargoBuildTask.kt
+++ b/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/CargoBuildTask.kt
@@ -91,12 +91,12 @@ abstract class CargoBuildTask : CargoVersions, DefaultTask() {
     }
 
     private fun buildForTarget(buildsForWindows: Boolean) {
-        exec.exec {
-            val rustupHome = rustInstallFolder.dir("rustup").get().asFile.absolutePath
-            val cargoHome = rustInstallFolder.dir("cargo").get().asFile.absolutePath
-            val zigPath = rustInstallFolder.file("zig/zig").get().asFile.absolutePath
-            val buildCommand = if (buildsForWindows) "build" else "zigbuild"
+        val rustupHome = rustInstallFolder.dir("rustup").get().asFile.absolutePath
+        val cargoHome = rustInstallFolder.dir("cargo").get().asFile
+        val zigPath = rustInstallFolder.file("zig/zig").get().asFile.absolutePath
+        val buildCommand = if (buildsForWindows) "build" else "zigbuild"
 
+        exec.exec {
             workingDir = cargoToml.get().asFile.parentFile
 
             environment("RUSTUP_HOME", rustupHome)
@@ -105,7 +105,7 @@ abstract class CargoBuildTask : CargoVersions, DefaultTask() {
 
             commandLine =
                 listOf(
-                    "$cargoHome/bin/cargo",
+                    File(cargoHome, "bin/cargo").absolutePath,
                     "+${rustVersion.get()}",
                     buildCommand,
                     "--target=${toolchain.get().target}"
@@ -142,5 +142,7 @@ abstract class CargoBuildTask : CargoVersions, DefaultTask() {
                 args("--verbose")
             }
         }
+
+        CargoUtil.cleanCache(cargoHome)
     }
 }

--- a/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/CargoBuildTask.kt
+++ b/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/CargoBuildTask.kt
@@ -29,7 +29,6 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -44,6 +43,10 @@ abstract class CargoBuildTask : DefaultTask() {
 
     @get:Input abstract val toolchain: Property<CargoToolchain>
 
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val rustInstallFolder: DirectoryProperty
+
     @get:InputFile
     @get:PathSensitive(PathSensitivity.NONE)
     abstract val cargoToml: RegularFileProperty
@@ -54,10 +57,6 @@ abstract class CargoBuildTask : DefaultTask() {
 
     @get:OutputDirectory abstract val destinationDirectory: DirectoryProperty
 
-    @get:Internal abstract val cargoBin: Property<String>
-
-    @get:Internal abstract val xwinFolder: Property<String>
-
     @get:Inject protected abstract val exec: ExecOperations
 
     @get:Inject protected abstract val files: FileOperations
@@ -66,7 +65,6 @@ abstract class CargoBuildTask : DefaultTask() {
     fun build() {
         val buildsForWindows = toolchain.get() == CargoToolchain.x86Windows
 
-        installCargoCrossCompiler(buildsForWindows)
         buildForTarget(buildsForWindows)
 
         val profile = if (release.get()) "release" else "debug"
@@ -97,48 +95,25 @@ abstract class CargoBuildTask : DefaultTask() {
         return toolchain.target
     }
 
-    private fun installCargoCrossCompiler(buildsForWindows: Boolean) {
-        exec.exec {
-            // Pin version to latest 0.6.6 RC to due to issue
-            // https://github.com/Jake-Shadle/xwin/issues/141
-            // Version should be removed, once 0.6.6 or newer is officially available
-            val crossCompiler = if (buildsForWindows) "xwin@0.6.6-rc.2" else "cargo-zigbuild"
-            commandLine = listOf(cargoBin.get() + "/cargo", "install", "--locked", crossCompiler)
-        }
-        if (buildsForWindows && !File(xwinFolder.get()).exists()) {
-            exec.exec {
-                // https://github.com/Jake-Shadle/xwin/issues/141#issuecomment-2416864318
-                environment("RAYON_NUM_THREADS", "1")
-                commandLine =
-                    listOf(
-                        cargoBin.get() + "/xwin",
-                        "--accept-license",
-                        "splat",
-                        "--output",
-                        xwinFolder.get()
-                    )
-            }
-        }
-    }
-
     private fun buildForTarget(buildsForWindows: Boolean) {
         exec.exec {
+            val cargoHome = rustInstallFolder.dir("cargo").get().asFile.absolutePath
+            val zigPath = rustInstallFolder.file("zig/zig").get().asFile.absolutePath
             val buildCommand = if (buildsForWindows) "build" else "zigbuild"
 
             workingDir = cargoToml.get().asFile.parentFile
 
+            environment("CARGO_HOME", cargoHome)
+            environment("CARGO_ZIGBUILD_ZIG_PATH", zigPath)
+
             commandLine =
-                listOf(
-                    cargoBin.get() + "/cargo",
-                    buildCommand,
-                    "--target=${toolchain.get().target}"
-                )
+                listOf("$cargoHome/bin/cargo", buildCommand, "--target=${toolchain.get().target}")
 
             if (buildsForWindows) {
                 // See https://github.com/Jake-Shadle/xwin/blob/main/xwin.dockerfile
-                val xwin = xwinFolder.get()
+                val xwinFolder = rustInstallFolder.dir("xwin").get().asFile.absolutePath
                 val clFlags =
-                    "-Wno-unused-command-line-argument -fuse-ld=lld-link /vctoolsdir $xwin/crt /winsdkdir $xwin/sdk"
+                    "-Wno-unused-command-line-argument -fuse-ld=lld-link /vctoolsdir $xwinFolder/crt /winsdkdir $xwinFolder/sdk"
                 environment("CC_x86_64_pc_windows_msvc", "clang-cl")
                 environment("CXX_x86_64_pc_windows_msvc", "clang-cl")
                 environment("AR_x86_64_pc_windows_msvc", "llvm-lib")
@@ -150,7 +125,7 @@ abstract class CargoBuildTask : DefaultTask() {
                 environment("CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER", "lld-link")
                 environment(
                     "RUSTFLAGS",
-                    "-Lnative=$xwin/crt/lib/x86_64 -Lnative=$xwin/sdk/lib/um/x86_64 -Lnative=$xwin/sdk/lib/ucrt/x86_64"
+                    "-Lnative=$xwinFolder/crt/lib/x86_64 -Lnative=$xwinFolder/sdk/lib/um/x86_64 -Lnative=$xwinFolder/sdk/lib/ucrt/x86_64"
                 )
             }
 

--- a/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/CargoUtil.kt
+++ b/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/CargoUtil.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.gradle.tasks
+
+import java.io.File
+
+internal object CargoUtil {
+
+    /*
+     * Clean the global Cargo cache to not have it as (unstable) part
+     * of the output of the RustToolchainInstallTask.
+     */
+    fun cleanCache(cargoFolder: File) {
+        File(cargoFolder, ".global-cache").delete()
+        File(cargoFolder, "registry/cache").deleteRecursively()
+    }
+}

--- a/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/RustToolchainInstallTask.kt
+++ b/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/RustToolchainInstallTask.kt
@@ -141,6 +141,7 @@ abstract class RustToolchainInstallTask : CargoVersions, DefaultTask() {
         )
         execute(listOf(xwinCmd, "--accept-license", "splat", "--output", xwinFolder))
 
+        CargoUtil.cleanCache(destinationDirectory.dir("cargo").get().asFile)
         files.delete(rustupInstall)
     }
 

--- a/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/RustToolchainInstallTask.kt
+++ b/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/RustToolchainInstallTask.kt
@@ -151,8 +151,6 @@ abstract class RustToolchainInstallTask : CargoVersions, DefaultTask() {
         exec.exec {
             environment("RUSTUP_HOME", rustupFolder)
             environment("CARGO_HOME", cargoFolder)
-            // https://github.com/Jake-Shadle/xwin/issues/141#issuecomment-2416864318
-            environment("RAYON_NUM_THREADS", "1")
             commandLine = cmd
         }
     }

--- a/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/RustToolchainInstallTask.kt
+++ b/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/RustToolchainInstallTask.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.gradle.tasks
+
+import com.hedera.gradle.extensions.CargoToolchain
+import java.net.URI
+import javax.inject.Inject
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ArchiveOperations
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.internal.file.FileOperations
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
+
+@CacheableTask
+abstract class RustToolchainInstallTask : DefaultTask() {
+
+    @get:Input abstract val rustVersion: Property<String>
+    @get:Input abstract val cargoZigbuildVersion: Property<String>
+    @get:Input abstract val zigVersion: Property<String>
+    @get:Input abstract val xwinVersion: Property<String>
+
+    @get:Input abstract val hostOperatingSystem: Property<String>
+    @get:Input abstract val hostArchitecture: Property<String>
+
+    @get:Input abstract val toolchains: ListProperty<CargoToolchain>
+
+    @get:OutputDirectory abstract val destinationDirectory: DirectoryProperty
+
+    @get:Inject protected abstract val exec: ExecOperations
+
+    @get:Inject protected abstract val files: FileOperations
+
+    @get:Inject protected abstract val archives: ArchiveOperations
+
+    @TaskAction
+    fun install() {
+        destinationDirectory.get().asFile.listFiles()?.forEach { files.delete(it) }
+        installZig()
+        installRust()
+    }
+
+    private fun installZig() {
+        val isWindows = hostOperatingSystem.get() == "windows"
+        val zigArchiveName =
+            "zig-${hostOperatingSystem.get()}-${hostArchitecture.get()}-${zigVersion.get()}"
+        val fileExtension = if (isWindows) "zip" else "tar.xz"
+
+        val url =
+            URI("https://ziglang.org/download/${zigVersion.get()}/$zigArchiveName.$fileExtension")
+                .toURL()
+        val zigArchive = destinationDirectory.file("$zigArchiveName.$fileExtension").get().asFile
+        zigArchive.writeBytes(url.readBytes())
+
+        if (isWindows) {
+            files.copy {
+                from(archives.tarTree(zigArchive))
+                into(destinationDirectory)
+            }
+        } else {
+            // Use command line to un-tar as it is unfortunately not supported by ArchiveOperations
+            // https://github.com/gradle/gradle/issues/15065
+
+            exec.exec {
+                commandLine(
+                    "tar",
+                    "xJf",
+                    zigArchive.absolutePath,
+                    "-C",
+                    destinationDirectory.get().asFile.absolutePath
+                )
+            }
+        }
+
+        destinationDirectory
+            .dir(zigArchiveName)
+            .get()
+            .asFile
+            .renameTo(destinationDirectory.dir("zig").get().asFile)
+
+        files.delete(zigArchive)
+    }
+
+    private fun installRust() {
+        val url = URI("https://sh.rustup.rs").toURL()
+        val rustupInstall = destinationDirectory.file("rustup-install.sh").get().asFile
+        rustupInstall.writeText(url.readText())
+        rustupInstall.setExecutable(true)
+
+        val cargoCmd = destinationDirectory.dir("cargo/bin/cargo").get().asFile.absolutePath
+        val xwinCmd = destinationDirectory.dir("cargo/bin/xwin").get().asFile.absolutePath
+        val xwinFolder = destinationDirectory.dir("xwin").get().asFile.absolutePath
+
+        val targets =
+            toolchains.get().flatMap {
+                listOf("-t", it.target.replaceAfter(".", "").replace(".", ""))
+            }
+
+        execute(
+            listOf(
+                rustupInstall.absolutePath,
+                "-y",
+                "--profile=minimal",
+                "--default-toolchain=${rustVersion.get()}"
+            ) + targets
+        )
+        execute(
+            listOf(
+                cargoCmd,
+                "+${rustVersion.get()}",
+                "install",
+                "--locked",
+                "--ignore-rust-version",
+                "--profile=release",
+                "cargo-zigbuild@${cargoZigbuildVersion.get()}"
+            )
+        )
+        execute(
+            listOf(
+                cargoCmd,
+                "+${rustVersion.get()}",
+                "install",
+                "--locked",
+                "--profile=release",
+                "xwin@${xwinVersion.get()}"
+            )
+        )
+        // execute(listOf(xwinCmd, "--accept-license", "splat", "--output", xwinFolder))
+
+        files.delete(rustupInstall)
+        files.delete(destinationDirectory.dir("rustup"))
+    }
+
+    private fun execute(cmd: List<String>) {
+        val rustupFolder = destinationDirectory.dir("rustup").get().asFile.absolutePath
+        val cargoFolder = destinationDirectory.dir("cargo").get().asFile.absolutePath
+        exec.exec {
+            environment("RUSTUP_HOME", rustupFolder)
+            environment("CARGO_HOME", cargoFolder)
+            // https://github.com/Jake-Shadle/xwin/issues/141#issuecomment-2416864318
+            environment("RAYON_NUM_THREADS", "1")
+            commandLine = cmd
+        }
+    }
+}

--- a/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/RustToolchainInstallTask.kt
+++ b/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/RustToolchainInstallTask.kt
@@ -17,6 +17,7 @@
 package com.hedera.gradle.tasks
 
 import com.hedera.gradle.extensions.CargoToolchain
+import com.hedera.gradle.extensions.CargoVersions
 import java.net.URI
 import javax.inject.Inject
 import org.gradle.api.DefaultTask
@@ -32,13 +33,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
 
 @CacheableTask
-abstract class RustToolchainInstallTask : DefaultTask() {
-
-    @get:Input abstract val rustVersion: Property<String>
-    @get:Input abstract val cargoZigbuildVersion: Property<String>
-    @get:Input abstract val zigVersion: Property<String>
-    @get:Input abstract val xwinVersion: Property<String>
-
+abstract class RustToolchainInstallTask : CargoVersions, DefaultTask() {
     @get:Input abstract val hostOperatingSystem: Property<String>
     @get:Input abstract val hostArchitecture: Property<String>
 
@@ -62,8 +57,7 @@ abstract class RustToolchainInstallTask : DefaultTask() {
     private fun installZig() {
         val isWindows = hostOperatingSystem.get() == "windows"
         val arch = hostArchitecture.get().let { if (it == "amd64") "x86_64" else it }
-        val zigArchiveName =
-            "zig-${hostOperatingSystem.get()}-$arch-${zigVersion.get()}"
+        val zigArchiveName = "zig-${hostOperatingSystem.get()}-$arch-${zigVersion.get()}"
         val fileExtension = if (isWindows) "zip" else "tar.xz"
 
         val url =

--- a/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/RustToolchainInstallTask.kt
+++ b/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/RustToolchainInstallTask.kt
@@ -68,7 +68,7 @@ abstract class RustToolchainInstallTask : CargoVersions, DefaultTask() {
 
         if (isWindows) {
             files.copy {
-                from(archives.tarTree(zigArchive))
+                from(archives.zipTree(zigArchive))
                 into(destinationDirectory)
             }
         } else {

--- a/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/RustToolchainInstallTask.kt
+++ b/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/RustToolchainInstallTask.kt
@@ -61,8 +61,9 @@ abstract class RustToolchainInstallTask : DefaultTask() {
 
     private fun installZig() {
         val isWindows = hostOperatingSystem.get() == "windows"
+        val arch = hostArchitecture.get().let { if (it == "amd64") "x86_64" else it }
         val zigArchiveName =
-            "zig-${hostOperatingSystem.get()}-${hostArchitecture.get()}-${zigVersion.get()}"
+            "zig-${hostOperatingSystem.get()}-$arch-${zigVersion.get()}"
         val fileExtension = if (isWindows) "zip" else "tar.xz"
 
         val url =

--- a/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/RustToolchainInstallTask.kt
+++ b/gradle/plugins/src/main/kotlin/com/hedera/gradle/tasks/RustToolchainInstallTask.kt
@@ -144,10 +144,9 @@ abstract class RustToolchainInstallTask : DefaultTask() {
                 "xwin@${xwinVersion.get()}"
             )
         )
-        // execute(listOf(xwinCmd, "--accept-license", "splat", "--output", xwinFolder))
+        execute(listOf(xwinCmd, "--accept-license", "splat", "--output", xwinFolder))
 
         files.delete(rustupInstall)
-        files.delete(destinationDirectory.dir("rustup"))
     }
 
     private fun execute(cmd: List<String>) {

--- a/gradle/toolchain-versions.properties
+++ b/gradle/toolchain-versions.properties
@@ -1,0 +1,4 @@
+rust=1.81.0
+cargo-zigbuild=0.19.5
+zig=0.13.0
+xwin=0.6.5


### PR DESCRIPTION
**Description**:
The setup of all tools for Rust cross-compilation is now done via the `installRustToolchains` Gradle task. The tools are installed locally in the `build` directory of the project that requires them. They are thus isolated from any state of Rust tooling already installed on a (local) machine.

~The new `installRustToolchains` task is cached*. Which means that the complete toolchains are put into the Gradle remote cache. Thus, once the installation ran successfully on a CI agent of a given operating system, the ready-to-use toolchains will be downloaded from the cache if a build runs on a machine with that operating system.~
Possible follow up: https://github.com/hashgraph/hedera-cryptography/issues/160

For stability and reproducibility, for both local and CI builds, the versions of Rust and the additional toolchain components (zig, xwin, ...) are now pinned and require explicit updating.

**Related issue(s)**:

Fixes #125
Fixes #94

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
