### PR TITLE
feat(16683): Add support for compressed representation in GroupElements

### DIFF
--- a/cryptography/hedera-cryptography-altbn128/build.gradle.kts
+++ b/cryptography/hedera-cryptography-altbn128/build.gradle.kts
@@ -31,3 +31,5 @@ testModuleInfo {
     requires("com.hedera.cryptography.utils.test.fixtures")
     requires("com.hedera.cryptography.pairings.test.fixtures")
 }
+
+jmhModuleInfo { requires("com.hedera.cryptography.pairings.test.fixtures") }

--- a/cryptography/hedera-cryptography-altbn128/src/jmh/java/com/hedera/cryptography/altbn128/GroupElementEqualityAndHashCodeBenchmark.java
+++ b/cryptography/hedera-cryptography-altbn128/src/jmh/java/com/hedera/cryptography/altbn128/GroupElementEqualityAndHashCodeBenchmark.java
@@ -65,7 +65,6 @@ public class GroupElementEqualityAndHashCodeBenchmark {
     public void init() {
         var seed = new Random().nextLong();
         var field = new AltBn128Field();
-        System.out.println("Random Seed: " + seed);
         var rng = new Random(seed);
         var group = new AltBn128Group(AltBN128CurveGroup.valueOf(value), field);
 

--- a/cryptography/hedera-cryptography-altbn128/src/jmh/java/com/hedera/cryptography/altbn128/GroupElementMbcVsHorner.java
+++ b/cryptography/hedera-cryptography-altbn128/src/jmh/java/com/hedera/cryptography/altbn128/GroupElementMbcVsHorner.java
@@ -19,6 +19,7 @@ package com.hedera.cryptography.altbn128;
 import com.hedera.cryptography.pairings.api.FieldElement;
 import com.hedera.cryptography.pairings.api.GroupElement;
 import com.hedera.cryptography.pairings.extensions.EcPolynomial;
+import com.hedera.cryptography.pairings.test.fixtures.Utils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -195,22 +196,8 @@ public class GroupElementMbcVsHorner {
         long[] a = new long[degree];
         a[0] = 1;
         for (int i = 1; i < degree; i++) {
-            a[i] = power(xInt, i);
+            a[i] = Utils.longPow(xInt, i);
         }
         return group.msm(coeffPoitns, a);
-    }
-
-    public long power(int base, int k) {
-        for (long accum = 1, b = base; ; k >>>= 1)
-            switch (k) {
-                case 0:
-                    return accum;
-                case 1:
-                    return accum * b;
-                default:
-                    if ((k & 1) != 0) // guava uses conditional multiplicand
-                    accum *= b;
-                    b *= b;
-            }
     }
 }

--- a/cryptography/hedera-cryptography-altbn128/src/jmh/java/com/hedera/cryptography/altbn128/GroupElementsBenchmark.java
+++ b/cryptography/hedera-cryptography-altbn128/src/jmh/java/com/hedera/cryptography/altbn128/GroupElementsBenchmark.java
@@ -129,7 +129,6 @@ public class GroupElementsBenchmark {
         return group.zero();
     }
 
-
     @State(Scope.Benchmark)
     public static class CoordinatesState {
         List<BigInteger> xs;

--- a/cryptography/hedera-cryptography-altbn128/src/jmh/java/com/hedera/cryptography/altbn128/GroupElementsBenchmark.java
+++ b/cryptography/hedera-cryptography-altbn128/src/jmh/java/com/hedera/cryptography/altbn128/GroupElementsBenchmark.java
@@ -16,15 +16,13 @@
 
 package com.hedera.cryptography.altbn128;
 
+import com.hedera.cryptography.altbn128.facade.GroupFacade.ToBytesFlags;
 import com.hedera.cryptography.pairings.api.FieldElement;
 import com.hedera.cryptography.pairings.api.GroupElement;
 import com.hedera.cryptography.utils.serialization.Deserializer;
 import com.hedera.cryptography.utils.serialization.Serializer;
 import java.math.BigInteger;
-import java.util.HashMap;
-import java.util.HexFormat;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -45,18 +43,37 @@ import org.openjdk.jmh.annotations.State;
 public class GroupElementsBenchmark {
     AltBn128Group group;
     Random rng = new Random();
+    FieldElement element;
     GroupElement point;
     GroupElement point2;
+    byte[] point2Array;
     Serializer<GroupElement> compressedSerializer;
     Deserializer<GroupElement> compressedDeserializer;
     Deserializer<GroupElement> deserializer;
     Serializer<GroupElement> serializer;
-    FieldElement element;
 
     @Param({"GROUP1", "GROUP2"})
     static String value;
 
-    static Map<String, byte[]> representations = new HashMap<>();
+    // Benchmark                                     (value)  Mode  Cnt   Score    Error  Units
+    // GroupElementsBenchmark.copy                    GROUP1  avgt    5  ≈ 10⁻⁵           ms/op
+    // GroupElementsBenchmark.copy                    GROUP2  avgt    5  ≈ 10⁻⁵           ms/op
+    // GroupElementsBenchmark.createRandom            GROUP1  avgt    5   0.012 ±  0.001  ms/op
+    // GroupElementsBenchmark.createRandom            GROUP2  avgt    5   0.187 ±  0.001  ms/op
+    // GroupElementsBenchmark.fromBytesCompress       GROUP1  avgt    5   0.042 ±  0.001  ms/op
+    // GroupElementsBenchmark.fromBytesCompress       GROUP2  avgt    5   0.115 ±  0.001  ms/op
+    // GroupElementsBenchmark.fromBytesNonValidated   GROUP1  avgt    5  ≈ 10⁻³           ms/op
+    // GroupElementsBenchmark.fromBytesNonValidated   GROUP2  avgt    5  ≈ 10⁻³           ms/op
+    // GroupElementsBenchmark.fromX                   GROUP1  avgt    5   0.048 ±  0.002  ms/op
+    // GroupElementsBenchmark.fromX                   GROUP2  avgt    5   0.134 ±  0.001  ms/op
+    // GroupElementsBenchmark.fromXAndY               GROUP1  avgt    5   0.043 ±  0.001  ms/op
+    // GroupElementsBenchmark.fromXAndY               GROUP2  avgt    5   0.117 ±  0.003  ms/op
+    // GroupElementsBenchmark.multiply                GROUP1  avgt    5   0.054 ±  0.001  ms/op
+    // GroupElementsBenchmark.multiply                GROUP2  avgt    5   0.159 ±  0.001  ms/op
+    // GroupElementsBenchmark.multiplyLong            GROUP1  avgt    5   0.022 ±  0.001  ms/op
+    // GroupElementsBenchmark.multiplyLong            GROUP2  avgt    5   0.058 ±  0.001  ms/op
+    // GroupElementsBenchmark.zero                    GROUP1  avgt    5  ≈ 10⁻⁴           ms/op
+    // GroupElementsBenchmark.zero                    GROUP2  avgt    5  ≈ 10⁻⁴           ms/op
 
     @Setup(Level.Trial)
     public void init() {
@@ -64,22 +81,8 @@ public class GroupElementsBenchmark {
         group = new AltBn128Group(AltBN128CurveGroup.valueOf(value), field);
         point = group.random(rng);
         point2 = group.random(rng);
+        point2Array = point2.toBytes();
         element = field.random(rng);
-        var parser = HexFormat.of().withUpperCase();
-        representations.put(
-                "CGROUP1", parser.parseHex("F1EE9FFEE1686777ED6873FB07900FE138F6A887D047D93F837B4D711221E283"));
-        representations.put(
-                "GROUP1",
-                parser.parseHex(
-                        "545BABA0D76CB1F5AB91D137997A6ACF4ECDDA2E3C1BF04784909DEDF1C4C5198DA77E6DC899EB46E6C9AB986EC71D19CE36493631E74FA89B81868BC96EEF01"));
-        representations.put(
-                "CGROUP2",
-                parser.parseHex(
-                        "DB6E273C0EECC178EB314E05CD3E3C43B06867A2127B99AFF2CFAFBAD005952AE752849D167C1C0DD7D4B45669038FA9C52F2E8B24C391A4EB98DE705EFD5F8D"));
-        representations.put(
-                "GROUP2",
-                parser.parseHex(
-                        "10B2661406630FAF67257CC04AED61D2CB4F0BA6709121FCEB3BF66FFD75E713A6FD2D39369D2B522E21255F26C363709417FED0E32809297776EFE912391A0A6CEC315983B781696C8CD23FD69ADCBB5DAC1F10F2F5F1BFF2592E34D30C8A22558DA61D9705AA8F65B69F8500403AE499B90A9A60399FE1CE99D5B98A9383AA"));
     }
     // Benchmark                                       (value)  Mode  Cnt   Score    Error  Units
     // GroupElementsBenchmark.compressedDeserialize     GROUP1  avgt    5   0.049 ±  0.001  ms/op
@@ -107,6 +110,21 @@ public class GroupElementsBenchmark {
     @Benchmark
     public GroupElement fromXAndY(CoordinatesState state) {
         return group.fromCoordinates(state.xs, state.ys);
+    }
+
+    @Benchmark
+    public GroupElement fromX(CoordinatesState state) {
+        return group.fromXCoordinate(state.xs, false);
+    }
+
+    @Benchmark
+    public GroupElement fromBytesNonValidated() {
+        return group.fromBytes(point2Array, ToBytesFlags.SKIP_VALIDATE);
+    }
+
+    @Benchmark
+    public GroupElement fromBytesCompress() {
+        return group.fromBytes(point2Array, ToBytesFlags.COMPRESS);
     }
 
     @Benchmark
@@ -150,26 +168,6 @@ public class GroupElementsBenchmark {
                         new BigInteger(
                                 "11631839690097995216017572651900167465857396346217730511548857041925508482915"));
             }
-        }
-    }
-
-    @State(Scope.Benchmark)
-    public static class CompressedState {
-        byte[] compressedBytes;
-
-        @Setup
-        public void setup() {
-            compressedBytes = representations.get("C" + value);
-        }
-    }
-
-    @State(Scope.Benchmark)
-    public static class UncompressState {
-        byte[] uncompressedBytes;
-
-        @Setup
-        public void setup() {
-            uncompressedBytes = representations.get(value);
         }
     }
 }

--- a/cryptography/hedera-cryptography-altbn128/src/jmh/java/com/hedera/cryptography/altbn128/GroupElementsBenchmark.java
+++ b/cryptography/hedera-cryptography-altbn128/src/jmh/java/com/hedera/cryptography/altbn128/GroupElementsBenchmark.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.cryptography.altbn128;
+
+import com.hedera.cryptography.pairings.api.FieldElement;
+import com.hedera.cryptography.pairings.api.GroupElement;
+import com.hedera.cryptography.utils.serialization.Deserializer;
+import com.hedera.cryptography.utils.serialization.Serializer;
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1, warmups = 1)
+public class GroupElementsBenchmark {
+    AltBn128Group group;
+    Random rng = new Random();
+    GroupElement point;
+    GroupElement point2;
+    Serializer<GroupElement> compressedSerializer;
+    Deserializer<GroupElement> compressedDeserializer;
+    Deserializer<GroupElement> deserializer;
+    Serializer<GroupElement> serializer;
+    FieldElement element;
+
+    @Param({"GROUP1", "GROUP2"})
+    static String value;
+
+    static Map<String, byte[]> representations = new HashMap<>();
+
+    @Setup(Level.Trial)
+    public void init() {
+        var field = new AltBn128Field();
+        group = new AltBn128Group(AltBN128CurveGroup.valueOf(value), field);
+        point = group.random(rng);
+        point2 = group.random(rng);
+        element = field.random(rng);
+        var parser = HexFormat.of().withUpperCase();
+        representations.put(
+                "CGROUP1", parser.parseHex("F1EE9FFEE1686777ED6873FB07900FE138F6A887D047D93F837B4D711221E283"));
+        representations.put(
+                "GROUP1",
+                parser.parseHex(
+                        "545BABA0D76CB1F5AB91D137997A6ACF4ECDDA2E3C1BF04784909DEDF1C4C5198DA77E6DC899EB46E6C9AB986EC71D19CE36493631E74FA89B81868BC96EEF01"));
+        representations.put(
+                "CGROUP2",
+                parser.parseHex(
+                        "DB6E273C0EECC178EB314E05CD3E3C43B06867A2127B99AFF2CFAFBAD005952AE752849D167C1C0DD7D4B45669038FA9C52F2E8B24C391A4EB98DE705EFD5F8D"));
+        representations.put(
+                "GROUP2",
+                parser.parseHex(
+                        "10B2661406630FAF67257CC04AED61D2CB4F0BA6709121FCEB3BF66FFD75E713A6FD2D39369D2B522E21255F26C363709417FED0E32809297776EFE912391A0A6CEC315983B781696C8CD23FD69ADCBB5DAC1F10F2F5F1BFF2592E34D30C8A22558DA61D9705AA8F65B69F8500403AE499B90A9A60399FE1CE99D5B98A9383AA"));
+    }
+    // Benchmark                                       (value)  Mode  Cnt   Score    Error  Units
+    // GroupElementsBenchmark.compressedDeserialize     GROUP1  avgt    5   0.049 ±  0.001  ms/op
+    // GroupElementsBenchmark.compressedDeserialize     GROUP2  avgt    5   0.136 ±  0.002  ms/op
+    // GroupElementsBenchmark.compressedSerialize       GROUP1  avgt    5  ≈ 10⁻³           ms/op
+    // GroupElementsBenchmark.compressedSerialize       GROUP2  avgt    5  ≈ 10⁻³           ms/op
+    // GroupElementsBenchmark.createRandom              GROUP1  avgt    5   0.012 ±  0.001  ms/op
+    // GroupElementsBenchmark.createRandom              GROUP2  avgt    5   0.190 ±  0.009  ms/op
+    // GroupElementsBenchmark.deserialize               GROUP1  avgt    5   0.043 ±  0.001  ms/op
+    // GroupElementsBenchmark.deserialize               GROUP2  avgt    5   0.119 ±  0.005  ms/op
+    // GroupElementsBenchmark.deserializeNotValidated   GROUP1  avgt    5  ≈ 10⁻³           ms/op
+    // GroupElementsBenchmark.deserializeNotValidated   GROUP2  avgt    5  ≈ 10⁻³           ms/op
+    // GroupElementsBenchmark.fromXAndY                 GROUP1  avgt    5   0.044 ±  0.002  ms/op
+    // GroupElementsBenchmark.fromXAndY                 GROUP2  avgt    5   0.117 ±  0.003  ms/op
+    // GroupElementsBenchmark.serialize                 GROUP1  avgt    5  ≈ 10⁻⁶           ms/op
+    // GroupElementsBenchmark.serialize                 GROUP2  avgt    5  ≈ 10⁻⁵           ms/op
+    // GroupElementsBenchmark.zero                      GROUP1  avgt    5  ≈ 10⁻⁴           ms/op
+    // GroupElementsBenchmark.zero                      GROUP2  avgt    5  ≈ 10⁻⁴           ms/op
+
+    @Benchmark
+    public GroupElement createRandom() {
+        return group.random(rng);
+    }
+
+    @Benchmark
+    public GroupElement fromXAndY(CoordinatesState state) {
+        return group.fromCoordinates(state.xs, state.ys);
+    }
+
+    @Benchmark
+    public GroupElement multiply() {
+        return point.multiply(element);
+    }
+
+    @Benchmark
+    public GroupElement multiplyLong() {
+        return point.multiply(Long.MAX_VALUE);
+    }
+
+    @Benchmark
+    public GroupElement copy() {
+        return point.copy();
+    }
+
+    @Benchmark
+    public GroupElement zero() {
+        return group.zero();
+    }
+
+
+    @State(Scope.Benchmark)
+    public static class CoordinatesState {
+        List<BigInteger> xs;
+        List<BigInteger> ys;
+
+        @Setup
+        public void setup() {
+            if ("GROUP1".equals(value)) {
+                xs = List.of(
+                        new BigInteger("4503322228978077916651710446042370109107355802721800704639343137502100212473"));
+                ys = List.of(
+                        new BigInteger("6132642251294427119375180147349983541569387941788025780665104001559216576968"));
+            } else {
+                xs = List.of(
+                        new BigInteger("20954117799226682825035885491234530437475518021362091509513177301640194298072"),
+                        new BigInteger("4540444681147253467785307942530223364530218361853237193970751657229138047649"));
+                ys = List.of(
+                        new BigInteger("21508930868448350162258892668132814424284302804699005394342512102884055673846"),
+                        new BigInteger(
+                                "11631839690097995216017572651900167465857396346217730511548857041925508482915"));
+            }
+        }
+    }
+
+    @State(Scope.Benchmark)
+    public static class CompressedState {
+        byte[] compressedBytes;
+
+        @Setup
+        public void setup() {
+            compressedBytes = representations.get("C" + value);
+        }
+    }
+
+    @State(Scope.Benchmark)
+    public static class UncompressState {
+        byte[] uncompressedBytes;
+
+        @Setup
+        public void setup() {
+            uncompressedBytes = representations.get(value);
+        }
+    }
+}

