### PR TITLE
ci: disable cross-version tests in Dependabot PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,7 @@ jobs:
 
   test-cross-platform:
     name: Test on ${{ matrix.os }}
+    if: ${{ github.actor != 'dependabot[bot]' }}
     needs: build
     strategy:
       matrix:


### PR DESCRIPTION
These require the 'Build software' step to write to the Gradle remote cache. But Dependabot PRs to not have write access to the cache.

I think this is a reasonable compromise as, if an updates breaks something, it is most likely in Java code.

