### PR TITLE
feat: overhaul HintsLibraryBridge.verifyBls()

### DIFF
--- a/cryptography/hedera-cryptography-hinTS/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
+++ b/cryptography/hedera-cryptography-hinTS/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
@@ -196,26 +196,36 @@ public class HintsLibraryBridge {
      * @param crs the CRS object
      * @param signature the signature
      * @param message the message
-     * @param extendedPublicKey the extended public key
+     * @param aggregationKey the extended public key
+     * @param partyId the party id whose public key from the aggregationKey should be used for verifying the signature
      * @return true if the signature is valid; false otherwise
      */
     public boolean verifyBls(
-            final byte[] crs, final byte[] signature, final byte[] message, final byte[] extendedPublicKey) {
+            final byte[] crs,
+            final byte[] signature,
+            final byte[] message,
+            final byte[] aggregationKey,
+            final int partyId) {
         if (crs == null
                 || crs.length == 0
                 || signature == null
                 || signature.length == 0
                 || message == null
                 || message.length == 0
-                || extendedPublicKey == null
-                || extendedPublicKey.length == 0) {
+                || aggregationKey == null
+                || aggregationKey.length == 0
+                || !validatePartyId(partyId, inferNFromCRSLength(crs))) {
             return false;
         }
-        return verifyBlsImpl(crs, signature, message, extendedPublicKey);
+        return verifyBlsImpl(crs, signature, message, aggregationKey, partyId);
     }
 
     private native boolean verifyBlsImpl(
-            final byte[] crs, final byte[] signature, final byte[] message, final byte[] extendedPublicKey);
+            final byte[] crs,
+            final byte[] signature,
+            final byte[] message,
+            final byte[] aggregationKey,
+            final int partyId);
 
     /**
      * Aggregates the signatures for party ids using hinTS aggregation and verification keys.
@@ -302,6 +312,13 @@ public class HintsLibraryBridge {
     // Returns true if the n is a positive power of two, and the crs isn't null and its length matches the n.
     private static boolean validateCRS(final byte[] crs, final int n) {
         return n > 0 && (n & (n - 1)) == 0 && crs != null && crs.length == (304 + n * 288);
+    }
+
+    private static int inferNFromCRSLength(final byte[] crs) {
+        if (crs == null) {
+            return -1;
+        }
+        return (crs.length - 304) / 288;
     }
 
     // Returns true if 0 <= partiyId < n.

--- a/cryptography/hedera-cryptography-hinTS/src/main/rust/hints.rs
+++ b/cryptography/hedera-cryptography-hinTS/src/main/rust/hints.rs
@@ -402,8 +402,14 @@ impl HinTS {
     }
 
     /// verifies the partial signature under the signer's public key
-    pub fn partial_verify(crs: &CRS, msg: &[u8], epk: &ExtendedPublicKey, sig: &PartialSignature) -> bool {
-        let lhs = <Curve as Pairing>::pairing(epk.pk_i, hash_to_g2(msg));
+    pub fn partial_verify(
+        crs: &CRS,
+        msg: &[u8],
+        ak: &AggregationKey,
+        party_id: usize,
+        sig: &PartialSignature
+    ) -> bool {
+        let lhs = <Curve as Pairing>::pairing(ak.pks[party_id], hash_to_g2(msg));
         let rhs = <Curve as Pairing>::pairing(crs.powers_of_g[0], sig);
         lhs == rhs
     }

--- a/cryptography/hedera-cryptography-hinTS/src/main/rust/jni_hints.rs
+++ b/cryptography/hedera-cryptography-hinTS/src/main/rust/jni_hints.rs
@@ -187,7 +187,8 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_ver
     crs_jarray: JByteArray,
     signature_jarray: JByteArray,
     message_jarray: JByteArray,
-    extended_public_key_jarray: JByteArray,
+    aggregation_key_jarray: JByteArray,
+    party_id: jint
 ) -> jboolean {
     let crs: CRS = match jni_util::deserialize_jbyte_array(&env, &crs_jarray) {
         Ok(val) => val,
@@ -199,7 +200,7 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_ver
         Err(_) => return jboolean::from(false)
     };
 
-    let extended_public_key: ExtendedPublicKey = match jni_util::deserialize_jbyte_array(&env, &extended_public_key_jarray) {
+    let aggregation_key: AggregationKey = match jni_util::deserialize_jbyte_array(&env, &aggregation_key_jarray) {
         Ok(val) => val,
         Err(_) => return jboolean::from(false)
     };
@@ -209,7 +210,7 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_ver
         Err(_) => return jboolean::from(false)
     };
 
-    jboolean::from(HinTS::partial_verify(&crs, &message, &extended_public_key, &signature))
+    jboolean::from(HinTS::partial_verify(&crs, &message, &aggregation_key, party_id as usize, &signature))
 }
 
 /// JNI for HintsLibraryBridge.aggregateSignatures

--- a/cryptography/hedera-cryptography-hinTS/src/test/java/com/hedera/cryptography/hints/HintsLibraryBridgeTest.java
+++ b/cryptography/hedera-cryptography-hinTS/src/test/java/com/hedera/cryptography/hints/HintsLibraryBridgeTest.java
@@ -270,37 +270,47 @@ public class HintsLibraryBridgeTest {
         final byte[] secretKey = INSTANCE.generateSecretKey(HintsConstants.RANDOM_2);
         assertArrayEquals(HintsConstants.SECRET_KEY, secretKey);
 
-        final byte[] hints = INSTANCE.computeHints(crs, secretKey, 2, 4);
+        final int partyId = 2;
+
+        final byte[] hints = INSTANCE.computeHints(crs, secretKey, partyId, 4);
         assertArrayEquals(HintsConstants.HINTS, hints);
+
+        final AggregationAndVerificationKeys keys =
+                INSTANCE.preprocess(crs, new int[] {partyId}, new byte[][] {hints}, new long[] {111}, 4);
 
         // Use the RANDOM as a message to sign, because why not?
         final byte[] signature = INSTANCE.signBls(HintsConstants.RANDOM_2, secretKey);
         assertArrayEquals(HintsConstants.SIGNATURE, signature);
 
-        assertTrue(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, hints));
+        assertTrue(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
     }
 
     @Test
     void testVerifyBlsConstraints() {
         final byte[] crs = INSTANCE.initCRS(4);
         final byte[] secretKey = INSTANCE.generateSecretKey(HintsConstants.RANDOM_2);
-        final byte[] hints = INSTANCE.computeHints(crs, secretKey, 2, 4);
+        final int partyId = 2;
+        final byte[] hints = INSTANCE.computeHints(crs, secretKey, partyId, 4);
+        final AggregationAndVerificationKeys keys =
+                INSTANCE.preprocess(crs, new int[] {partyId}, new byte[][] {hints}, new long[] {111}, 4);
         final byte[] signature = INSTANCE.signBls(HintsConstants.RANDOM_2, secretKey);
 
-        assertFalse(INSTANCE.verifyBls(null, signature, HintsConstants.RANDOM_2, hints));
-        assertFalse(INSTANCE.verifyBls(EMPTY, signature, HintsConstants.RANDOM_2, hints));
-        assertFalse(INSTANCE.verifyBls(crs, null, HintsConstants.RANDOM_2, hints));
-        assertFalse(INSTANCE.verifyBls(crs, EMPTY, HintsConstants.RANDOM_2, hints));
-        assertFalse(INSTANCE.verifyBls(crs, signature, null, hints));
-        assertFalse(INSTANCE.verifyBls(crs, signature, EMPTY, hints));
-        assertFalse(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, null));
-        assertFalse(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, EMPTY));
+        assertFalse(INSTANCE.verifyBls(null, signature, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
+        assertFalse(INSTANCE.verifyBls(EMPTY, signature, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
+        assertFalse(INSTANCE.verifyBls(crs, null, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
+        assertFalse(INSTANCE.verifyBls(crs, EMPTY, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
+        assertFalse(INSTANCE.verifyBls(crs, signature, null, keys.aggregationKey(), partyId));
+        assertFalse(INSTANCE.verifyBls(crs, signature, EMPTY, keys.aggregationKey(), partyId));
+        assertFalse(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, null, partyId));
+        assertFalse(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, EMPTY, partyId));
+        assertFalse(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, keys.aggregationKey(), -1));
+        assertFalse(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, keys.aggregationKey(), 666));
 
         // corrupt the CRS
         crs[27]++;
         crs[172]--;
         crs[387]++;
-        assertFalse(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, hints));
+        assertFalse(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
 
         // uncorrupt the CRS...
         crs[27]--;
@@ -308,21 +318,21 @@ public class HintsLibraryBridgeTest {
         crs[387]--;
         // and corrupt the signature
         signature[23]++;
-        assertFalse(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, hints));
+        assertFalse(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
 
         // undo the signature...
         signature[23]--;
-        // and corrupt the hints instead
-        hints[17]++;
-        hints[111]--;
-        hints[302]++;
-        assertFalse(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, hints));
+        // and corrupt the aggregationKey instead
+        keys.aggregationKey()[17]++;
+        keys.aggregationKey()[111]--;
+        keys.aggregationKey()[302]++;
+        assertFalse(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
 
-        // uncorrupt the hints and do a sanity check
-        hints[17]--;
-        hints[111]++;
-        hints[302]--;
-        assertTrue(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, hints));
+        // uncorrupt the aggregationKey and do a sanity check
+        keys.aggregationKey()[17]--;
+        keys.aggregationKey()[111]++;
+        keys.aggregationKey()[302]--;
+        assertTrue(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
     }
 
     @Test

--- a/cryptography/hedera-cryptography-rpm/build.gradle.kts
+++ b/cryptography/hedera-cryptography-rpm/build.gradle.kts
@@ -12,3 +12,5 @@ testModuleInfo {
     requires("org.junit.jupiter.params")
     requires("com.hedera.cryptography.hints")
 }
+
+tasks.test { environment(mapOf("TSS_LIB_NUM_OF_CORES" to "10")) }


### PR DESCRIPTION
**Description**:
Overhauling the `HintsLibraryBridge.verifyBls()` to accept an AggregateKey and a partyId instead of accepting an extendedPublicKey.

In `cryptography/hedera-cryptography-rpm/build.gradle.kts`, I'm increasing the number of threads that unit tests can use when running the tests in GitHub runners or on local desktops. This allows the tests to complete in a reasonable time rather than take hours.

**Related issue(s)**:

Fixes #285

**Notes for reviewer**:
All tests pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