--- a/cryptography/hedera-cryptography-altbn128/src/jmh/java/com/hedera/cryptography/altbn128/GroupElementsBenchmark.java
+++ b/cryptography/hedera-cryptography-altbn128/src/jmh/java/com/hedera/cryptography/altbn128/GroupElementsBenchmark.java
@@ -84,23 +84,6 @@ public class GroupElementsBenchmark {
         point2Array = point2.toBytes();
         element = field.random(rng);
     }
-    // Benchmark                                       (value)  Mode  Cnt   Score    Error  Units
-    // GroupElementsBenchmark.compressedDeserialize     GROUP1  avgt    5   0.049 ±  0.001  ms/op
-    // GroupElementsBenchmark.compressedDeserialize     GROUP2  avgt    5   0.136 ±  0.002  ms/op
-    // GroupElementsBenchmark.compressedSerialize       GROUP1  avgt    5  ≈ 10⁻³           ms/op
-    // GroupElementsBenchmark.compressedSerialize       GROUP2  avgt    5  ≈ 10⁻³           ms/op
-    // GroupElementsBenchmark.createRandom              GROUP1  avgt    5   0.012 ±  0.001  ms/op
-    // GroupElementsBenchmark.createRandom              GROUP2  avgt    5   0.190 ±  0.009  ms/op
-    // GroupElementsBenchmark.deserialize               GROUP1  avgt    5   0.043 ±  0.001  ms/op
-    // GroupElementsBenchmark.deserialize               GROUP2  avgt    5   0.119 ±  0.005  ms/op
-    // GroupElementsBenchmark.deserializeNotValidated   GROUP1  avgt    5  ≈ 10⁻³           ms/op
-    // GroupElementsBenchmark.deserializeNotValidated   GROUP2  avgt    5  ≈ 10⁻³           ms/op
-    // GroupElementsBenchmark.fromXAndY                 GROUP1  avgt    5   0.044 ±  0.002  ms/op
-    // GroupElementsBenchmark.fromXAndY                 GROUP2  avgt    5   0.117 ±  0.003  ms/op
-    // GroupElementsBenchmark.serialize                 GROUP1  avgt    5  ≈ 10⁻⁶           ms/op
-    // GroupElementsBenchmark.serialize                 GROUP2  avgt    5  ≈ 10⁻⁵           ms/op
-    // GroupElementsBenchmark.zero                      GROUP1  avgt    5  ≈ 10⁻⁴           ms/op
-    // GroupElementsBenchmark.zero                      GROUP2  avgt    5  ≈ 10⁻⁴           ms/op
 
     @Benchmark
     public GroupElement createRandom() {

--- a/cryptography/hedera-cryptography-altbn128/src/jmh/java/com/hedera/cryptography/altbn128/GroupElementsBenchmark.java
+++ b/cryptography/hedera-cryptography-altbn128/src/jmh/java/com/hedera/cryptography/altbn128/GroupElementsBenchmark.java
@@ -16,7 +16,7 @@
 
 package com.hedera.cryptography.altbn128;
 
-import com.hedera.cryptography.altbn128.facade.GroupFacade.ToBytesModes;
+import com.hedera.cryptography.altbn128.facade.GroupFacade.FromBytesFlags;
 import com.hedera.cryptography.pairings.api.FieldElement;
 import com.hedera.cryptography.pairings.api.GroupElement;
 import com.hedera.cryptography.utils.serialization.Deserializer;
@@ -102,17 +102,17 @@ public class GroupElementsBenchmark {
 
     @Benchmark
     public GroupElement fromBytesNonValidated() {
-        return group.fromBytes(point2Array, new ToBytesModes(false, false, true));
+        return group.fromBytes(point2Array, new FromBytesFlags(false, false, true));
     }
 
     @Benchmark
     public GroupElement fromBytesCompress() {
-        return group.fromBytes(point2Array, new ToBytesModes(false, true, false));
+        return group.fromBytes(point2Array, new FromBytesFlags(false, true, false));
     }
 
     @Benchmark
     public GroupElement fromBytesUncompress(CoordinatesState state) {
-        return group.fromBytes(state.xsBytes, new ToBytesModes(true, false, false));
+        return group.fromBytes(state.xsBytes, new FromBytesFlags(true, false, false));
     }
 
     @Benchmark

--- a/cryptography/hedera-cryptography-altbn128/src/jmh/java/com/hedera/cryptography/altbn128/GroupElementsBenchmark.java
+++ b/cryptography/hedera-cryptography-altbn128/src/jmh/java/com/hedera/cryptography/altbn128/GroupElementsBenchmark.java
@@ -158,7 +158,7 @@ public class GroupElementsBenchmark {
                         new BigInteger(
                                 "11631839690097995216017572651900167465857396346217730511548857041925508482915"));
             }
-            xsBytes = ArkworksSerialization.coordinatesToBytes(xs);
+            xsBytes = ArkworksSerialization.coordinatesToBytes(xs, null);
         }
     }
 }

--- a/cryptography/hedera-cryptography-altbn128/src/jmh/java/com/hedera/cryptography/altbn128/GroupElementsBenchmark.java
+++ b/cryptography/hedera-cryptography-altbn128/src/jmh/java/com/hedera/cryptography/altbn128/GroupElementsBenchmark.java
@@ -16,7 +16,7 @@
 
 package com.hedera.cryptography.altbn128;
 
-import com.hedera.cryptography.altbn128.facade.GroupFacade.ToBytesFlags;
+import com.hedera.cryptography.altbn128.facade.GroupFacade.ToBytesModes;
 import com.hedera.cryptography.pairings.api.FieldElement;
 import com.hedera.cryptography.pairings.api.GroupElement;
 import com.hedera.cryptography.utils.serialization.Deserializer;
@@ -102,12 +102,17 @@ public class GroupElementsBenchmark {
 
     @Benchmark
     public GroupElement fromBytesNonValidated() {
-        return group.fromBytes(point2Array, ToBytesFlags.SKIP_VALIDATE);
+        return group.fromBytes(point2Array, new ToBytesModes(false, false, true));
     }
 
     @Benchmark
     public GroupElement fromBytesCompress() {
-        return group.fromBytes(point2Array, ToBytesFlags.COMPRESS);
+        return group.fromBytes(point2Array, new ToBytesModes(false, true, false));
+    }
+
+    @Benchmark
+    public GroupElement fromBytesUncompress(CoordinatesState state) {
+        return group.fromBytes(state.xsBytes, new ToBytesModes(true, false, false));
     }
 
     @Benchmark
@@ -133,6 +138,7 @@ public class GroupElementsBenchmark {
     @State(Scope.Benchmark)
     public static class CoordinatesState {
         List<BigInteger> xs;
+        byte[] xsBytes;
         List<BigInteger> ys;
 
         @Setup
@@ -142,6 +148,7 @@ public class GroupElementsBenchmark {
                         new BigInteger("4503322228978077916651710446042370109107355802721800704639343137502100212473"));
                 ys = List.of(
                         new BigInteger("6132642251294427119375180147349983541569387941788025780665104001559216576968"));
+
             } else {
                 xs = List.of(
                         new BigInteger("20954117799226682825035885491234530437475518021362091509513177301640194298072"),
@@ -151,6 +158,7 @@ public class GroupElementsBenchmark {
                         new BigInteger(
                                 "11631839690097995216017572651900167465857396346217730511548857041925508482915"));
             }
+            xsBytes = ArkworksSerialization.coordinatesToBytes(xs);
         }
     }
 }

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/AltBn128Group.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/AltBn128Group.java
@@ -18,7 +18,7 @@ package com.hedera.cryptography.altbn128;
 
 import com.hedera.cryptography.altbn128.adapter.jni.ArkBn254Adapter;
 import com.hedera.cryptography.altbn128.facade.GroupFacade;
-import com.hedera.cryptography.altbn128.facade.GroupFacade.ToBytesFlags;
+import com.hedera.cryptography.altbn128.facade.GroupFacade.ToBytesModes;
 import com.hedera.cryptography.pairings.api.Field;
 import com.hedera.cryptography.pairings.api.FieldElement;
 import com.hedera.cryptography.pairings.api.Group;
