### PR TITLE
fix: build error in hints test

### DIFF
--- a/cryptography/hedera-cryptography-hinTS/src/main/rust/setup.rs
+++ b/cryptography/hedera-cryptography-hinTS/src/main/rust/setup.rs
@@ -270,7 +270,7 @@ mod tests {
         // serialization test
         assert_eq!(
             next_next_crs,
-            CRS::deserialize_uncompressed(&crate::hints::serialize(&next_next_crs)).unwrap()
+            CRS::deserialize_uncompressed(crate::hints::serialize(&next_next_crs).as_slice()).unwrap()
         );
     }
 }

--- a/cryptography/hedera-cryptography-rpm/build.gradle.kts
+++ b/cryptography/hedera-cryptography-rpm/build.gradle.kts
@@ -12,3 +12,5 @@ testModuleInfo {
     requires("org.junit.jupiter.params")
     requires("com.hedera.cryptography.hints")
 }
+
+tasks.test { environment(mapOf("TSS_LIB_NUM_OF_CORES" to "10")) }


### PR DESCRIPTION
**Description**:
This PR fixes a build error in a test case, likely introduced by a change to our serialization primitives. This is a rust test, and not executed by `gradle build`, which is perhaps why it went undetected.

Also, changes the gradle build to use up to 10 threads for the test, as restricting to a single core slows the build down to over an hour -- thanks to @anthony-swirldslabs for the suggestion.
