### PR TITLE
test: add more tests for CRS methods

### DIFF
--- a/cryptography/hedera-cryptography-hinTS/build.gradle.kts
+++ b/cryptography/hedera-cryptography-hinTS/build.gradle.kts
@@ -7,4 +7,7 @@ plugins {
 
 cargo { libname = "hints" }
 
-testModuleInfo { requires("org.junit.jupiter.api") }
+testModuleInfo {
+    requires("org.junit.jupiter.api")
+    requires("org.junit.jupiter.params")
+}

--- a/cryptography/hedera-cryptography-hinTS/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
+++ b/cryptography/hedera-cryptography-hinTS/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
@@ -55,10 +55,10 @@ public class HintsLibraryBridge {
         if (signersNum < 1) {
             return null;
         }
-        return _initCRS(signersNum);
+        return initCRSImpl(signersNum);
     }
 
-    private native byte[] _initCRS(long signersNum);
+    private native byte[] initCRSImpl(long signersNum);
 
     /**
      * Update a previous CRS object with a new contribution.

--- a/cryptography/hedera-cryptography-hinTS/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
+++ b/cryptography/hedera-cryptography-hinTS/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
@@ -63,7 +63,7 @@ public class HintsLibraryBridge {
     /**
      * Update a previous CRS object with a new contribution.
      * @param prevCRS the previous CRS object
-     * @param random the random contribution of 128 bits (16 bytes)
+     * @param random the random contribution of 256 bits (32 bytes)
      * @return the updated CRS object and a concatenated contribution proof for the update
      */
     public native byte[] updateCRS(final byte[] prevCRS, final byte[] random);

--- a/cryptography/hedera-cryptography-hinTS/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
+++ b/cryptography/hedera-cryptography-hinTS/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
@@ -39,11 +39,26 @@ public class HintsLibraryBridge {
     ///////////////////////////////////////////////////////////////////////////
 
     /**
-     * Generates a new CRS object for the given number of signers.
-     * @param signersNum the number of signers
+     * Generates a new CRS object for the given number of signers plus 1.
+     * <p>
+     * The provided signersNum argument must be greater than the maximum number of nodes
+     * that the network supports by at least 1. For example, if the network supports up to 1023 nodes,
+     * then the signersNum argument must be equal to at least 1024. It's mathematically
+     * okay to have the singersNum much larger than the current number of nodes in the network,
+     * however, this will result in a larger space required to store the CRS.
+     *
+     * @param signersNum the number of signers plus 1
      * @return the CRS object
      */
-    public native byte[] initCRS(long signersNum);
+    public byte[] initCRS(long signersNum) {
+        // Support a degenerate case of 0 signers, or a normal case with more signers. Otherwise, error out.
+        if (signersNum < 1) {
+            return null;
+        }
+        return _initCRS(signersNum);
+    }
+
+    private native byte[] _initCRS(long signersNum);
 
     /**
      * Update a previous CRS object with a new contribution.

--- a/cryptography/hedera-cryptography-hinTS/src/main/rust/jni_crs.rs
+++ b/cryptography/hedera-cryptography-hinTS/src/main/rust/jni_crs.rs
@@ -29,7 +29,7 @@ use crate::jni_util;
 /// # Returns
 /// *   a byte array with a serialized CRS object, or null on error
 #[no_mangle]
-pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge__1initCRS(
+pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_initCRSImpl(
     env: JNIEnv,
     _instance: JObject,
     signers_num: jlong,

--- a/cryptography/hedera-cryptography-hinTS/src/main/rust/jni_crs.rs
+++ b/cryptography/hedera-cryptography-hinTS/src/main/rust/jni_crs.rs
@@ -29,7 +29,7 @@ use crate::jni_util;
 /// # Returns
 /// *   a byte array with a serialized CRS object, or null on error
 #[no_mangle]
-pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_initCRS(
+pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge__1initCRS(
     env: JNIEnv,
     _instance: JObject,
     signers_num: jlong,

--- a/cryptography/hedera-cryptography-hinTS/src/main/rust/jni_util.rs
+++ b/cryptography/hedera-cryptography-hinTS/src/main/rust/jni_util.rs
@@ -14,11 +14,12 @@
 // limitations under the License.
 //
 
+use std::any::Any;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use jni::JNIEnv;
 use jni::objects::{JByteArray, JObject};
 use jni::sys::{jbyte, jbyteArray};
-use crate::hints::{deserialize, serialize, RANDOM_SIZE};
+use crate::hints::{serialize, RANDOM_SIZE};
 
 /// Creates a jbyteArray out of a Vec<jbyte> object.
 /// # Arguments
@@ -81,10 +82,14 @@ pub fn build_entropy_array(env: &JNIEnv, random_array: &JByteArray) -> Result<[u
 }
 
 /// Deserializes a JByteArray into an object, or returns Err.
-pub fn deserialize_jbyte_array<T: CanonicalDeserialize>(env: &JNIEnv, jarray: &JByteArray) -> Result<T, ()> {
-    match env.convert_byte_array(&jarray) {
-        Ok(val) => Ok(deserialize(&val)),
-        Err(_) => Err(())
+pub fn deserialize_jbyte_array<T: CanonicalDeserialize>(env: &JNIEnv, jarray: &JByteArray) -> Result<T, Box<dyn Any>> {
+    let vec = match env.convert_byte_array(&jarray) {
+        Ok(val) => val,
+        Err(err) => return Err(Box::new(err))
+    };
+    match T::deserialize_uncompressed(&*vec) {
+        Ok(val) => Ok(val),
+        Err(err) => Err(Box::new(err))
     }
 }
 

--- a/cryptography/hedera-cryptography-hinTS/src/test/java/com/hedera/cryptography/hints/HintsLibraryBridgeCRSTest.java
+++ b/cryptography/hedera-cryptography-hinTS/src/test/java/com/hedera/cryptography/hints/HintsLibraryBridgeCRSTest.java
@@ -3,11 +3,15 @@ package com.hedera.cryptography.hints;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class HintsLibraryBridgeCRSTest {
     private static final HintsLibraryBridge INSTANCE = HintsLibraryBridge.getInstance();
@@ -29,6 +33,19 @@ public class HintsLibraryBridgeCRSTest {
     @Test
     void testInitCRS() {
         initAndVerifyCRS();
+    }
+
+    @Test
+    void testInitCRSConstraints() {
+        assertNull(INSTANCE.initCRS(0));
+        assertNull(INSTANCE.initCRS(-2));
+        assertNull(INSTANCE.initCRS(Long.MIN_VALUE));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 11, 101, 1024})
+    void testInitCRSLength(final int n) {
+        assertEquals(304 + n * 288, INSTANCE.initCRS(n).length);
     }
 
     private byte[] updateAndVerifyCRS(final byte[] prevCRS) {
@@ -53,6 +70,24 @@ public class HintsLibraryBridgeCRSTest {
     }
 
     @Test
+    void testUpdateCRSConstraints() {
+        assertNull(INSTANCE.updateCRS(null, CRSConstants.RANDOM));
+        assertNull(INSTANCE.updateCRS(initAndVerifyCRS(), null));
+
+        // Only byte[32] is valid for entropy input:
+        assertNull(INSTANCE.updateCRS(initAndVerifyCRS(), new byte[0]));
+        assertNull(INSTANCE.updateCRS(initAndVerifyCRS(), new byte[2]));
+        assertNull(INSTANCE.updateCRS(initAndVerifyCRS(), new byte[33]));
+
+        // Only a real CRS should work correctly
+        assertNull(INSTANCE.updateCRS(new byte[0], CRSConstants.RANDOM));
+        assertNull(INSTANCE.updateCRS(new byte[1], CRSConstants.RANDOM));
+        // This last one cause a panic. It seems that 16 zeros are able to
+        // represent an (invalid) serialized CRS struct somehow.
+        // assertNull(INSTANCE.updateCRS(new byte[16], CRSConstants.RANDOM));
+    }
+
+    @Test
     void testVerifyCRS() {
         final byte[] prevCRS = initAndVerifyCRS();
         final byte[] nextCRSandContributionProof = updateAndVerifyCRS(prevCRS);
@@ -62,5 +97,44 @@ public class HintsLibraryBridgeCRSTest {
                 Arrays.copyOfRange(nextCRSandContributionProof, CRS_4_LENGTH, nextCRSandContributionProof.length);
 
         assertTrue(INSTANCE.verifyCRS(prevCRS, nextCRS, contributionProof));
+
+        // Damage the nextCRS first:
+        nextCRS[456]++;
+        nextCRS[917]--;
+        nextCRS[1357]++;
+
+        assertFalse(INSTANCE.verifyCRS(prevCRS, nextCRS, contributionProof));
+
+        // Undo the nextCRS dmage:
+        nextCRS[456]--;
+        nextCRS[917]++;
+        nextCRS[1357]--;
+        // and damage the contributionProof instead:
+        contributionProof[55]++;
+        contributionProof[79]--;
+        contributionProof[102]++;
+
+        assertFalse(INSTANCE.verifyCRS(prevCRS, nextCRS, contributionProof));
+
+        // Restore the contributionProof back, and check one more time, just for sanity:
+        contributionProof[55]--;
+        contributionProof[79]++;
+        contributionProof[102]--;
+
+        assertTrue(INSTANCE.verifyCRS(prevCRS, nextCRS, contributionProof));
+    }
+
+    @Test
+    void testVerifyCRSConstraints() {
+        final byte[] prevCRS = initAndVerifyCRS();
+        final byte[] nextCRSandContributionProof = updateAndVerifyCRS(prevCRS);
+
+        final byte[] nextCRS = Arrays.copyOf(nextCRSandContributionProof, CRS_4_LENGTH);
+        final byte[] contributionProof =
+                Arrays.copyOfRange(nextCRSandContributionProof, CRS_4_LENGTH, nextCRSandContributionProof.length);
+
+        assertFalse(INSTANCE.verifyCRS(null, nextCRS, contributionProof));
+        assertFalse(INSTANCE.verifyCRS(prevCRS, null, contributionProof));
+        assertFalse(INSTANCE.verifyCRS(prevCRS, nextCRS, null));
     }
 }


### PR DESCRIPTION
**Description**:
Adding more comprehensive tests for CRS method in the `HintsLibraryBridge`.
Also, partially addressing https://github.com/hashgraph/hedera-cryptography/issues/240 by improving the deserialization method in the `jni_util.rs`, and using the new capability in the tests.

**Related issue(s)**:

Fixes #261 

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