@@ -131,14 +131,15 @@ public class AltBn128Group implements Group {
      * Internal method to construct a {@link GroupElement} from a byte[] representation using different modes.
      *
      * @param bytes the intended representation
-     * @param flags the modes use: {@link ToBytesFlags#DEFAULT} for standard behaviour
+     * @param flags the modes use: {@link ToBytesModes#DEFAULT} for standard behaviour
      * @return the groupElement object.
      * @apiNote This is an internal method. No external user of the pairings library will be able to access this as it is not part of the api.
-     * @implNote some flags {@link ToBytesFlags#COMPRESS} would render the internal representation incompatible with arithmetics operations
+     * @implNote the use of flag: {@link ToBytesModes#compress()}  would render the internal representation incompatible with arithmetics operations
+     *  until we add support for internal group element compression
      */
     @Deprecated
-    public GroupElement fromBytes(@NonNull final byte[] bytes, @NonNull final ToBytesFlags... flags) {
-        return new AltBn128GroupElement(this, facade.fromBytes(bytes, Objects.requireNonNull(flags)));
+    public GroupElement fromBytes(@NonNull final byte[] bytes, @NonNull final ToBytesModes flags) {
+        return new AltBn128GroupElement(this, facade.fromBytes(bytes, flags));
     }
 
     /**
@@ -151,8 +152,8 @@ public class AltBn128Group implements Group {
                         Objects.requireNonNull(x, "x must not be null").stream(),
                         Objects.requireNonNull(y, "y must not be null").stream())
                 .toList();
-        final byte[] bytes = ArkworksSerialization.coordinatesToBytes(this.elementSize(), coordinates);
-        return new AltBn128GroupElement(this, facade.fromBytes(bytes, ToBytesFlags.DEFAULT));
+        final byte[] bytes = ArkworksSerialization.coordinatesToBytes(coordinates);
+        return new AltBn128GroupElement(this, facade.fromBytes(bytes, ToBytesModes.DEFAULT));
     }
 
     /**
@@ -161,11 +162,11 @@ public class AltBn128Group implements Group {
     @NonNull
     @Override
     public GroupElement fromXCoordinate(@NonNull final List<BigInteger> x, final boolean isYNegative) {
-        byte[] bytes = ArkworksSerialization.coordinatesToBytes(this.elementSize() / 2, x);
+        byte[] bytes = ArkworksSerialization.coordinatesToBytes(x);
         if (isYNegative) {
             ArkworksSerialization.setYNegativeFlag(bytes, true);
         }
-        return new AltBn128GroupElement(this, facade.fromBytes(bytes, ToBytesFlags.IS_COMPRESSED));
+        return new AltBn128GroupElement(this, facade.fromBytes(bytes, new ToBytesModes(true, false, false)));
     }
 
     /**

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/AltBn128Group.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/AltBn128Group.java
@@ -33,7 +33,6 @@ import java.security.Security;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Stream;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 /**
@@ -147,11 +146,9 @@ public class AltBn128Group implements Group {
     @NonNull
     @Override
     public GroupElement fromCoordinates(@NonNull final List<BigInteger> x, @NonNull final List<BigInteger> y) {
-        final var coordinates = Stream.concat(
-                        Objects.requireNonNull(x, "x must not be null").stream(),
-                        Objects.requireNonNull(y, "y must not be null").stream())
-                .toList();
-        final byte[] bytes = ArkworksSerialization.coordinatesToBytes(coordinates);
+        Objects.requireNonNull(x, "x must not be null");
+        Objects.requireNonNull(y, "y must not be null");
+        final byte[] bytes = ArkworksSerialization.coordinatesToBytes(x, y);
         return new AltBn128GroupElement(this, facade.fromBytes(bytes, ToBytesModes.DEFAULT));
     }
 
@@ -161,7 +158,7 @@ public class AltBn128Group implements Group {
     @NonNull
     @Override
     public GroupElement fromXCoordinate(@NonNull final List<BigInteger> x, final boolean isYNegative) {
-        byte[] bytes = ArkworksSerialization.coordinatesToBytes(x);
+        byte[] bytes = ArkworksSerialization.coordinatesToBytes(x, null);
         ArkworksSerialization.setYNegativeFlag(bytes, isYNegative);
         return new AltBn128GroupElement(this, facade.fromBytes(bytes, new ToBytesModes(true, false, false)));
     }

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/AltBn128Group.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/AltBn128Group.java
@@ -18,7 +18,7 @@ package com.hedera.cryptography.altbn128;
 
 import com.hedera.cryptography.altbn128.adapter.jni.ArkBn254Adapter;
 import com.hedera.cryptography.altbn128.facade.GroupFacade;
-import com.hedera.cryptography.altbn128.facade.GroupFacade.ToBytesModes;
+import com.hedera.cryptography.altbn128.facade.GroupFacade.FromBytesFlags;
 import com.hedera.cryptography.pairings.api.Field;
 import com.hedera.cryptography.pairings.api.FieldElement;
 import com.hedera.cryptography.pairings.api.Group;
@@ -130,13 +130,13 @@ public class AltBn128Group implements Group {
      * Internal method to construct a {@link GroupElement} from a byte[] representation using different modes.
      *
      * @param bytes the intended representation
-     * @param flags the modes use: {@link ToBytesModes#DEFAULT} for standard behaviour
+     * @param flags the modes use: {@link FromBytesFlags#DEFAULT} for standard behaviour
      * @return the groupElement object.
      * @apiNote This is an internal method. No external user of the pairings library will be able to access this as it is not part of the api.
-     * @implNote the use of flag: {@link ToBytesModes#compress()}  would render the internal representation incompatible with arithmetics operations
+     * @implNote the use of flag: {@link FromBytesFlags#compress()}  would render the internal representation incompatible with arithmetics operations
      *  until we add support for internal group element compression
      */
-    public GroupElement fromBytes(@NonNull final byte[] bytes, @NonNull final ToBytesModes flags) {
+    public GroupElement fromBytes(@NonNull final byte[] bytes, @NonNull final FromBytesFlags flags) {
         return new AltBn128GroupElement(this, facade.fromBytes(bytes, flags));
     }
 
@@ -149,7 +149,7 @@ public class AltBn128Group implements Group {
         Objects.requireNonNull(x, "x must not be null");
         Objects.requireNonNull(y, "y must not be null");
         final byte[] bytes = ArkworksSerialization.coordinatesToBytes(x, y);
-        return new AltBn128GroupElement(this, facade.fromBytes(bytes, ToBytesModes.DEFAULT));
+        return new AltBn128GroupElement(this, facade.fromBytes(bytes, FromBytesFlags.DEFAULT));
     }
 
     /**
@@ -160,7 +160,7 @@ public class AltBn128Group implements Group {
     public GroupElement fromXCoordinate(@NonNull final List<BigInteger> x, final boolean isYNegative) {
         byte[] bytes = ArkworksSerialization.coordinatesToBytes(x, null);
         ArkworksSerialization.setYNegativeFlag(bytes, isYNegative);
-        return new AltBn128GroupElement(this, facade.fromBytes(bytes, new ToBytesModes(true, false, false)));
+        return new AltBn128GroupElement(this, facade.fromBytes(bytes, new FromBytesFlags(true, false, false)));
     }
 
     /**

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/AltBn128Group.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/AltBn128Group.java
@@ -18,6 +18,7 @@ package com.hedera.cryptography.altbn128;
 
 import com.hedera.cryptography.altbn128.adapter.jni.ArkBn254Adapter;
 import com.hedera.cryptography.altbn128.facade.GroupFacade;
+import com.hedera.cryptography.altbn128.facade.GroupFacade.ToBytesFlags;
 import com.hedera.cryptography.pairings.api.Field;
 import com.hedera.cryptography.pairings.api.FieldElement;
 import com.hedera.cryptography.pairings.api.Group;
@@ -29,7 +30,6 @@ import com.hedera.cryptography.utils.ValidationUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
 import java.security.Security;
-import java.util.BitSet;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -138,7 +138,7 @@ public class AltBn128Group implements Group {
                         Objects.requireNonNull(y, "y must not be null").stream())
                 .toList();
         final byte[] bytes = ArkworksSerialization.coordinatesToBytes(this.elementSize(), coordinates);
-        return new AltBn128GroupElement(this, facade.fromBytes(bytes));
+        return new AltBn128GroupElement(this, facade.fromBytes(bytes, ToBytesFlags.DEFAULT));
     }
 
     /**
@@ -148,14 +148,10 @@ public class AltBn128Group implements Group {
     @Override
     public GroupElement fromXCoordinate(@NonNull final List<BigInteger> x, final boolean isYNegative) {
         byte[] bytes = ArkworksSerialization.coordinatesToBytes(this.elementSize() / 2, x);
-        final var bs = BitSet.valueOf(bytes);
         if (isYNegative) {
-            bs.set(8 * bytes.length - 1, true);
-            bytes = bs.toByteArray();
-        } else if (bs.isEmpty()) {
-            return zero();
+            ArkworksSerialization.setYNegativeFlag(bytes, true);
         }
-        return new AltBn128GroupElement(this, facade.fromBytes(bytes, true, true, false));
+        return new AltBn128GroupElement(this, facade.fromBytes(bytes, ToBytesFlags.IS_COMPRESSED));
     }
 
     /**

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/AltBn128Group.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/AltBn128Group.java
@@ -128,6 +128,20 @@ public class AltBn128Group implements Group {
     }
 
     /**
+     * Internal method to construct a {@link GroupElement} from a byte[] representation using different modes.
+     *
+     * @param bytes the intended representation
+     * @param flags the modes use: {@link ToBytesFlags#DEFAULT} for standard behaviour
+     * @return the groupElement object.
+     * @apiNote This is an internal method. No external user of the pairings library will be able to access this as it is not part of the api.
+     * @implNote some flags {@link ToBytesFlags#COMPRESS} would render the internal representation incompatible with arithmetics operations
+     */
+    @Deprecated
+    public GroupElement fromBytes(@NonNull final byte[] bytes, @NonNull final ToBytesFlags... flags) {
+        return new AltBn128GroupElement(this, facade.fromBytes(bytes, Objects.requireNonNull(flags)));
+    }
+
+    /**
      * {@inheritDoc}
      */
     @NonNull

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/AltBn128Group.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/AltBn128Group.java
@@ -29,6 +29,7 @@ import com.hedera.cryptography.utils.ValidationUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
 import java.security.Security;
+import java.util.BitSet;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -111,6 +112,48 @@ public class AltBn128Group implements Group {
     }
 
     /**
+     * Creates a group element from its serialized encoding, validating if the point is in the curve.
+     *
+     * @throws NullPointerException if the bytes is null
+     * @throws IllegalArgumentException if the bytes is of invalid size or the point does not belong to the curve
+     * @throws AltBn128Exception in case of error.
+     * @deprecated Implementation specific
+     */
+    @NonNull
+    @Override
+    @Deprecated
+    public GroupElement fromBytes(@NonNull final byte[] bytes) {
+        return new AltBn128GroupElement(this, facade.fromBytes(bytes));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public GroupElement fromCoordinates(@NonNull final List<BigInteger> x, @NonNull final List<BigInteger> y) {
+        final byte[] bytes = ArkworksSerialization.coordinatesToBytes(x, y);
+        return new AltBn128GroupElement(this, facade.fromBytes(bytes));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public GroupElement fromXCoordinate(@NonNull final List<BigInteger> x, final boolean isYNegative) {
+        byte[] bytes = ArkworksSerialization.coordinatesToBytes(x);
+        final var bs = BitSet.valueOf(bytes);
+        if (isYNegative) {
+            bs.set(0, true);
+            bytes = bs.toByteArray();
+        } else if (bs.isEmpty()) {
+            return zero();
+        }
+        return new AltBn128GroupElement(this, facade.fromBytes(bytes, true, true, false));
+    }
+
+    /**
      * {@inheritDoc}
      */
     @NonNull
@@ -123,7 +166,7 @@ public class AltBn128Group implements Group {
         for (int i = 0; i < HASH_RETRIES; i++) {
             calculator.append(candidate);
             candidate = calculator.hash();
-            final byte[] element = facade.fromXCoordinate(candidate);
+            final byte[] element = facade.hashToGroup(candidate);
             if (element != null) {
                 return new AltBn128GroupElement(this, element);
             }
@@ -204,29 +247,6 @@ public class AltBn128Group implements Group {
     @Override
     public int hashCode() {
         return Objects.hashCode(group);
-    }
-
-    /**
-     * Creates a group element from its serialized encoding, validating if the point is in the curve.
-     *
-     * @throws NullPointerException if the bytes is null
-     * @throws IllegalArgumentException if the bytes is of invalid size or the point does not belong to the curve
-     * @throws AltBn128Exception in case of error.
-     */
-    @NonNull
-    @Override
-    public GroupElement fromBytes(@NonNull final byte[] bytes) {
-        return new AltBn128GroupElement(this, facade.fromBytes(bytes));
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @NonNull
-    @Override
-    public GroupElement fromCoordinates(@NonNull final List<BigInteger> x, @NonNull final List<BigInteger> y) {
-        final byte[] bytes = ArkworksSerialization.coordinatesToBytes(x, y);
-        return fromBytes(bytes);
     }
 
     /**

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/AltBn128Group.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/AltBn128Group.java
@@ -137,7 +137,6 @@ public class AltBn128Group implements Group {
      * @implNote the use of flag: {@link ToBytesModes#compress()}  would render the internal representation incompatible with arithmetics operations
      *  until we add support for internal group element compression
      */
-    @Deprecated
     public GroupElement fromBytes(@NonNull final byte[] bytes, @NonNull final ToBytesModes flags) {
         return new AltBn128GroupElement(this, facade.fromBytes(bytes, flags));
     }
@@ -163,9 +162,7 @@ public class AltBn128Group implements Group {
     @Override
     public GroupElement fromXCoordinate(@NonNull final List<BigInteger> x, final boolean isYNegative) {
         byte[] bytes = ArkworksSerialization.coordinatesToBytes(x);
-        if (isYNegative) {
-            ArkworksSerialization.setYNegativeFlag(bytes, true);
-        }
+        ArkworksSerialization.setYNegativeFlag(bytes, isYNegative);
         return new AltBn128GroupElement(this, facade.fromBytes(bytes, new ToBytesModes(true, false, false)));
     }
 

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/AltBn128Group.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/AltBn128Group.java
@@ -33,6 +33,7 @@ import java.util.BitSet;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Stream;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 /**
@@ -132,7 +133,11 @@ public class AltBn128Group implements Group {
     @NonNull
     @Override
     public GroupElement fromCoordinates(@NonNull final List<BigInteger> x, @NonNull final List<BigInteger> y) {
-        final byte[] bytes = ArkworksSerialization.coordinatesToBytes(x, y);
+        final var coordinates = Stream.concat(
+                        Objects.requireNonNull(x, "x must not be null").stream(),
+                        Objects.requireNonNull(y, "y must not be null").stream())
+                .toList();
+        final byte[] bytes = ArkworksSerialization.coordinatesToBytes(this.elementSize(), coordinates);
         return new AltBn128GroupElement(this, facade.fromBytes(bytes));
     }
 
@@ -142,10 +147,10 @@ public class AltBn128Group implements Group {
     @NonNull
     @Override
     public GroupElement fromXCoordinate(@NonNull final List<BigInteger> x, final boolean isYNegative) {
-        byte[] bytes = ArkworksSerialization.coordinatesToBytes(x);
+        byte[] bytes = ArkworksSerialization.coordinatesToBytes(this.elementSize() / 2, x);
         final var bs = BitSet.valueOf(bytes);
         if (isYNegative) {
-            bs.set(0, true);
+            bs.set(8 * bytes.length - 1, true);
             bytes = bs.toByteArray();
         } else if (bs.isEmpty()) {
             return zero();

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/ArkworksSerialization.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/ArkworksSerialization.java
@@ -248,8 +248,7 @@ public enum ArkworksSerialization {
     public static byte[] coordinatesToBytes(@NonNull final List<BigInteger> xs, @Nullable List<BigInteger> ys) {
         Objects.requireNonNull(xs, "xs must not be null");
         final int coordinateSize = xs.size();
-        final int numElements =
-                coordinateSize + Optional.ofNullable(ys).map(List::size).orElse(0);
+        final int numElements = coordinateSize + (ys != null ? ys.size() : 0);
         final byte[] bytes = new byte[NUMBER_SIZE_BYTES * numElements];
         for (int i = 0; i < numElements; i++) {
             final BigInteger bi = i < coordinateSize ? xs.get(i) : ys.get(i - coordinateSize);

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/ArkworksSerialization.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/ArkworksSerialization.java
@@ -240,15 +240,19 @@ public enum ArkworksSerialization {
     /**
      * Creates a byte array from a list of BigInteger values
      *
-     * @param coordinates all the coordinates elements
+     * @param xs all the xs elements
+     * @param ys some other group of optional ys
      * @return the serialized bytes in arkworks format
      */
     @NonNull
-    public static byte[] coordinatesToBytes(@NonNull final List<BigInteger> coordinates) {
-        Objects.requireNonNull(coordinates, "coordinates must not be null");
-        final byte[] bytes = new byte[NUMBER_SIZE_BYTES * coordinates.size()];
-        for (int i = 0; i < coordinates.size(); i++) {
-            final BigInteger bi = coordinates.get(i);
+    public static byte[] coordinatesToBytes(@NonNull final List<BigInteger> xs, @Nullable List<BigInteger> ys) {
+        Objects.requireNonNull(xs, "xs must not be null");
+        final int coordinateSize = xs.size();
+        final int numElements =
+                coordinateSize + Optional.ofNullable(ys).map(List::size).orElse(0);
+        final byte[] bytes = new byte[NUMBER_SIZE_BYTES * numElements];
+        for (int i = 0; i < numElements; i++) {
+            final BigInteger bi = i < coordinateSize ? xs.get(i) : ys.get(i - coordinateSize);
             final byte[] biArray = bi.toByteArray();
             if (biArray.length > NUMBER_SIZE_BYTES) {
                 throw new IllegalArgumentException("BigInteger is too large to fit in a 254-bit number");

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/ArkworksSerialization.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/ArkworksSerialization.java
@@ -222,39 +222,21 @@ public enum ArkworksSerialization {
     }
 
     /**
-     * Serialize the coordinates into a byte array
+     * Creates a byte array from a list of BigInteger values
      *
-     * @param x the X coordinate
-     * @param y the Y coordinate
+     * @param size the final size of the produced byte array
+     * @param coordinates all the coordinates elements
      * @return the serialized bytes in arkworks format
      */
     @NonNull
-    public static byte[] coordinatesToBytes(@NonNull final List<BigInteger> x, @NonNull final List<BigInteger> y) {
-        final int numCount = Objects.requireNonNull(x, "x must not be null").size()
-                + Objects.requireNonNull(y, "y must not be null").size();
-        final byte[] bytes = new byte[NUMBER_SIZE_BYTES * numCount];
-        for (int i = 0; i < numCount; i++) {
-            final BigInteger bi = i < x.size() ? x.get(i) : y.get(i - x.size());
-            final byte[] biArray = bi.toByteArray();
-            if (biArray.length > NUMBER_SIZE_BYTES) {
-                throw new IllegalArgumentException("BigInteger is too large to fit in a 254-bit number");
-            }
-            copyAndReverse(biArray, 0, bytes, i * NUMBER_SIZE_BYTES, biArray.length);
+    public static byte[] coordinatesToBytes(final int size, @NonNull final List<BigInteger> coordinates) {
+        final int numCount = size / NUMBER_SIZE_BYTES;
+        if (Objects.requireNonNull(coordinates, "coordinates must not be null").size() != numCount) {
+            throw new IllegalArgumentException("Invalid number of coordinates");
         }
-
-        return bytes;
-    }
-
-    /**
-     * Creates a byte array from a list of BigInteger values
-     * @param x the X coordinate
-     * @return the serialized bytes in arkworks format
-     */
-    public static byte[] coordinatesToBytes(@NonNull final List<BigInteger> x) {
-        final int numCount = Objects.requireNonNull(x, "x must not be null").size() / NUMBER_SIZE_BYTES;
-        final byte[] bytes = new byte[NUMBER_SIZE_BYTES * numCount];
+        final byte[] bytes = new byte[size];
         for (int i = 0; i < numCount; i++) {
-            final BigInteger bi = x.get(i);
+            final BigInteger bi = coordinates.get(i);
             final byte[] biArray = bi.toByteArray();
             if (biArray.length > NUMBER_SIZE_BYTES) {
                 throw new IllegalArgumentException("BigInteger is too large to fit in a 254-bit number");

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/ArkworksSerialization.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/ArkworksSerialization.java
@@ -191,6 +191,22 @@ public enum ArkworksSerialization {
     }
 
     /**
+     * Sets or clears the Y coordinate negative flag in the Arkworks serialized bytes.
+     *
+     * @param bytes the Arkworks serialized bytes
+     * @param set   true to set the flag, false to clear it
+     */
+    public static void setYNegativeFlag(@NonNull final byte[] bytes, boolean set) {
+        if (set) {
+            // Set the flag using bitwise OR
+            bytes[bytes.length - 1] |= MASK_Y_COORDINATE;
+        } else {
+            // Clear the flag using bitwise AND with the negated mask
+            bytes[bytes.length - 1] &= ~MASK_Y_COORDINATE;
+        }
+    }
+
+    /**
      * Removes the flags from this serialized element
      *
      * @param bytes the Arkworks serialized bytes

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/ArkworksSerialization.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/ArkworksSerialization.java
@@ -226,7 +226,7 @@ public enum ArkworksSerialization {
      *
      * @param x the X coordinate
      * @param y the Y coordinate
-     * @return the serialized bytes
+     * @return the serialized bytes in arkworks format
      */
     @NonNull
     public static byte[] coordinatesToBytes(@NonNull final List<BigInteger> x, @NonNull final List<BigInteger> y) {
@@ -242,6 +242,25 @@ public enum ArkworksSerialization {
             copyAndReverse(biArray, 0, bytes, i * NUMBER_SIZE_BYTES, biArray.length);
         }
 
+        return bytes;
+    }
+
+    /**
+     * Creates a byte array from a list of BigInteger values
+     * @param x the X coordinate
+     * @return the serialized bytes in arkworks format
+     */
+    public static byte[] coordinatesToBytes(@NonNull final List<BigInteger> x) {
+        final int numCount = Objects.requireNonNull(x, "x must not be null").size() / NUMBER_SIZE_BYTES;
+        final byte[] bytes = new byte[NUMBER_SIZE_BYTES * numCount];
+        for (int i = 0; i < numCount; i++) {
+            final BigInteger bi = x.get(i);
+            final byte[] biArray = bi.toByteArray();
+            if (biArray.length > NUMBER_SIZE_BYTES) {
+                throw new IllegalArgumentException("BigInteger is too large to fit in a 254-bit number");
+            }
+            copyAndReverse(biArray, 0, bytes, i * NUMBER_SIZE_BYTES, biArray.length);
+        }
         return bytes;
     }
 }

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/ArkworksSerialization.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/ArkworksSerialization.java
@@ -240,18 +240,14 @@ public enum ArkworksSerialization {
     /**
      * Creates a byte array from a list of BigInteger values
      *
-     * @param size the final size of the produced byte array
      * @param coordinates all the coordinates elements
      * @return the serialized bytes in arkworks format
      */
     @NonNull
-    public static byte[] coordinatesToBytes(final int size, @NonNull final List<BigInteger> coordinates) {
-        final int numCount = size / NUMBER_SIZE_BYTES;
-        if (Objects.requireNonNull(coordinates, "coordinates must not be null").size() != numCount) {
-            throw new IllegalArgumentException("Invalid number of coordinates");
-        }
-        final byte[] bytes = new byte[size];
-        for (int i = 0; i < numCount; i++) {
+    public static byte[] coordinatesToBytes(@NonNull final List<BigInteger> coordinates) {
+        Objects.requireNonNull(coordinates, "coordinates must not be null");
+        final byte[] bytes = new byte[NUMBER_SIZE_BYTES * coordinates.size()];
+        for (int i = 0; i < coordinates.size(); i++) {
             final BigInteger bi = coordinates.get(i);
             final byte[] biArray = bi.toByteArray();
             if (biArray.length > NUMBER_SIZE_BYTES) {

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/adapter/GroupElementsLibraryAdapter.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/adapter/GroupElementsLibraryAdapter.java
@@ -43,17 +43,17 @@ public interface GroupElementsLibraryAdapter extends RandomElementsAdapter {
     int groupElementsFromSeed(final int group, final byte[] input, final byte[] output);
 
     /**
-     * Attempts to obtain a GroupElement byte internal representation from a given x coordinate
+     * Attempts to obtain a GroupElement byte internal representation from a given hashed value
      *
      * @param group  on which of the groups of the curve to perform the operation
      * @param input  a 256-bit byte array of that represents an x coordinate
      * @param output a {@link GroupElementsLibraryAdapter#groupElementsSize(int)} array to hold the internal
-     *               representation of the point, if the given x coordinate is not in the curve, the output will be
+     *               representation of the point, if the given hash can not be represented as a point in the curve, the output will be
      *               unchanged
      * @return {@link GroupElementsLibraryAdapter#SUCCESS} for success, {@link GroupElementsLibraryAdapter#NOT_IN_CURVE}
      * if the point is not in the curve, or a less than zero error code if there was an error
      */
-    int groupElementsFromXCoordinate(final int group, final byte[] input, final byte[] output);
+    int groupElementsHashToGroup(final int group, final byte[] input, final byte[] output);
 
     /**
      * Returns the GroupElement byte internal representation of the point at infinity
@@ -123,14 +123,23 @@ public interface GroupElementsLibraryAdapter extends RandomElementsAdapter {
     int groupElementsLongMul(final int group, final byte[] point, final long scalar, final byte[] output);
 
     /**
-     * Validates if a byte array of {@link GroupElementsLibraryAdapter#groupElementsSize(int)} is a valid representation of a point in the curve
-     *
-     * @param group on which of the groups of the curve to perform the operation
-     * @param point a byte array of {@link GroupElementsLibraryAdapter#groupElementsSize(int)} that will be used as the seed to create the
-     *              point
-     * @return {@link GroupElementsLibraryAdapter#SUCCESS} for success, {@link GroupElementsLibraryAdapter#NOT_IN_CURVE} if the point is invalid or a less than zero error code if there was an error
+     * @param group    on which of the groups of the curve to perform the operation
+     * @param isCompressed
+     * @param validate
+     * @param compress
+     * @param input    a byte array of {@link GroupElementsLibraryAdapter#groupElementsSize(int)} that will be used as
+     *                 the seed to create the point
+     * @param output
+     * @return {@link GroupElementsLibraryAdapter#SUCCESS} for success, {@link GroupElementsLibraryAdapter#NOT_IN_CURVE}
+     * if the point is invalid or a less than zero error code if there was an error
      */
-    int groupElementsBytes(final int group, final byte[] point);
+    int groupElementsBytes(
+            final int group,
+            final boolean isCompressed,
+            final boolean validate,
+            final boolean compress,
+            final byte[] input,
+            final byte[] output);
 
     /**
      * Returns the result of the multiplication of each point in the  {@code points} list with each scalar in the {@code scalars} list.

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/adapter/GroupElementsLibraryAdapter.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/adapter/GroupElementsLibraryAdapter.java
@@ -36,8 +36,8 @@ public interface GroupElementsLibraryAdapter extends RandomElementsAdapter {
     /**
      * Creates a GroupElement byte internal representation from a seed byte array
      * @param group on which of the groups of the curve to perform the operation
-     * @param input a byte array of {@link GroupElementsLibraryAdapter#groupElementsSize(int)} that contains the internal represents the point
-     * @param output a {@link GroupElementsLibraryAdapter#groupElementsSize(int)} array to hold the internal representation of the point
+     * @param input a byte array that will be used as seed to get the random point
+     * @param output a byte array representation of the point resulting of this operation
      * @return {@link GroupElementsLibraryAdapter#SUCCESS} for success, or a less than zero error code if there was an error
      */
     int groupElementsFromSeed(final int group, final byte[] input, final byte[] output);
@@ -46,10 +46,8 @@ public interface GroupElementsLibraryAdapter extends RandomElementsAdapter {
      * Attempts to obtain a GroupElement byte internal representation from a given hashed value
      *
      * @param group  on which of the groups of the curve to perform the operation
-     * @param input  a 256-bit byte array of that represents an x coordinate
-     * @param output a {@link GroupElementsLibraryAdapter#groupElementsSize(int)} array to hold the internal
-     *               representation of the point, if the given hash can not be represented as a point in the curve, the output will be
-     *               unchanged
+     * @param input  a byte array of that represents an x coordinate
+     * @param output a byte array representation of the point resulting of this operation
      * @return {@link GroupElementsLibraryAdapter#SUCCESS} for success, {@link GroupElementsLibraryAdapter#NOT_IN_CURVE}
      * if the point is not in the curve, or a less than zero error code if there was an error
      */
@@ -58,7 +56,7 @@ public interface GroupElementsLibraryAdapter extends RandomElementsAdapter {
     /**
      * Returns the GroupElement byte internal representation of the point at infinity
      * @param group on which of the groups of the curve to perform the operation
-     * @param output a {@link GroupElementsLibraryAdapter#groupElementsSize(int)} array to hold the internal representation of the point
+     * @param output a byte array representation of the point resulting of this operation
      * @return {@link GroupElementsLibraryAdapter#SUCCESS} for success, or a less than zero error code if there was an error
      */
     int groupElementsZero(final int group, final byte[] output);
@@ -66,7 +64,7 @@ public interface GroupElementsLibraryAdapter extends RandomElementsAdapter {
     /**
      * Returns the GroupElement byte internal representation of the generator point of the group
      * @param group on which of the groups of the curve to perform the operation
-     * @param output a {@link GroupElementsLibraryAdapter#groupElementsSize(int)} array to hold the internal representation of the point
+     * @param output a byte array representation of the point resulting of this operation
      * @return {@link GroupElementsLibraryAdapter#SUCCESS} for success, or a less than zero error code if there was an error
      */
     int groupElementsGenerator(final int group, final byte[] output);
@@ -75,8 +73,8 @@ public interface GroupElementsLibraryAdapter extends RandomElementsAdapter {
      * returns if two representations are the same
      *
      * @param group on which of the groups of the curve to perform the operation
-     * @param value a byte array of {@link GroupElementsLibraryAdapter#groupElementsSize(int)} that contains the internal represents the point
-     * @param other a byte array of {@link GroupElementsLibraryAdapter#groupElementsSize(int)}  that contains the internal represents the point
+     * @param value a byte array representation of the point argument
+     * @param other a byte array representation of the point argument
      * @return 0 if false, 1 if true, or a less than zero error code if there was an error
      */
     int groupElementsEquals(final int group, final byte[] value, final byte[] other);
@@ -93,10 +91,10 @@ public interface GroupElementsLibraryAdapter extends RandomElementsAdapter {
      * Returns the addition of code {@code value} and  {@code other}.
      *
      * @param group on which of the groups of the curve to perform the operation
-     * @param value a byte array of {@link GroupElementsLibraryAdapter#groupElementsSize(int)} that contains the internal represents the point
-     * @param other a byte array of {@link GroupElementsLibraryAdapter#groupElementsSize(int)} that contains the internal represents the point
-     * @param output a {@link GroupElementsLibraryAdapter#groupElementsSize(int)} array to hold the internal representation of the point
-     * @return 0 if false, 1 if true, or a less than zero error code if there was an error
+     * @param value a byte array representation of the point argument
+     * @param other a byte array representation of the point argument
+     * @param output a byte array representation of the point resulting of this operation
+     * @return {@link GroupElementsLibraryAdapter#SUCCESS} for success, or a less than zero error code if there was an error
      */
     int groupElementsAdd(final int group, final byte[] value, final byte[] other, final byte[] output);
 
@@ -104,9 +102,9 @@ public interface GroupElementsLibraryAdapter extends RandomElementsAdapter {
      * Returns the scalar multiplication between code {@code point} and {@code scalar}.
      *
      * @param group on which of the groups of the curve to perform the operation
-     * @param point a byte array of {@link GroupElementsLibraryAdapter#groupElementsSize(int)} that will be used as the seed to create the point
-     * @param scalar a byte array of {@link FieldElementsLibraryAdapter#fieldElementsSize()}} that contains the representation of the scalar
-     * @param output a {@link GroupElementsLibraryAdapter#groupElementsSize(int)} array to hold the internal representation of the point
+     * @param point a byte array representation of the point argument
+     * @param scalar the byte array representation of the scalar
+     * @param output a byte array representation of the point resulting of this operation
      * @return {@link GroupElementsLibraryAdapter#SUCCESS} for success, or a less than zero error code if there was an error
      */
     int groupElementsScalarMul(final int group, final byte[] point, final byte[] scalar, final byte[] output);
@@ -115,21 +113,22 @@ public interface GroupElementsLibraryAdapter extends RandomElementsAdapter {
      * Returns the scalar multiplication between code {@code point} and {@code scalar}.
      *
      * @param group on which of the groups of the curve to perform the operation
-     * @param point a byte array of {@link GroupElementsLibraryAdapter#groupElementsSize(int)} that will be used as the seed to create the point
+     * @param point a byte array that holds the internal representation of the point argument
      * @param scalar a long representation of the scalar
-     * @param output a {@link GroupElementsLibraryAdapter#groupElementsSize(int)} array to hold the internal representation of the point
+     * @param output a byte array representation of the point resulting of this operation
      * @return {@link GroupElementsLibraryAdapter#SUCCESS} for success, or a less than zero error code if there was an error
      */
     int groupElementsLongMul(final int group, final byte[] point, final long scalar, final byte[] output);
 
     /**
-     * @param group    on which of the groups of the curve to perform the operation
-     * @param isCompressed
-     * @param validate
-     * @param compress
-     * @param input    a byte array of {@link GroupElementsLibraryAdapter#groupElementsSize(int)} that will be used as
-     *                 the seed to create the point
-     * @param output
+     * Returns the internal representation of a point under different modes.
+     *
+     * @param group on which of the groups of the curve to perform the operation
+     * @param isCompressed if the input byte array is in compressed format
+     * @param validate if the point should be validated when created
+     * @param compress if the output byte array should be in compressed format
+     * @param input a byte array of that holds the coordinates of the point
+     * @param output a byte array representation of the point resulting of this operation
      * @return {@link GroupElementsLibraryAdapter#SUCCESS} for success, {@link GroupElementsLibraryAdapter#NOT_IN_CURVE}
      * if the point is invalid or a less than zero error code if there was an error
      */
@@ -145,37 +144,32 @@ public interface GroupElementsLibraryAdapter extends RandomElementsAdapter {
      * Returns the result of the multiplication of each point in the  {@code points} list with each scalar in the {@code scalars} list.
      *
      * @param group   on which of the groups of the curve to perform the operation
-     * @param scalars a byte matrix representing a list of N byte arrays of
-     *                  {@link FieldElementsLibraryAdapter#fieldElementsSize()} size each representing a scalar
-     * @param points a byte matrix representing a list of N byte arrays of
-     *                {@link GroupElementsLibraryAdapter#groupElementsSize(int)} size each representing a point
-     * @param outputs a byte matrix of N byte arrays {@link GroupElementsLibraryAdapter#groupElementsSize(int)}size to
-     *                hold the internal representation of the generator point times the scalar in {@code scalars}
+     * @param scalars a byte matrix representing a list of N byte arrays each representing a scalar
+     * @param points a byte matrix representing a list of N byte arrays each representing a point
+     * @param output a byte array representation of the point resulting of this operation
      * @return {@link GroupElementsLibraryAdapter#SUCCESS} for success, or a less than zero error code if there was an
      * error
      */
-    int groupElementsMsm(final int group, final byte[][] scalars, final byte[][] points, final byte[] outputs);
+    int groupElementsMsm(final int group, final byte[][] scalars, final byte[][] points, final byte[] output);
 
     /**
      * Returns the result of the multiplication of each point in the  {@code points} list with each scalar in the {@code scalars} list.
      *
      * @param group   on which of the groups of the curve to perform the operation
      * @param scalars an int array representing a list of N scalars
-     * @param points a byte matrix representing a list of N byte arrays of
-     *                {@link GroupElementsLibraryAdapter#groupElementsSize(int)} size each representing a point
-     * @param outputs a byte matrix of N byte arrays {@link GroupElementsLibraryAdapter#groupElementsSize(int)}size to
-     *                hold the internal representation of the generator point times the scalar in {@code scalars}
+     * @param points a byte matrix representing a list of N point
+     * @param output a byte array representation of the point resulting of this operation
      * @return {@link GroupElementsLibraryAdapter#SUCCESS} for success, or a less than zero error code if there was an
      * error
      */
-    int groupElementsMsm(final int group, final long[] scalars, final byte[][] points, final byte[] outputs);
+    int groupElementsMsm(final int group, final long[] scalars, final byte[][] points, final byte[] output);
 
     /**
      * Returns the point that is the result of the total sum a collection of points
      *
      * @param group on which of the groups of the curve to perform the operation
-     * @param input a byte matrix representing a list of N byte arrays of {@link GroupElementsLibraryAdapter#groupElementsSize(int)} representing each point
-     * @param output a {@link GroupElementsLibraryAdapter#groupElementsSize(int)} array to hold the internal representation of the point
+     * @param input a byte matrix representing a list of N byte arrays representing each point
+     * @param output an array to hold the internal representation of the point
      * @return {@link GroupElementsLibraryAdapter#SUCCESS} for success, or a less than zero error code if there was an error
      */
     int groupElementsBatchAdd(final int group, final byte[][] input, final byte[] output);

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/adapter/jni/ArkBn254Adapter.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/adapter/jni/ArkBn254Adapter.java
@@ -205,7 +205,7 @@ public final class ArkBn254Adapter
      * @return {@link GroupElementsLibraryAdapter#SUCCESS} for success, {@link GroupElementsLibraryAdapter#NOT_IN_CURVE}
      * if the point is not in the curve, or a less than zero error code if there was an error
      */
-    public native int groupElementsFromXCoordinate(final int group, final byte[] input, final byte[] output);
+    public native int groupElementsHashToGroup(final int group, final byte[] input, final byte[] output);
 
     /**
      * Returns the point at infinity
@@ -267,12 +267,22 @@ public final class ArkBn254Adapter
     /**
      * Validates if a byte array is a valid representation of a point in the curve
      *
-     * @param group on which of the groups of the curve to perform the operation
-     * @param point a byte array that will be used as the seed to create the
-     *              point
-     * @return {@link GroupElementsLibraryAdapter#SUCCESS} for success, {@link GroupElementsLibraryAdapter#NOT_IN_CURVE} if the point is invalid or a less than zero error code if there was an error
+     * @param group    on which of the groups of the curve to perform the operation
+     * @param isCompressed if the representation is compressed format
+     * @param validate if the point needs to be validated
+     * @param compress if the compression needs to be returned in compressed format
+     * @param input  a byte array that represents the point
+     * @param output the byte array that will be filled with the result of the operation
+     * @return {@link GroupElementsLibraryAdapter#SUCCESS} for success, {@link GroupElementsLibraryAdapter#NOT_IN_CURVE}
+     * if the point is invalid or a less than zero error code if there was an error
      */
-    public native int groupElementsBytes(final int group, final byte[] point);
+    public native int groupElementsBytes(
+            final int group,
+            final boolean isCompressed,
+            final boolean validate,
+            final boolean compress,
+            final byte[] input,
+            final byte[] output);
 
     /**
      * Returns the scalar multiplication between code {@code point} and {@code scalar}.

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/facade/GroupFacade.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/facade/GroupFacade.java
@@ -219,10 +219,12 @@ public final class GroupFacade implements ElementFacade {
     @NonNull
     public byte[] fromBytes(
             @NonNull final byte[] bytes, final boolean isCompressed, final boolean validate, final boolean compress) {
+        final int expectedSize = isCompressed ? this.size / 2 : this.size;
+        validateSize(
+                Objects.requireNonNull(bytes, "bytes must not be null"), expectedSize, "Invalid representation size");
 
-        validateSize(Objects.requireNonNull(bytes, "bytes must not be null"), this.size, "Invalid representation size");
-
-        final byte[] representation = new byte[bytes.length];
+        final int returnSize = compress ? this.size / 2 : this.size;
+        final byte[] representation = new byte[returnSize];
         final int result = adapter.groupElementsBytes(group, isCompressed, validate, compress, bytes, representation);
         if (result == GroupElementsLibraryAdapter.NOT_IN_CURVE) {
             throw new IllegalArgumentException("The point is not in curve");

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/facade/GroupFacade.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/facade/GroupFacade.java
@@ -72,24 +72,25 @@ public final class GroupFacade implements ElementFacade {
         final byte[] output = new byte[size];
         final int result = adapter.groupElementsFromSeed(group, seed, output);
         if (result != GroupElementsLibraryAdapter.SUCCESS) {
-            throw new AltBn128Exception(result, "groupElementsFromSeed in" + this.group);
+            throw new AltBn128Exception(result, "groupElementsFromSeed in " + this.group);
         }
         return output;
     }
 
     /**
      * Attempts to create a point from an x coordinate
-     * @param xCoordinate the x coordinate array
-     * @return the byte array representation of the point or null if the point is not in the curve.
+     * @param hash the hashed value to convert to a group element representation
+     * @return the byte array representation of the point or null if the hash cannot be represented as a point in the curve.
      * @throws AltBn128Exception in case of error
      */
-    public @Nullable byte[] fromXCoordinate(@NonNull final byte[] xCoordinate) {
+    @Nullable
+    public byte[] hashToGroup(@NonNull final byte[] hash) {
         final byte[] output = new byte[size];
-        final int result = adapter.groupElementsFromXCoordinate(group, xCoordinate, output);
+        final int result = adapter.groupElementsHashToGroup(group, hash, output);
         return switch (result) {
             case GroupElementsLibraryAdapter.SUCCESS -> output;
             case GroupElementsLibraryAdapter.NOT_IN_CURVE -> null;
-            default -> throw new AltBn128Exception(result, "fromXCoordinate in" + this.group);
+            default -> throw new AltBn128Exception(result, "hashToGroup in " + this.group);
         };
     }
 
@@ -104,7 +105,7 @@ public final class GroupFacade implements ElementFacade {
         final byte[] output = new byte[size];
         final int result = adapter.groupElementsZero(group, output);
         if (result != GroupElementsLibraryAdapter.SUCCESS) {
-            throw new AltBn128Exception(result, "groupElementsZero in" + this.group);
+            throw new AltBn128Exception(result, "groupElementsZero in " + this.group);
         }
         return output;
     }
@@ -119,7 +120,7 @@ public final class GroupFacade implements ElementFacade {
         final byte[] output = new byte[size];
         final int result = adapter.groupElementsGenerator(group, output);
         if (result != GroupElementsLibraryAdapter.SUCCESS) {
-            throw new AltBn128Exception(result, "groupElementsGenerator in" + this.group);
+            throw new AltBn128Exception(result, "groupElementsGenerator in " + this.group);
         }
         return output;
     }
@@ -138,9 +139,15 @@ public final class GroupFacade implements ElementFacade {
         }
         final int result = adapter.groupElementsEquals(group, point1, point2);
         if (result < GroupElementsLibraryAdapter.SUCCESS) {
-            throw new AltBn128Exception(result, "groupElementsEquals in" + this.group);
+            throw new AltBn128Exception(result, "groupElementsEquals in " + this.group);
         }
         return result == 1;
+    }
+
+    @NonNull
+    @Override
+    public byte[] fromBytes(@NonNull final byte[] representation) {
+        return fromBytes(representation, false, true, false);
     }
 
     /**
@@ -157,7 +164,7 @@ public final class GroupFacade implements ElementFacade {
         final byte[] output = new byte[size];
         final int result = adapter.groupElementsAdd(group, point1, point2, output);
         if (result != GroupElementsLibraryAdapter.SUCCESS) {
-            throw new AltBn128Exception(result, "groupElementsAdd in" + this.group);
+            throw new AltBn128Exception(result, "groupElementsAdd in " + this.group);
         }
         return output;
     }
@@ -176,7 +183,7 @@ public final class GroupFacade implements ElementFacade {
         final byte[] output = new byte[size];
         final int result = adapter.groupElementsScalarMul(group, point, scalar, output);
         if (result != GroupElementsLibraryAdapter.SUCCESS) {
-            throw new AltBn128Exception(result, "groupElementsScalarMul in" + this.group);
+            throw new AltBn128Exception(result, "groupElementsScalarMul in " + this.group);
         }
         return output;
     }
@@ -193,7 +200,7 @@ public final class GroupFacade implements ElementFacade {
         final byte[] output = new byte[size];
         final int result = adapter.groupElementsLongMul(group, point, scalar, output);
         if (result != GroupElementsLibraryAdapter.SUCCESS) {
-            throw new AltBn128Exception(result, "groupElementsScalarMul in" + this.group);
+            throw new AltBn128Exception(result, "groupElementsScalarMul in " + this.group);
         }
         return output;
     }
@@ -202,26 +209,27 @@ public final class GroupFacade implements ElementFacade {
      * If the byte array is a valid representation of a point, returns a copy of the representation or fails otherwise.
      *
      * @param bytes an array representing a point to validate
+     * @param validate
+     * @param isCompressed
      * @return a copy of bytes if the representation is valid
-     * @throws NullPointerException if the bytes is null
+     * @throws NullPointerException     if the bytes is null
      * @throws IllegalArgumentException if the bytes is of invalid size or the point does not belong to the curve
-     * @throws AltBn128Exception in case of error.
+     * @throws AltBn128Exception        in case of error.
      */
-    @Override
     @NonNull
-    public byte[] fromBytes(@NonNull final byte[] bytes) {
+    public byte[] fromBytes(
+            @NonNull final byte[] bytes, final boolean isCompressed, final boolean validate, final boolean compress) {
+
         validateSize(Objects.requireNonNull(bytes, "bytes must not be null"), this.size, "Invalid representation size");
 
-        final int result = adapter.groupElementsBytes(group, bytes);
+        final byte[] representation = new byte[bytes.length];
+        final int result = adapter.groupElementsBytes(group, isCompressed, validate, compress, bytes, representation);
         if (result == GroupElementsLibraryAdapter.NOT_IN_CURVE) {
             throw new IllegalArgumentException("The point is not in curve");
         } else if (result != GroupElementsLibraryAdapter.SUCCESS) {
-            throw new AltBn128Exception(result, "groupElementsBytes in" + this.group);
+            throw new AltBn128Exception(result, "groupElementsBytes in " + this.group);
         }
-
-        final byte[] ret = new byte[bytes.length]; // TODO get this representation from arkworks
-        System.arraycopy(bytes, 0, ret, 0, bytes.length);
-        return ret;
+        return representation;
     }
 
     /**
@@ -240,7 +248,7 @@ public final class GroupFacade implements ElementFacade {
         final byte[] output = new byte[size];
         int result = adapter.groupElementsBatchAdd(group, points, output);
         if (result != GroupElementsLibraryAdapter.SUCCESS) {
-            throw new AltBn128Exception(result, "groupElementsBatchAdd in" + this.group);
+            throw new AltBn128Exception(result, "groupElementsBatchAdd in " + this.group);
         }
         return output;
     }
@@ -311,4 +319,6 @@ public final class GroupFacade implements ElementFacade {
         }
         return array;
     }
+
+    public enum ToBytesModes {}
 }

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/facade/GroupFacade.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/facade/GroupFacade.java
@@ -147,7 +147,7 @@ public final class GroupFacade implements ElementFacade {
     @NonNull
     @Override
     public byte[] fromBytes(@NonNull final byte[] representation) {
-        return fromBytes(representation, ToBytesFlags.DEFAULT);
+        return fromBytes(representation, ToBytesModes.DEFAULT);
     }
 
     /**
@@ -216,19 +216,16 @@ public final class GroupFacade implements ElementFacade {
      * @throws AltBn128Exception in case of error.
      */
     @NonNull
-    public byte[] fromBytes(@NonNull final byte[] bytes, @Nullable final ToBytesFlags... flags) {
-        final int flagValues = ToBytesFlags.combine(flags);
-        final boolean isCompressed = ToBytesFlags.containsFlag(flagValues, ToBytesFlags.IS_COMPRESSED);
-        final int expectedSize = isCompressed ? this.size / 2 : this.size;
+    public byte[] fromBytes(@NonNull final byte[] bytes, @Nullable final ToBytesModes flags) {
+        Objects.requireNonNull(flags, "bytes cannot be null");
+        final int expectedSize = flags.isCompressed() ? this.size / 2 : this.size;
         validateSize(
                 Objects.requireNonNull(bytes, "bytes must not be null"), expectedSize, "Invalid representation size");
 
-        final boolean compress = ToBytesFlags.containsFlag(flagValues, ToBytesFlags.COMPRESS);
-        final int returnSize = compress ? this.size / 2 : this.size;
+        final int returnSize = flags.compress() ? this.size / 2 : this.size;
         final byte[] representation = new byte[returnSize];
-        final boolean notValidate = ToBytesFlags.containsFlag(flagValues, ToBytesFlags.SKIP_VALIDATE);
-        final int result =
-                adapter.groupElementsBytes(group, isCompressed, !notValidate, compress, bytes, representation);
+        final int result = adapter.groupElementsBytes(
+                group, flags.isCompressed(), !flags.skipValidation(), flags.compress(), bytes, representation);
         if (result == GroupElementsLibraryAdapter.NOT_IN_CURVE) {
             throw new IllegalArgumentException("The point is not in curve");
         } else if (result != GroupElementsLibraryAdapter.SUCCESS) {
@@ -326,57 +323,12 @@ public final class GroupFacade implements ElementFacade {
     }
 
     /**
-     * The different modes to get an element from a byte[]
+     * The different modes to get a groupElement from a byte[]
+     * @param isCompressed indicates that the input array to deserialize should be understood as a compressed representation.
+     * @param compress  indicates that the deserialized output array should be returned in the compressed representation.
+     * @param skipValidation indicates that when deserializing the input, it should not perform the correct point and subgroup validation.
      */
-    public enum ToBytesFlags {
-        /**
-         * Default arkworks deserialization
-         * is-compressed:not compress:not skip-validate:not.
-         */
-        DEFAULT(0),
-        /**
-         * indicates that the input array to deserialize should be understood as a compressed representation.
-         * is-compressed:yes
-         */
-        IS_COMPRESSED(1), // 0001
-        /**
-         * indicates that the deserialized output array should be returned in the compressed representation.
-         * compress:yes
-         */
-        COMPRESS(1 << 1), // 0010
-        /**
-         * indicates that when deserializing the input, it should not perform the correct point and subgroup validation.
-         * skip-validate:yes
-         */
-        SKIP_VALIDATE(1 << 2); // 0100
-
-        private final int value;
-
-        ToBytesFlags(int value) {
-            this.value = value;
-        }
-
-        public int getValue() {
-            return value;
-        }
-
-        /**
-         * Combines multiple flags into a single int.
-         */
-        static int combine(ToBytesFlags... flags) {
-            int combined = 0;
-            if (flags != null) {
-                for (ToBytesFlags flag : flags) {
-                    combined |= flag.getValue();
-                }
-            }
-            return combined;
-        }
-        /**
-         * Checks if a combined value contains this flag.
-         */
-        static boolean containsFlag(int combinedValue, ToBytesFlags flag) {
-            return (combinedValue & flag.getValue()) == flag.getValue();
-        }
+    public record ToBytesModes(boolean isCompressed, boolean compress, boolean skipValidation) {
+        public static final ToBytesModes DEFAULT = new ToBytesModes(false, false, false);
     }
 }

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/facade/GroupFacade.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/facade/GroupFacade.java
@@ -147,7 +147,7 @@ public final class GroupFacade implements ElementFacade {
     @NonNull
     @Override
     public byte[] fromBytes(@NonNull final byte[] representation) {
-        return fromBytes(representation, ToBytesModes.DEFAULT);
+        return fromBytes(representation, FromBytesFlags.DEFAULT);
     }
 
     /**
@@ -216,7 +216,7 @@ public final class GroupFacade implements ElementFacade {
      * @throws AltBn128Exception in case of error.
      */
     @NonNull
-    public byte[] fromBytes(@NonNull final byte[] bytes, @Nullable final ToBytesModes flags) {
+    public byte[] fromBytes(@NonNull final byte[] bytes, @NonNull final FromBytesFlags flags) {
         Objects.requireNonNull(flags, "bytes cannot be null");
         final int expectedSize = flags.isCompressed() ? this.size / 2 : this.size;
         validateSize(
@@ -328,7 +328,7 @@ public final class GroupFacade implements ElementFacade {
      * @param compress  indicates that the deserialized output array should be returned in the compressed representation.
      * @param skipValidation indicates that when deserializing the input, it should not perform the correct point and subgroup validation.
      */
-    public record ToBytesModes(boolean isCompressed, boolean compress, boolean skipValidation) {
-        public static final ToBytesModes DEFAULT = new ToBytesModes(false, false, false);
+    public record FromBytesFlags(boolean isCompressed, boolean compress, boolean skipValidation) {
+        public static final FromBytesFlags DEFAULT = new FromBytesFlags(false, false, false);
     }
 }

--- a/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/facade/GroupFacade.java
+++ b/cryptography/hedera-cryptography-altbn128/src/main/java/com/hedera/cryptography/altbn128/facade/GroupFacade.java
@@ -147,7 +147,7 @@ public final class GroupFacade implements ElementFacade {
     @NonNull
     @Override
     public byte[] fromBytes(@NonNull final byte[] representation) {
-        return fromBytes(representation, false, true, false);
+        return fromBytes(representation, ToBytesFlags.DEFAULT);
     }
 
     /**
@@ -208,24 +208,27 @@ public final class GroupFacade implements ElementFacade {
     /**
      * If the byte array is a valid representation of a point, returns a copy of the representation or fails otherwise.
      *
-     * @param bytes an array representing a point to validate
-     * @param validate
-     * @param isCompressed
-     * @return a copy of bytes if the representation is valid
-     * @throws NullPointerException     if the bytes is null
+     * @param bytes an array representing a point
+     * @param flags how the serialization should occur
+     * @return the internal representation as returned by arkworks
+     * @throws NullPointerException if the bytes is null
      * @throws IllegalArgumentException if the bytes is of invalid size or the point does not belong to the curve
-     * @throws AltBn128Exception        in case of error.
+     * @throws AltBn128Exception in case of error.
      */
     @NonNull
-    public byte[] fromBytes(
-            @NonNull final byte[] bytes, final boolean isCompressed, final boolean validate, final boolean compress) {
+    public byte[] fromBytes(@NonNull final byte[] bytes, @Nullable final ToBytesFlags... flags) {
+        final int flagValues = ToBytesFlags.combine(flags);
+        final boolean isCompressed = ToBytesFlags.containsFlag(flagValues, ToBytesFlags.IS_COMPRESSED);
         final int expectedSize = isCompressed ? this.size / 2 : this.size;
         validateSize(
                 Objects.requireNonNull(bytes, "bytes must not be null"), expectedSize, "Invalid representation size");
 
+        final boolean compress = ToBytesFlags.containsFlag(flagValues, ToBytesFlags.COMPRESS);
         final int returnSize = compress ? this.size / 2 : this.size;
         final byte[] representation = new byte[returnSize];
-        final int result = adapter.groupElementsBytes(group, isCompressed, validate, compress, bytes, representation);
+        final boolean notValidate = ToBytesFlags.containsFlag(flagValues, ToBytesFlags.SKIP_VALIDATE);
+        final int result =
+                adapter.groupElementsBytes(group, isCompressed, !notValidate, compress, bytes, representation);
         if (result == GroupElementsLibraryAdapter.NOT_IN_CURVE) {
             throw new IllegalArgumentException("The point is not in curve");
         } else if (result != GroupElementsLibraryAdapter.SUCCESS) {
@@ -322,5 +325,58 @@ public final class GroupFacade implements ElementFacade {
         return array;
     }
 
-    public enum ToBytesModes {}
+    /**
+     * The different modes to get an element from a byte[]
+     */
+    public enum ToBytesFlags {
+        /**
+         * Default arkworks deserialization
+         * is-compressed:not compress:not skip-validate:not.
+         */
+        DEFAULT(0),
+        /**
+         * indicates that the input array to deserialize should be understood as a compressed representation.
+         * is-compressed:yes
+         */
+        IS_COMPRESSED(1), // 0001
+        /**
+         * indicates that the deserialized output array should be returned in the compressed representation.
+         * compress:yes
+         */
+        COMPRESS(1 << 1), // 0010
+        /**
+         * indicates that when deserializing the input, it should not perform the correct point and subgroup validation.
+         * skip-validate:yes
+         */
+        SKIP_VALIDATE(1 << 2); // 0100
+
+        private final int value;
+
+        ToBytesFlags(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+        /**
+         * Combines multiple flags into a single int.
+         */
+        static int combine(ToBytesFlags... flags) {
+            int combined = 0;
+            if (flags != null) {
+                for (ToBytesFlags flag : flags) {
+                    combined |= flag.getValue();
+                }
+            }
+            return combined;
+        }
+        /**
+         * Checks if a combined value contains this flag.
+         */
+        static boolean containsFlag(int combinedValue, ToBytesFlags flag) {
+            return (combinedValue & flag.getValue()) == flag.getValue();
+        }
+    }
 }

--- a/cryptography/hedera-cryptography-altbn128/src/main/rust/bn254_field_elements.rs
+++ b/cryptography/hedera-cryptography-altbn128/src/main/rust/bn254_field_elements.rs
@@ -15,7 +15,7 @@
 //
 
 use crate::jni_helpers;
-use crate::jni_helpers::{batch_add_scalars, batch_multiply_scalars};
+use crate::jni_helpers::{batch_add_scalars, batch_multiply_scalars, SEED_SIZE};
 use crate::scalars_utils::*;
 use jni::objects::{JByteArray, JLongArray, JObject, JObjectArray};
 use jni::sys::{jint, jlong};
@@ -43,12 +43,12 @@ pub extern "system" fn Java_com_hedera_cryptography_altbn128_adapter_jni_ArkBn25
     input_seed: JByteArray,
     output: JByteArray,
 ) -> jint {
-    let seed_array = match jni_helpers::extract_random_seed(&env, &input_seed) {
+    let seed_vec = match jni_helpers::from_jbytearray_to_vec(&env, &input_seed) {
         Ok(value) => value,
         Err(value) => return value,
     };
-
-    let mut rng = ChaCha8Rng::from_seed(seed_array);
+    let fixed_array: [u8; SEED_SIZE] = seed_vec[0..SEED_SIZE].try_into().unwrap();
+    let mut rng = ChaCha8Rng::from_seed(fixed_array);
 
     let scalar = scalars_from_random::<ChaCha8Rng>(&mut rng);
 

--- a/cryptography/hedera-cryptography-altbn128/src/main/rust/bn254_group_elements.rs
+++ b/cryptography/hedera-cryptography-altbn128/src/main/rust/bn254_group_elements.rs
@@ -16,9 +16,9 @@
 
 use crate::group_element_utils::*;
 use crate::jni_helpers;
-use crate::jni_helpers::{G1, G2};
+use crate::jni_helpers::{G1, G2, SEED_SIZE};
 use jni::objects::{JByteArray, JLongArray, JObject, JObjectArray};
-use jni::sys::{jint, jlong};
+use jni::sys::{jboolean, jint, jlong};
 use jni::JNIEnv;
 use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaCha8Rng;
@@ -47,10 +47,11 @@ pub extern "system" fn Java_com_hedera_cryptography_altbn128_adapter_jni_ArkBn25
     input_seed: JByteArray,
     output: JByteArray,
 ) -> jint {
-    let seed_array = match jni_helpers::extract_random_seed(&env, &input_seed) {
+    let input_vec = match jni_helpers::from_jbytearray_to_vec(&env, &input_seed) {
         Ok(value) => value,
         Err(value) => return value,
     };
+    let seed_array: [u8; SEED_SIZE] = input_vec[0..SEED_SIZE].try_into().unwrap();
     let mut rng = ChaCha8Rng::from_seed(seed_array);
     match group_id {
         GROUP1 => {
@@ -81,31 +82,35 @@ pub extern "system" fn Java_com_hedera_cryptography_altbn128_adapter_jni_ArkBn25
 /// *   -4   Business Error: Point is not in the curve
 /// * A less than 0 error code in case of error
 #[no_mangle]
-pub extern "system" fn Java_com_hedera_cryptography_altbn128_adapter_jni_ArkBn254Adapter_groupElementsFromXCoordinate(
+pub extern "system" fn Java_com_hedera_cryptography_altbn128_adapter_jni_ArkBn254Adapter_groupElementsHashToGroup(
     env: JNIEnv,
     _instance: JObject,
     group_id: jint,
     input_x: JByteArray,
     output: JByteArray,
 ) -> jint {
-    let hash_array = match jni_helpers::extract_random_seed(&env, &input_x) {
+    let hash_vec = match jni_helpers::from_jbytearray_to_vec(&env, &input_x) {
         Ok(value) => value,
         Err(value) => return value,
     };
 
     if group_id == GROUP1 {
-        elements_from_hash_generic::<G1Config>(env, &hash_array, output)
+        elements_from_hash_generic::<G1Config>(env, &hash_vec, output)
     } else {
-        elements_from_hash_generic::<G2Config>(env, &hash_array, output)
+        elements_from_hash_generic::<G2Config>(env, &hash_vec, output)
     }
 }
 
-/// JNI function that determines if a byte array representation of a group element is valid
+/// JNI function that determines to get the arkworks internal byte array representation of a group element
+/// under different modes.
 /// # Arguments
 /// * `env` _ The JNI environment.
 /// * `_instance` _ The Java instance calling this function.
 /// * `group_id`  in which group to perform the operation
-/// * `value`   the byte that of size GROUP2_ELEMENT_AFFINE_SIZE represents the group element
+/// * `is_compressed`   if the array representation is in compressed format
+/// * `validate`   if it should be validated that the point is in the curve and in the correct subgroup
+/// * `compress`  if the point should be returned in the compressed format
+/// * `value`   the byte array that represents the group element
 /// # Returns
 /// *   0    Success
 /// *  BUSINESS_ERROR_POINT_NOT_IN_CURVE   Business Error: Point is not in the curve
@@ -115,16 +120,24 @@ pub extern "system" fn Java_com_hedera_cryptography_altbn128_adapter_jni_ArkBn25
     env: JNIEnv,
     _instance: JObject,
     group_id: jint,
+    is_compressed: jboolean,
+    validate: jboolean,
+    compress: jboolean,
     value: JByteArray,
+    output: JByteArray,
 ) -> jint {
-    let input_bytes = match jni_helpers::from_jbytearray_to_vec(env, &value) {
+    let input_vec = match jni_helpers::from_jbytearray_to_vec(&env, &value) {
         Ok(value) => value,
         Err(value) => return value,
     };
-    match group_id {
-        GROUP1 => jni_helpers::validate_g1point(&input_bytes),
-        _ => jni_helpers::validate_g2point(&input_bytes),
-    }
+  match group_id {
+     GROUP1 => {
+         jni_helpers::hadle_group::<G1>(env, is_compressed, validate, compress, output, &input_vec).unwrap_or_else(|value| value)
+     }
+     _ => {
+         jni_helpers::hadle_group::<G2>(env, is_compressed, validate, compress, output, &input_vec).unwrap_or_else(|value| value)
+     }
+  }
 }
 
 /// Returns the zero group element

--- a/cryptography/hedera-cryptography-altbn128/src/main/rust/bn254_pairings.rs
+++ b/cryptography/hedera-cryptography-altbn128/src/main/rust/bn254_pairings.rs
@@ -45,19 +45,19 @@ pub extern "system" fn Java_com_hedera_cryptography_altbn128_adapter_jni_ArkBn25
     value3: JByteArray,
     value4: JByteArray,
 ) -> jint {
-    let p1: G1 = match jni_helpers::to_point::<G1>(&env, &value) {
+    let p1: G1 = match jni_helpers::to_point::<G1>(&env, &value, false) {
         Ok(val) => val,
         Err(err) => return err,
     };
-    let p2: G2 = match jni_helpers::to_point::<G2>(&env, &value2) {
+    let p2: G2 = match jni_helpers::to_point::<G2>(&env, &value2, false) {
         Ok(val) => val,
         Err(err) => return err,
     };
-    let p3: G1 = match jni_helpers::to_point::<G1>(&env, &value3) {
+    let p3: G1 = match jni_helpers::to_point::<G1>(&env, &value3, false) {
         Ok(val) => val,
         Err(err) => return err,
     };
-    let p4: G2 = match jni_helpers::to_point::<G2>(&env, &value4) {
+    let p4: G2 = match jni_helpers::to_point::<G2>(&env, &value4, false) {
         Ok(val) => val,
         Err(err) => return err,
     };

--- a/cryptography/hedera-cryptography-altbn128/src/main/rust/group_element_utils.rs
+++ b/cryptography/hedera-cryptography-altbn128/src/main/rust/group_element_utils.rs
@@ -18,7 +18,7 @@ use crate::jni_helpers;
 use ark_ec::short_weierstrass::{Affine, SWCurveConfig};
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::{Field, PrimeField};
-use ark_serialize::CanonicalSerialize;
+use ark_serialize::{CanonicalSerialize, Compress, Validate};
 use jni::objects::JByteArray;
 use jni::sys::jint;
 use jni::JNIEnv;
@@ -63,25 +63,48 @@ pub fn group_elements_total_sum<G: CurveGroup>(values: Vec<G>) -> G {
 /// (De)/Serialization
 /// ******************
 
-pub fn canonical_serialize<S: CanonicalSerialize>(element: &S) -> Result<Vec<u8>, String> {
+pub fn canonical_serialize_with_mode<S: CanonicalSerialize>(
+    element: &S,
+    compress: bool
+) -> Result<Vec<u8>, String> {
     let mut serialized = Vec::new();
-    match element.serialize_uncompressed(&mut serialized) {
+    let mode: Compress = if compress {
+        Compress::Yes
+    } else {
+        Compress::No
+    };
+    match element.serialize_with_mode(&mut serialized, mode) {
         Ok(_) => Ok(serialized),
         Err(v) => Err(v.to_string()),
     }
 }
 
 /// returns the point from a projective byte representation of a point
-pub fn group_elements_deserialize<G: CurveGroup>(value: &[u8]) -> Result<G, String> {
-    match G::deserialize_uncompressed_unchecked(value) {
+pub fn group_elements_deserialize<G: CurveGroup>(value: &[u8], compress: bool) -> Result<G, String> {
+    let mode: Compress = if compress {
+        Compress::Yes
+    } else {
+        Compress::No
+    };
+    match G::deserialize_with_mode(value, mode, Validate::No) {
         Ok(val) => Ok(val),
         Err(err) => Err(err.to_string()),
     }
 }
 
 /// returns the point from a projective byte representation of a point
-pub fn group_elements_deserialize_and_validate<G: CurveGroup>(value: &[u8]) -> Result<G, String> {
-    match G::deserialize_uncompressed(value) {
+pub fn group_elements_deserialize_with_modes<G: CurveGroup>(value: &[u8], is_compressed: bool, validate: bool) -> Result<G, String> {
+    let compress: Compress = if is_compressed {
+        Compress::Yes
+    } else {
+        Compress::No
+    };
+    let validate: Validate = if validate {
+        Validate::Yes
+    } else {
+        Validate::No
+    };
+    match G::deserialize_with_mode(value, compress, validate) {
         Ok(val) => Ok(val),
         Err(err) => Err(err.to_string()),
     }

--- a/cryptography/hedera-cryptography-altbn128/src/main/rust/jni_helpers.rs
+++ b/cryptography/hedera-cryptography-altbn128/src/main/rust/jni_helpers.rs
@@ -14,10 +14,7 @@
 // limitations under the License.
 //
 
-use crate::group_element_utils::{
-    canonical_serialize, group_elements_add, group_elements_deserialize,
-    group_elements_deserialize_and_validate, group_elements_total_sum,
-};
+use crate::group_element_utils::{canonical_serialize_with_mode, group_elements_add, group_elements_deserialize, group_elements_deserialize_with_modes, group_elements_total_sum};
 use crate::scalars_utils::{
     scalars_batch_add, scalars_batch_multiply, scalars_curve_from_bytes, scalars_curve_from_i64,
     scalars_curve_group_elements_msm, scalars_curve_group_elements_multiply, scalars_from_bytes,
@@ -27,7 +24,7 @@ use ark_bn254::{G1Projective, G2Projective};
 use ark_ec::{CurveConfig, CurveGroup};
 use ark_serialize::CanonicalSerialize;
 use jni::objects::{JByteArray, JLongArray, JObjectArray};
-use jni::sys::{jbyte, jint, jlong, jsize};
+use jni::sys::{jboolean, jbyte, jint, jlong, jsize};
 use jni::JNIEnv;
 
 pub(crate) type G1 = G1Projective;
@@ -39,8 +36,6 @@ const SUCCESS: i32 = 0;
 pub(crate) const SEED_SIZE: usize = 32;
 /// * -1001  Jni Error: Could not convert argument array to vector
 const JNI_ERROR_ARG_TO_VEC: i32 = -1001;
-/// * -1002  Rust error: Could not convert argument vector to an unsigned byte array
-const RUST_ERROR_COULD_NOT_TRANSFORM_ARGUMENT_DATA_TYPE: i32 = -1002;
 /// * -1003   Ark Error: Result cannot be serialized
 const ARK_ERROR_RESULT_SERIALIZATION: i32 = -1003;
 /// * -1004  Jni Error: Could not set the scalar in the output byte array
@@ -99,27 +94,32 @@ pub fn write_return_scalar(env: JNIEnv, output: JByteArray, scalar: F) -> Result
     )
 }
 
-/// Utility function to extract the random seed from a JByteArray
-pub fn extract_random_seed(env: &JNIEnv, input_seed: &JByteArray) -> Result<[u8; 32], jint> {
-    let input_seed_bytes = match env.convert_byte_array(&input_seed) {
-        Ok(val) => val,
-        Err(_) => return Err(JNI_ERROR_ARG_TO_VEC),
-    };
-
-    let seed_array: [u8; SEED_SIZE] = match input_seed_bytes.try_into() {
-        Ok(val) => val,
-        Err(_) => return Err(RUST_ERROR_COULD_NOT_TRANSFORM_ARGUMENT_DATA_TYPE),
-    };
-    Ok(seed_array)
-}
-
 /// Utility function to write the serialized representation in an existing JByteArray
 pub fn serialize_to_jbytearray<G: CanonicalSerialize>(
     env: JNIEnv,
     point: &G,
     output: JByteArray,
 ) -> Result<jint, jint> {
-    let ge_bytes = match canonical_serialize::<G>(&point) {
+    let ge_bytes = match canonical_serialize_with_mode::<G>(&point,false) {
+        Ok(val) => val,
+        Err(_) => return Err(ARK_ERROR_RESULT_SERIALIZATION),
+    };
+
+    let transformed_vec: Vec<jbyte> = ge_bytes.iter().map(|&x| x as jbyte).collect();
+
+    match env.set_byte_array_region(output, 0, &transformed_vec) {
+        Ok(_) => Ok(SUCCESS),
+        Err(_) => Err(JNI_ERROR_COULD_SET_RESULT_DATA_IN_ARRAY),
+    }
+}
+
+/// Utility function to write the serialized representation in an existing JByteArray
+pub fn serialize_to_jbytearray_compress<G: CanonicalSerialize>(
+    env: JNIEnv,
+    point: &G,
+    output: JByteArray,
+) -> Result<jint, jint> {
+    let ge_bytes = match canonical_serialize_with_mode::<G>(&point, true) {
         Ok(val) => val,
         Err(_) => return Err(ARK_ERROR_RESULT_SERIALIZATION),
     };
@@ -133,13 +133,13 @@ pub fn serialize_to_jbytearray<G: CanonicalSerialize>(
 }
 
 /// Utility function read a curve point form a JByteArray, the point is not validated, so this function must be used with trusted source of information.
-pub fn to_point<G: CurveGroup>(env: &JNIEnv, value: &JByteArray) -> Result<G, jint> {
+pub fn to_point<G: CurveGroup>(env: &JNIEnv, value: &JByteArray, compress:bool) -> Result<G, jint> {
     let input_bytes = match env.convert_byte_array(&value) {
         Ok(val) => val,
         Err(_) => return Err(JNI_ERROR_ARG_TO_VEC),
     };
 
-    let point1 = match group_elements_deserialize::<G>(&input_bytes) {
+    let point1 = match group_elements_deserialize::<G>(&input_bytes, compress) {
         Ok(val) => val,
         Err(_) => return Err(ARK_ERROR_ARGUMENT_SERIALIZATION),
     };
@@ -163,7 +163,7 @@ pub fn to_vec_of_points<G: CurveGroup>(
         };
 
         let element_byte_array: JByteArray = unsafe { JByteArray::from_raw(*element) };
-        let point1 = match to_point::<G>(&env, &element_byte_array) {
+        let point1 = match to_point::<G>(&env, &element_byte_array, false) {
             Ok(value) => value,
             Err(value) => return Err(value),
         };
@@ -272,7 +272,7 @@ pub fn from_jlongs_to_vec_of_curve_scalars<G: CurveGroup>(
 }
 
 /// Utility function to extract a vec u8 from a JByteArray
-pub fn from_jbytearray_to_vec(env: JNIEnv, value: &JByteArray) -> Result<Vec<u8>, jint> {
+pub fn from_jbytearray_to_vec(env: &JNIEnv, value: &JByteArray) -> Result<Vec<u8>, jint> {
     let input_bytes = match env.convert_byte_array(&value) {
         Ok(val) => val,
         Err(_) => return Err(JNI_ERROR_ARG_TO_VEC),
@@ -280,30 +280,15 @@ pub fn from_jbytearray_to_vec(env: JNIEnv, value: &JByteArray) -> Result<Vec<u8>
     Ok(input_bytes)
 }
 
-/// Utility function to validate a g1 point
-pub fn validate_g1point(input_bytes: &Vec<u8>) -> i32 {
-    match group_elements_deserialize_and_validate::<G1Projective>(&input_bytes) {
-        Ok(_) => SUCCESS,
-        Err(_) => BUSINESS_ERROR_POINT_NOT_IN_CURVE,
-    }
-}
-
-/// Utility function to validate a g2 point
-pub fn validate_g2point(input_bytes: &Vec<u8>) -> i32 {
-    match group_elements_deserialize_and_validate::<G2Projective>(&input_bytes) {
-        Ok(_) => SUCCESS,
-        Err(_) => BUSINESS_ERROR_POINT_NOT_IN_CURVE,
-    }
-}
 
 /// Utility function to compare two points
 pub fn compare_points<G: CurveGroup>(env: &JNIEnv, value: &JByteArray, value2: &JByteArray) -> i32 {
-    let point1 = match to_point::<G>(&env, &value) {
+    let point1 = match to_point::<G>(&env, &value, false) {
         Ok(value) => value,
         Err(value) => return value,
     };
 
-    let point2 = match to_point::<G>(&env, &value2) {
+    let point2 = match to_point::<G>(&env, &value2, false) {
         Ok(value) => value,
         Err(value) => return value,
     };
@@ -318,12 +303,12 @@ pub fn add_points<G: CurveGroup>(
     value2: &JByteArray,
     output: JByteArray,
 ) -> i32 {
-    let point1 = match to_point::<G>(&env, &value) {
+    let point1 = match to_point::<G>(&env, &value, false) {
         Ok(value) => value,
         Err(value) => return value,
     };
 
-    let point2 = match to_point::<G>(&env, &value2) {
+    let point2 = match to_point::<G>(&env, &value2, false) {
         Ok(value) => value,
         Err(value) => return value,
     };
@@ -339,7 +324,7 @@ pub fn multiply_point_and_scalar<G: CurveGroup>(
     value2: &JByteArray,
     output: JByteArray,
 ) -> i32 {
-    let point1 = match to_point::<G>(&env, &value) {
+    let point1 = match to_point::<G>(&env, &value, false) {
         Ok(value) => value,
         Err(value) => return value,
     };
@@ -444,7 +429,7 @@ pub fn multiply_point_and_scalar_long<G: CurveGroup>(
     value2: jlong,
     output: JByteArray,
 ) -> i32 {
-    let point1 = match to_point::<G>(&env, &value) {
+    let point1 = match to_point::<G>(&env, &value, false) {
         Ok(value) => value,
         Err(value) => return value,
     };
@@ -455,4 +440,22 @@ pub fn multiply_point_and_scalar_long<G: CurveGroup>(
 
     let point = scalars_curve_group_elements_multiply(value, point1);
     serialize_to_jbytearray(env, &point, output).unwrap_or_else(|value| value)
+}
+
+pub fn hadle_group<G: CurveGroup>(env: JNIEnv, is_compressed: jboolean, validate: jboolean, compress: jboolean, output: JByteArray, input_vec: &Vec<u8>) -> Result<jint, jint> {
+    let point = match group_elements_deserialize_with_modes::<G>(
+        &input_vec,
+        is_compressed != 0,
+        validate != 0,
+    ) {
+        Ok(a) => a,
+        Err(_) => return Err(BUSINESS_ERROR_POINT_NOT_IN_CURVE),
+    };
+    Ok(match compress {
+        0 => {
+            serialize_to_jbytearray::<G>(env, &point, output).unwrap_or_else(|value| value)
+        }
+        _ => serialize_to_jbytearray_compress::<G>(env, &point, output)
+            .unwrap_or_else(|value| value),
+    })
 }

--- a/cryptography/hedera-cryptography-altbn128/src/test/java/com/hedera/cryptography/altbn128/AltBn128GroupElementTest.java
+++ b/cryptography/hedera-cryptography-altbn128/src/test/java/com/hedera/cryptography/altbn128/AltBn128GroupElementTest.java
@@ -18,6 +18,7 @@ package com.hedera.cryptography.altbn128;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -143,6 +144,79 @@ class AltBn128GroupElementTest {
                                 "4082367875863433681332203403145435568316851327593401208105741076214120093531")));
     }
 
+    @Test
+    void g2FromCoordinatesTest() {
+        final var group = new AltBn128Group(AltBN128CurveGroup.GROUP2, new AltBn128Field());
+
+        var x = List.of(
+                new BigInteger("7031240240644549789964684346421651657413149655254591106755800187295583390686"),
+                new BigInteger("11925796103144459273863446402654145580591864121894287082155917744014974668227"));
+        var negativeY = List.of(
+                new BigInteger("14636893922571631340936704898436226741317401229693847486683496866081642675008"),
+                new BigInteger("14331914237324588013612977362562070301993194762051881872592154596781761039271"));
+        var positiveY = List.of(
+                new BigInteger("7251348949267643881309700846821048347378909927603976176005541028563583533575"),
+                new BigInteger("7556328634514687208633428382695204786703116395245941790096883297863465169312"));
+
+        var negative = group.fromXCoordinate(x, true);
+        var positive = group.fromXCoordinate(x, false);
+
+        assertTrue(negative.isYNegative());
+        assertFalse(positive.isYNegative());
+
+        assertEquals(negative.getYCoordinate(), negativeY);
+        assertEquals(positive.getYCoordinate(), positiveY);
+
+        assertEquals(negative, group.fromCoordinates(x, negativeY));
+        assertEquals(positive, group.fromCoordinates(x, positiveY));
+    }
+
+    @Test
+    void g1FromCoordinatesTest() {
+        final var group = new AltBn128Group(AltBN128CurveGroup.GROUP1, new AltBn128Field());
+
+        var x = List.of(
+                new BigInteger("17370179114844557828620377206794063292054094720673581175635719115816088574235"));
+        var negativeY = List.of(
+                new BigInteger("20990165166396755383220676224378276007672276198953266474736810932327658391856"));
+        var positiveY =
+                List.of(new BigInteger("898077705442519839025729520878999081024034958344557187952226962317567816727"));
+
+        var negative = group.fromXCoordinate(x, true);
+        var positive = group.fromXCoordinate(x, false);
+
+        assertTrue(negative.isYNegative());
+        assertFalse(positive.isYNegative());
+
+        assertEquals(negative.getYCoordinate(), negativeY);
+        assertEquals(positive.getYCoordinate(), positiveY);
+
+        assertEquals(negative, group.fromCoordinates(x, negativeY));
+        assertEquals(positive, group.fromCoordinates(x, positiveY));
+    }
+
+    @ParameterizedTest
+    @EnumSource(AltBN128CurveGroup.class)
+    @Disabled
+    void notATest(AltBN128CurveGroup gr, Random rng) {
+        final var group = new AltBn128Group(gr, new AltBn128Field());
+        while (true) {
+            GroupElement element = group.random(rng);
+            if (element.isYNegative()) {
+                System.out.printf(
+                        "isNegative %s: %s,%s%n",
+                        element.isYNegative(), element.getXCoordinate(), element.getYCoordinate());
+                final GroupElement element1 = group.fromXCoordinate(element.getXCoordinate(), false);
+                System.out.printf(
+                        "isNegative %s: %s,%s%n",
+                        element1.isYNegative(), element1.getXCoordinate(), element1.getYCoordinate());
+                break;
+            } else {
+                System.out.printf("positive: %s,%s%n", element.getXCoordinate(), element.getYCoordinate());
+            }
+        }
+    }
+
     @ParameterizedTest
     @EnumSource(AltBN128CurveGroup.class)
     void zeroIsZero(AltBN128CurveGroup g) {
@@ -152,14 +226,23 @@ class AltBn128GroupElementTest {
         assertEquals(group.zero(), group.fromBytes(group.zero().toBytes()));
     }
 
-    @ParameterizedTest
-    @EnumSource(AltBN128CurveGroup.class)
-    void pointNotInCurve(AltBN128CurveGroup g) {
+    @Test
+    void g1PointNotInCurve() {
         var field = new AltBn128Field();
-        var group = new AltBn128Group(g, field);
-        var nonZero = new byte[group.elementSize()];
-        Arrays.fill(nonZero, (byte) 0);
-        assertThrows(IllegalArgumentException.class, () -> group.fromBytes(nonZero));
+        var group = new AltBn128Group(AltBN128CurveGroup.GROUP1, field);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> group.fromCoordinates(List.of(BigInteger.ZERO), List.of(BigInteger.ZERO)));
+    }
+
+    @Test
+    void g2PointNotInCurve() {
+        var field = new AltBn128Field();
+        var group = new AltBn128Group(AltBN128CurveGroup.GROUP2, field);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> group.fromCoordinates(
+                        List.of(BigInteger.ZERO, BigInteger.ZERO), List.of(BigInteger.ZERO, BigInteger.ZERO)));
     }
 
     @Test

--- a/cryptography/hedera-cryptography-altbn128/src/test/java/com/hedera/cryptography/altbn128/ArkworksSerializationTest.java
+++ b/cryptography/hedera-cryptography-altbn128/src/test/java/com/hedera/cryptography/altbn128/ArkworksSerializationTest.java
@@ -46,7 +46,7 @@ class ArkworksSerializationTest {
         final BigInteger x = new BigInteger("703710");
         final BigInteger y = new BigInteger("65535");
 
-        final byte[] bytes = ArkworksSerialization.coordinatesToBytes(List.of(x, y));
+        final byte[] bytes = ArkworksSerialization.coordinatesToBytes(List.of(x, y), null);
 
         assertEquals(x, ArkworksSerialization.getCoordinate(bytes, true).getFirst());
         assertEquals(y, ArkworksSerialization.getCoordinate(bytes, false).getFirst());
@@ -57,7 +57,7 @@ class ArkworksSerializationTest {
         final String hexExpected =
                 "aabbccddeeff00000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000";
         final byte[] bytes = ArkworksSerialization.coordinatesToBytes(
-                List.of(new BigInteger("281401388481450"), new BigInteger("1")));
+                List.of(new BigInteger("281401388481450"), new BigInteger("1")), null);
         System.out.println(HexFormat.of().formatHex(bytes));
         assertEquals(
                 hexExpected, HexFormat.of().formatHex(bytes), "Coordinates should be converted to bytes correctly");

--- a/cryptography/hedera-cryptography-altbn128/src/test/java/com/hedera/cryptography/altbn128/ArkworksSerializationTest.java
+++ b/cryptography/hedera-cryptography-altbn128/src/test/java/com/hedera/cryptography/altbn128/ArkworksSerializationTest.java
@@ -46,7 +46,7 @@ class ArkworksSerializationTest {
         final BigInteger x = new BigInteger("703710");
         final BigInteger y = new BigInteger("65535");
 
-        final byte[] bytes = ArkworksSerialization.coordinatesToBytes(List.of(x), List.of(y));
+        final byte[] bytes = ArkworksSerialization.coordinatesToBytes(64, List.of(x, y));
 
         assertEquals(x, ArkworksSerialization.getCoordinate(bytes, true).getFirst());
         assertEquals(y, ArkworksSerialization.getCoordinate(bytes, false).getFirst());
@@ -57,7 +57,7 @@ class ArkworksSerializationTest {
         final String hexExpected =
                 "aabbccddeeff00000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000";
         final byte[] bytes = ArkworksSerialization.coordinatesToBytes(
-                List.of(new BigInteger("281401388481450")), List.of(new BigInteger("1")));
+                64, List.of(new BigInteger("281401388481450"), new BigInteger("1")));
         System.out.println(HexFormat.of().formatHex(bytes));
         assertEquals(
                 hexExpected, HexFormat.of().formatHex(bytes), "Coordinates should be converted to bytes correctly");

--- a/cryptography/hedera-cryptography-altbn128/src/test/java/com/hedera/cryptography/altbn128/ArkworksSerializationTest.java
+++ b/cryptography/hedera-cryptography-altbn128/src/test/java/com/hedera/cryptography/altbn128/ArkworksSerializationTest.java
@@ -46,7 +46,7 @@ class ArkworksSerializationTest {
         final BigInteger x = new BigInteger("703710");
         final BigInteger y = new BigInteger("65535");
 
-        final byte[] bytes = ArkworksSerialization.coordinatesToBytes(64, List.of(x, y));
+        final byte[] bytes = ArkworksSerialization.coordinatesToBytes(List.of(x, y));
 
         assertEquals(x, ArkworksSerialization.getCoordinate(bytes, true).getFirst());
         assertEquals(y, ArkworksSerialization.getCoordinate(bytes, false).getFirst());
@@ -57,7 +57,7 @@ class ArkworksSerializationTest {
         final String hexExpected =
                 "aabbccddeeff00000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000";
         final byte[] bytes = ArkworksSerialization.coordinatesToBytes(
-                64, List.of(new BigInteger("281401388481450"), new BigInteger("1")));
+                List.of(new BigInteger("281401388481450"), new BigInteger("1")));
         System.out.println(HexFormat.of().formatHex(bytes));
         assertEquals(
                 hexExpected, HexFormat.of().formatHex(bytes), "Coordinates should be converted to bytes correctly");

--- a/cryptography/hedera-cryptography-altbn128/src/test/java/com/hedera/cryptography/altbn128/adapter/jni/ArkBn254AdapterTest.java
+++ b/cryptography/hedera-cryptography-altbn128/src/test/java/com/hedera/cryptography/altbn128/adapter/jni/ArkBn254AdapterTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 class ArkBn254AdapterTest {
 
     /**
-     * Tests the {@link ArkBn254Adapter#groupElementsFromXCoordinate(int, byte[], byte[])} method.
+     * Tests the {@link ArkBn254Adapter#groupElementsHashToGroup(int, byte[], byte[])} method.
      */
     @Test
     void groupElementsFromXCoordinateTest() {
@@ -41,7 +41,7 @@ class ArkBn254AdapterTest {
         // success case
         final byte[] xCoordinate =
                 HexFormat.of().parseHex("60b420bb3851d9d47acb933dbe70399bf6c92da33af01d4fb770e98c0325f41d");
-        final int result1 = adapter.groupElementsFromXCoordinate(groupId, xCoordinate, output);
+        final int result1 = adapter.groupElementsHashToGroup(groupId, xCoordinate, output);
         assertEquals(GroupElementsLibraryAdapter.SUCCESS, result1, "we expect the method to return success");
         assertNotEquals(
                 0,
@@ -52,7 +52,7 @@ class ArkBn254AdapterTest {
         Arrays.fill(output, (byte) 0);
 
         // failure case
-        final int result2 = adapter.groupElementsFromXCoordinate(groupId, new byte[32], output);
+        final int result2 = adapter.groupElementsHashToGroup(groupId, new byte[32], output);
         assertNotEquals(
                 GroupElementsLibraryAdapter.SUCCESS,
                 result2,

--- a/cryptography/hedera-cryptography-bls/src/main/java/com/hedera/cryptography/bls/GroupAssignment.java
+++ b/cryptography/hedera-cryptography-bls/src/main/java/com/hedera/cryptography/bls/GroupAssignment.java
@@ -16,6 +16,8 @@
 
 package com.hedera.cryptography.bls;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 /**
  * An enum to clarify which group public keys and signatures are in, for a given
  * {@link SignatureSchema SignatureSchema}
@@ -48,6 +50,11 @@ public enum GroupAssignment {
         return id;
     }
 
+    /**
+     * @param id the id of the groupAssigment enum
+     * @return the group assigment given an Id
+     */
+    @NonNull
     public static GroupAssignment fromId(final int id) {
         return switch (id) {
             case 0 -> SHORT_SIGNATURES;

--- a/cryptography/hedera-cryptography-pairings-api/src/main/java/com/hedera/cryptography/pairings/api/Group.java
+++ b/cryptography/hedera-cryptography-pairings-api/src/main/java/com/hedera/cryptography/pairings/api/Group.java
@@ -204,6 +204,8 @@ public interface Group {
      * Creates a group element from its x coordinates
      *
      * @param x the x coordinate
+     * @param isYNegative indicates which of the two possible Y coordinates to select.
+     *                    Also referred as odd/even.
      * @return the new group element
      */
     @NonNull

--- a/cryptography/hedera-cryptography-pairings-api/src/main/java/com/hedera/cryptography/pairings/api/Group.java
+++ b/cryptography/hedera-cryptography-pairings-api/src/main/java/com/hedera/cryptography/pairings/api/Group.java
@@ -178,17 +178,16 @@ public interface Group {
     GroupElement add(@NonNull Collection<GroupElement> elements);
 
     /**
-     * Creates a group element from its serialized encoding. The serialization is implementation specific and should not
-     * be relied upon to be consistent across different versions of the library.
+     * Creates a group element from its internal encoding.
+     * The serialization is implementation specific and should not be relied upon to be consistent across different versions of the library.
      *
      * @param bytes serialized form
      * @return the new group element
      * @throws IllegalArgumentException if the byte representation is not a valid point on the curve
+     * @deprecated This method is implementation specific and should not be used.
      */
-    // TODO: (?)Maybe add:
-    //  + List<GroupElement> allFromBytes(List<byte[]> collection)
-    //  + fromBytes(byte[] bytes, Mode.NO_VALIDATE)
     @NonNull
+    @Deprecated
     GroupElement fromBytes(@NonNull byte[] bytes);
 
     /**
@@ -200,6 +199,15 @@ public interface Group {
      */
     @NonNull
     GroupElement fromCoordinates(@NonNull final List<BigInteger> x, @NonNull final List<BigInteger> y);
+
+    /**
+     * Creates a group element from its x coordinates
+     *
+     * @param x the x coordinate
+     * @return the new group element
+     */
+    @NonNull
+    GroupElement fromXCoordinate(@NonNull final List<BigInteger> x, boolean isYNegative);
 
     /**
      * Gets the size in bytes of the seed necessary to generate a new element

--- a/cryptography/hedera-cryptography-pairings-api/src/main/java/com/hedera/cryptography/pairings/api/PairingFriendlyCurve.java
+++ b/cryptography/hedera-cryptography-pairings-api/src/main/java/com/hedera/cryptography/pairings/api/PairingFriendlyCurve.java
@@ -29,6 +29,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public abstract class PairingFriendlyCurve {
 
     /**
+     * Constructor
+     */
+    protected PairingFriendlyCurve() { // EMPTY CONSTRUCTOR
+    }
+
+    /**
      * Implementations should include here all the steps necessary to load the library, e.g.,
      * perform native library loads.
      * This method will be called only once per instance and thread-safe guaranteed invocation.

--- a/cryptography/hedera-cryptography-pairings-api/src/testFixtures/java/com/hedera/cryptography/pairings/test/fixtures/curve/NaiveGroup.java
+++ b/cryptography/hedera-cryptography-pairings-api/src/testFixtures/java/com/hedera/cryptography/pairings/test/fixtures/curve/NaiveGroup.java
@@ -162,6 +162,15 @@ public class NaiveGroup implements Group {
                         .intValue());
     }
 
+    @NonNull
+    @Override
+    public GroupElement fromXCoordinate(@NonNull final List<BigInteger> x, final boolean isYNegative) {
+        return new NaiveGroupElement(
+                this,
+                curve.field(),
+                x.stream().reduce(BigInteger.ZERO, BigInteger::add).intValue());
+    }
+
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
**Description**:
This PR adds support for building GroupElements from their X coordinate and a flag indicating the nature of the Y coordinate.
Also, it removes some code duplicity on the rust side while adding support in Java for different modes of instantiation of group elements (accept compressed, return compressed, and do not validate)
Last, it includes a benchmark for all the groupElement operations.

**Related issue(s)**:

Fixes #[16683](https://github.com/hashgraph/hedera-services/issues/16683)

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
