### PR TITLE
feat: introduce HintsLibraryBridge

### DIFF
--- a/cryptography/hedera-cryptography-hinTS/src/main/java/com/hedera/cryptography/hints/Dummy.java
+++ b/cryptography/hedera-cryptography-hinTS/src/main/java/com/hedera/cryptography/hints/Dummy.java
@@ -1,4 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-package com.hedera.cryptography.hints;
-
-public class Dummy {}

--- a/cryptography/hedera-cryptography-hinTS/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
+++ b/cryptography/hedera-cryptography-hinTS/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.cryptography.hints;
+
+import com.hedera.common.nativesupport.SingletonLoader;
+
+/**
+ * A JNI Bridge for the HintsLibrary implementation as defined at
+ * https://github.com/hashgraph/hedera-services/blob/main/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/HintsLibrary.java .
+ */
+public class HintsLibraryBridge {
+    /** Instance Holder for lazy loading and concurrency handling */
+    private static final SingletonLoader<HintsLibraryBridge> INSTANCE_HOLDER =
+            new SingletonLoader<>("hints", new HintsLibraryBridge());
+
+    static {
+        // Open the package to allow access to the native library
+        // This can be done in module-info.java as well, but by default the compiler complains since there are no
+        // classes in the package, just resources
+        HintsLibraryBridge.class
+                .getModule()
+                .addOpens(INSTANCE_HOLDER.getNativeLibraryPackageName(), SingletonLoader.class.getModule());
+    }
+
+    private HintsLibraryBridge() {
+        // private constructor to ensure singleton
+    }
+
+    /**
+     * Returns the singleton instance of this library adapter.
+     *
+     * @return the singleton instance of this library adapter.
+     */
+    public static HintsLibraryBridge getInstance() {
+        return INSTANCE_HOLDER.getInstance();
+    }
+
+    /**
+     * Generates a new BLS key pair.
+     * @return the key pair
+     */
+    public native byte[] newBlsKeyPair();
+
+    /**
+     * Computes the hints for the given public key and number of parties.
+     *
+     * @param blsPrivateKey the private key
+     * @param partyId the party id
+     * @param n the number of parties
+     * @return the hints
+     */
+    public native byte[] computeHints(final byte[] blsPrivateKey, int partyId, int n);
+
+    /**
+     * Validates the hinTS public key for the given number of parties.
+     *
+     * @param hintsKey the hinTS key
+     * @param partyId the party id
+     * @param n the number of parties
+     * @return true if the hints are valid; false otherwise
+     */
+    public native boolean validateHintsKey(final byte[] hintsKey, int partyId, int n);
+
+    /**
+     * Runs the hinTS preprocessing algorithm on the given validated hint keys and party weights for the given number
+     * of parties. The output includes,
+     * <ol>
+     *     <li>The linear size aggregation key to use in combining partial signatures on a message with a provably
+     *     well-formed aggregate public key.</li>
+     *     <li>The succinct verification key to use when verifying an aggregate signature.</li>
+     * </ol>
+     * The parties, hintsKeys, and weights model the original {@code Map<Integer, Bytes> hintsKeys} and {@code
+     * Map<Integer, Long> weights} input arguments and use arrays for performance reasons.
+     * @param parties the party ids for the indices in hintsKeys and weights
+     * @param hintsKeys the valid hinTS keys by party id
+     * @param weights the weights by party id
+     * @param n the number of parties
+     * @return the preprocessed keys
+     */
+    public native byte[] preprocess(final int[] parties, final byte[][] hintsKeys, final long[] weights, int n);
+
+    /**
+     * Signs a message with a BLS private key.
+     *
+     * @param message the message
+     * @param privateKey the private key
+     * @return the signature
+     */
+    public native byte[] signBls(final byte[] message, final byte[] privateKey);
+
+    /**
+     * Checks that a signature on a message verifies under a BLS public key.
+     *
+     * @param signature the signature
+     * @param message the message
+     * @param publicKey the public key
+     * @return true if the signature is valid; false otherwise
+     */
+    public native boolean verifyBls(final byte[] signature, final byte[] message, final byte[] publicKey);
+
+    /**
+     * Aggregates the signatures for party ids using hinTS aggregation and verification keys.
+     *
+     * @param aggregationKey the aggregation key
+     * @param verificationKey the verification key
+     * @param parties the party ids for the partialSignatures array
+     * @param partialSignatures the partial signatures by party id
+     * @return the aggregated signature
+     */
+    public native byte[] aggregateSignatures(
+            byte[] aggregationKey, byte[] verificationKey, int[] parties, byte[][] partialSignatures);
+
+    /**
+     * Checks an aggregate signature on a message verifies under a hinTS verification key, where
+     * this is only true if the aggregate signature has weight exceeding the specified threshold
+     * or total weight stipulated in the verification key.
+     *
+     * @param signature the aggregate signature
+     * @param message the message
+     * @param verificationKey the verification key
+     * @param thresholdNumerator the numerator of a fraction of total weight the signature must have
+     * @param thresholdDenominator the denominator of a fraction of total weight the signature must have
+     * @return true if the signature is valid; false otherwise
+     */
+    public native boolean verifyAggregate(
+            byte[] signature,
+            byte[] message,
+            byte[] verificationKey,
+            long thresholdNumerator,
+            long thresholdDenominator);
+}

--- a/cryptography/hedera-cryptography-hinTS/src/main/java/module-info.java
+++ b/cryptography/hedera-cryptography-hinTS/src/main/java/module-info.java
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  */
-module com.hedera.cryptography.hints {}
+module com.hedera.cryptography.hints {
+    exports com.hedera.cryptography.hints;
+
+    requires com.hedera.common.nativesupport;
+}


### PR DESCRIPTION
**Description**:
Introducing the `HintsLibraryBridge` class that implements a JNI bridge for the HintsLibrary implementation. Please note that the corresponding native Rust methods will be implemented in a separate PR under a separate story: https://github.com/hashgraph/hedera-cryptography/issues/218

**Related issue(s)**:

Fixes #217 

**Notes for reviewer**:
`gr build` succeeds.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
