### PR TITLE
ci: set default java setup version and distribution when no input is provided

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -157,8 +157,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
         with:
-          distribution: ${{ inputs.java-distribution }}
-          java-version: ${{ inputs.java-version }}
+          distribution: ${{ inputs.java-distribution || 'temurin' }}
+          java-version: ${{ inputs.java-version || '21.0.4' }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2


### PR DESCRIPTION
**Description**:
This PR sets a default java version and distribution for when none are provided via inputs in the publish_release workflow. This is usually the case when the workflow is triggered with a push to main instead of manually.

**Related issue(s)**:

Fixes #195 

**Notes for reviewer**:
N/A

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
