### PR TITLE
fix: update CRS and n validation

### DIFF
--- a/cryptography/hedera-cryptography-hinTS/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
+++ b/cryptography/hedera-cryptography-hinTS/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
@@ -309,9 +309,10 @@ public class HintsLibraryBridge {
             long thresholdNumerator,
             long thresholdDenominator);
 
-    // Returns true if the n is a positive power of two, and the crs isn't null and its length matches the n.
+    // Returns true if the n is a positive power of two, and the crs isn't null and its length matches or is greater
+    // than the n.
     private static boolean validateCRS(final byte[] crs, final int n) {
-        return n > 0 && (n & (n - 1)) == 0 && crs != null && crs.length == (304 + n * 288);
+        return n > 0 && (n & (n - 1)) == 0 && crs != null && crs.length >= (304 + n * 288);
     }
 
     private static int inferNFromCRSLength(final byte[] crs) {

--- a/cryptography/hedera-cryptography-hinTS/src/test/java/com/hedera/cryptography/hints/HintsLibraryBridgeTest.java
+++ b/cryptography/hedera-cryptography-hinTS/src/test/java/com/hedera/cryptography/hints/HintsLibraryBridgeTest.java
@@ -50,8 +50,10 @@ public class HintsLibraryBridgeTest {
         assertNull(INSTANCE.computeHints(crs, secretKey, 2, 3));
         assertNull(INSTANCE.computeHints(crs, secretKey, 2, 5));
 
-        // n must match the CRS size
+        // n must match the CRS size...
         assertNull(INSTANCE.computeHints(crs, secretKey, 2, 8));
+        // ...or be smaller than the CRS size, but should still be a positive power of two
+        assertNotNull(INSTANCE.computeHints(crs, secretKey, 0, 2));
 
         // 0 <= partyId < n
         assertNull(INSTANCE.computeHints(crs, secretKey, -1, 4));


### PR DESCRIPTION
**Description**:
Per a discussion with @Neeharika-Sompalli and @rsinha , we determined that the existing validation for CRS length and `n` is incorrect. This fix updates it making it possible to pass values of `n` that are still positive powers-of-two but may be smaller than the `signersNum` with which the CRS was initially generated. This is to allow for optimized computations in smaller networks which can still re-use a CRS generated for a potentially very large network size.

**Related issue(s)**:

Fixes #295

**Notes for reviewer**:
Also updating a test to verify the new constraint.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
