### PR TITLE
build: remove duplicated dependency versions

### DIFF
--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -6,17 +6,18 @@ plugins {
     id("org.hiero.gradle.check.spotless-kotlin")
 }
 
-// define versions for gradle to grab dependencies
+val junit5 = "5.10.2"
+val mockito = "5.8.0"
+
 dependencies.constraints {
     api("com.github.spotbugs:spotbugs-annotations:4.7.3") {
         because("com.github.spotbugs.annotations")
     }
-    api("org.junit.jupiter:junit-jupiter-api:5.10.2") { because("org.junit.jupiter.api") }
-    api("org.junit.jupiter:junit-jupiter-engine:5.10.2") { because("org.junit.jupiter.engine") }
-    api("org.mockito:mockito-core:5.8.0") { because("org.mockito") }
-    api("org.mockito:mockito-junit-jupiter:5.8.0") { because("org.mockito.junit.jupiter") }
-    api("org.junit.jupiter:junit-jupiter-api:5.10.2") { because("org.junit.jupiter.api") }
+    api("com.google.code.gson:gson:2.8.6") { because("com.google.gson") }
     api("jakarta.inject:jakarta.inject-api:2.0.1") { because("jakarta.inject") }
     api("org.bouncycastle:bcprov-jdk18on:1.78.1") { because("org.bouncycastle.provider") }
-    api("com.google.code.gson:gson:2.8.6") { because("com.google.gson") }
+    api("org.junit.jupiter:junit-jupiter-api:$junit5") { because("org.junit.jupiter.api") }
+    api("org.junit.jupiter:junit-jupiter-engine:$junit5") { because("org.junit.jupiter.engine") }
+    api("org.mockito:mockito-core:$mockito") { because("org.mockito") }
+    api("org.mockito:mockito-junit-jupiter:$mockito") { because("org.mockito.junit.jupiter") }
 }


### PR DESCRIPTION
**Description**:

Some versions for _dependency groups_ were defined multiple times. This let to multiple Dependabot PRs for the same versions, leading to inconsistencies between merging of the several PRs.

Each repeated version is now only defined once in a `val` in the `hiero-dependency-versions/build.gradle.kts` file. This notation is supported by Dependabot.

