### PR TITLE
ci: fix Snyk/Gradle integration / pin JDK to 21.0.4 everywhere

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 name: "Publish Release"
 
 on:
@@ -102,7 +103,7 @@ jobs:
       new-version: ${{ needs.prepare-release.outputs.version }}
       dry-run-enabled: ${{ github.event.inputs.dry-run-enabled == 'true' }}
       java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
-      java-version: ${{ github.event.inputs.java-version || '21.0.1' }}
+      java-version: ${{ github.event.inputs.java-version || '21.0.4' }}
       gradle-version: ${{ github.event.inputs.gradle-version || 'wrapper' }}
     secrets:
       gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}

--- a/.github/workflows/zxc-code-analysis.yaml
+++ b/.github/workflows/zxc-code-analysis.yaml
@@ -1,19 +1,4 @@
-##
-# Copyright (C) 2024 Hedera Hashgraph, LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-##
-
+# SPDX-License-Identifier: Apache-2.0
 name: "ZXC: Code Analysis"
 # The purpose of this reusable workflow is to perform static code analysis and code coverage reporting.
 # This reusable component is called by the following workflows:
@@ -79,7 +64,7 @@ jobs:
         if: ${{ inputs.enable-snyk-scan && !cancelled() && !failure() }}
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 21.0.4
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2

--- a/.github/workflows/zxf-snyk-monitor.yaml
+++ b/.github/workflows/zxf-snyk-monitor.yaml
@@ -1,19 +1,4 @@
-##
-# Copyright (C) 2024 Hedera Hashgraph, LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-##
-
+# SPDX-License-Identifier: Apache-2.0
 name: "ZXF: Snyk Monitor"
 # The purpose of this job is to run on each commit to the main branch and daily at midnight UTC on the most recent commit.
 # This job is not intended to be run manually, but rather to be run when triggered by either a commit or the schedule.
@@ -45,7 +30,7 @@ jobs:
         uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 21.0.4
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2
@@ -65,6 +50,13 @@ jobs:
 
       - name: Setup Snyk
         run: npm install -g snyk
+
+      # For the Snyk Gradle integration to work, the configuration cache needs to be disabled and there needs to be an
+      # (empty) build.gradle.kts in the root folder.
+      - name: Disable Gradle Configuration Cache
+        run: |
+          sed -i 's/^org.gradle.configuration-cache=.*$/org.gradle.configuration-cache=false/' gradle.properties
+          touch build.gradle.kts
 
       # This step is what actually uploads the Snyk analysis to the Snyk Cloud. The Snyk token is stored as a secret
       # in the Github repository and is passed to the Snyk CLI via the environment variable SNYK_TOKEN.


### PR DESCRIPTION
**Description**:

Follow up to #78 

These issues were only discovered on `main` as the Snyk workflow is not running on PRs.
