### PR TITLE
build: bump hiero-gradle-conventions to 0.3.2 / Gradle to 8.12.1

### DIFF
--- a/cryptography/hedera-cryptography-altbn128/Cargo.toml
+++ b/cryptography/hedera-cryptography-altbn128/Cargo.toml
@@ -29,5 +29,5 @@ ark-bn254 = { version = "0.4.0", default-features = false, features = [ "curve" 
 ark-serialize = { version = "^0.4.2", default-features = true }
 jni = "0.21.1"
 
-rand = "*"
-rand_chacha = "*"
+rand = "0.8.5"
+rand_chacha = "0.3.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-plugins { id("org.hiero.gradle.build") version "0.3.0" }
+plugins { id("org.hiero.gradle.build") version "0.3.2" }
 
 rootProject.name = "hedera-cryptography"
 


### PR DESCRIPTION
**Description**:

This update improves the performance of the Rust toolchain installation. It is now done only once (and not once per Module) and the Cargo cache is preserved between different rust compile task, speeding up the build time of successive runs.

**Related issue(s)**:

Makes issues in #245 easier to analyze
