### PR TITLE
chore: updating license on all rust sources

### DIFF
--- a/cryptography/hedera-cryptography-hinTS/src/main/rust/errors.rs
+++ b/cryptography/hedera-cryptography-hinTS/src/main/rust/errors.rs
@@ -1,17 +1,4 @@
-//
-// Copyright (C) 2024 Hedera Hashgraph, LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 use std::error::Error;
 use std::fmt;

--- a/cryptography/hedera-cryptography-hinTS/src/main/rust/hints.rs
+++ b/cryptography/hedera-cryptography-hinTS/src/main/rust/hints.rs
@@ -1,17 +1,4 @@
-//
-// Copyright (C) 2024 Hedera Hashgraph, LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 use ark_bls12_381::{g1::Config as G1Config, g2::Config as G2Config, Bls12_381};
 use ark_ec::hashing::{

--- a/cryptography/hedera-cryptography-hinTS/src/main/rust/jni_crs.rs
+++ b/cryptography/hedera-cryptography-hinTS/src/main/rust/jni_crs.rs
@@ -1,18 +1,4 @@
-//
-// Copyright (C) 2025 Hedera Hashgraph, LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// SPDX-License-Identifier: Apache-2.0
 
 use jni::objects::{JByteArray, JObject};
 use jni::sys::{jlong, jbyteArray, jboolean};

--- a/cryptography/hedera-cryptography-hinTS/src/main/rust/jni_hints.rs
+++ b/cryptography/hedera-cryptography-hinTS/src/main/rust/jni_hints.rs
@@ -1,18 +1,4 @@
-//
-// Copyright (C) 2025 Hedera Hashgraph, LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
 use jni::JNIEnv;

--- a/cryptography/hedera-cryptography-hinTS/src/main/rust/jni_util.rs
+++ b/cryptography/hedera-cryptography-hinTS/src/main/rust/jni_util.rs
@@ -1,18 +1,4 @@
-//
-// Copyright (C) 2025 Hedera Hashgraph, LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// SPDX-License-Identifier: Apache-2.0
 
 use std::any::Any;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};

--- a/cryptography/hedera-cryptography-hinTS/src/main/rust/kzg.rs
+++ b/cryptography/hedera-cryptography-hinTS/src/main/rust/kzg.rs
@@ -1,17 +1,4 @@
-//
-// Copyright (C) 2024 Hedera Hashgraph, LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 //adapted from https://github.com/arkworks-rs/poly-commit/blob/master/src/kzg10/mod.rs
 #![allow(dead_code)]

--- a/cryptography/hedera-cryptography-hinTS/src/main/rust/lib.rs
+++ b/cryptography/hedera-cryptography-hinTS/src/main/rust/lib.rs
@@ -1,17 +1,4 @@
-//
-// Copyright (C) 2024 Hedera Hashgraph, LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 pub mod hints;
 pub mod jni_crs;

--- a/cryptography/hedera-cryptography-hinTS/src/main/rust/setup.rs
+++ b/cryptography/hedera-cryptography-hinTS/src/main/rust/setup.rs
@@ -1,17 +1,4 @@
-//
-// Copyright (C) 2024 Hedera Hashgraph, LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 /// module responsible for generating the CRS
 /// implements the algorithm in https://eprint.iacr.org/2022/1592.pdf

--- a/cryptography/hedera-cryptography-hinTS/src/main/rust/utils.rs
+++ b/cryptography/hedera-cryptography-hinTS/src/main/rust/utils.rs
@@ -1,17 +1,4 @@
-//
-// Copyright (C) 2024 Hedera Hashgraph, LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 use ark_ff::PrimeField;
 use ark_poly::{

--- a/cryptography/hedera-cryptography-rpm/src/main/rust/common/src/address_book.rs
+++ b/cryptography/hedera-cryptography-rpm/src/main/rust/common/src/address_book.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use derive_more::derive::Deref;
 use serde::{Deserialize, Serialize};
 use serde_big_array::Array;

--- a/cryptography/hedera-cryptography-rpm/src/main/rust/common/src/ed25519.rs
+++ b/cryptography/hedera-cryptography-rpm/src/main/rust/common/src/ed25519.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use derive_more::derive::Deref;
 use serde::{Deserialize, Serialize};
 use serde_big_array::Array;

--- a/cryptography/hedera-cryptography-rpm/src/main/rust/common/src/errors.rs
+++ b/cryptography/hedera-cryptography-rpm/src/main/rust/common/src/errors.rs
@@ -1,17 +1,4 @@
-//
-// Copyright (C) 2024 Hedera Hashgraph, LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 use std::error::Error;
 use std::fmt;

--- a/cryptography/hedera-cryptography-rpm/src/main/rust/common/src/lib.rs
+++ b/cryptography/hedera-cryptography-rpm/src/main/rust/common/src/lib.rs
@@ -1,4 +1,5 @@
-// TODO: better error types
+// SPDX-License-Identifier: Apache-2.0
+
 #![allow(clippy::result_unit_err)]
 
 use alloy_sol_types::sol;

--- a/cryptography/hedera-cryptography-rpm/src/main/rust/common/src/sha256.rs
+++ b/cryptography/hedera-cryptography-rpm/src/main/rust/common/src/sha256.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use sha2::{Digest, Sha256};
 
 pub const HASH_LENGTH: usize = 32;

--- a/cryptography/hedera-cryptography-rpm/src/main/rust/common/src/statement.rs
+++ b/cryptography/hedera-cryptography-rpm/src/main/rust/common/src/statement.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{address_book::AddressBook, address_book::Signatures};
 use serde::{Deserialize, Serialize};
 use crate::sha256::HASH_LENGTH;

--- a/cryptography/hedera-cryptography-rpm/src/main/rust/raps/src/jni_history.rs
+++ b/cryptography/hedera-cryptography-rpm/src/main/rust/raps/src/jni_history.rs
@@ -1,18 +1,4 @@
-//
-// Copyright (C) 2025 Hedera Hashgraph, LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// SPDX-License-Identifier: Apache-2.0
 
 use std::env;
 use jni::objects::{JByteArray, JLongArray, JObject, JObjectArray, JValue};

--- a/cryptography/hedera-cryptography-rpm/src/main/rust/raps/src/jni_util.rs
+++ b/cryptography/hedera-cryptography-rpm/src/main/rust/raps/src/jni_util.rs
@@ -1,18 +1,4 @@
-//
-// Copyright (C) 2025 Hedera Hashgraph, LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// SPDX-License-Identifier: Apache-2.0
 
 use ab_rotation_lib::ed25519::{VerifyingKey, ENTROPY_SIZE, PUBLIC_KEY_LENGTH};
 use jni::JNIEnv;

--- a/cryptography/hedera-cryptography-rpm/src/main/rust/raps/src/lib.rs
+++ b/cryptography/hedera-cryptography-rpm/src/main/rust/raps/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod raps;
 mod jni_util;
 pub mod jni_history;

--- a/cryptography/hedera-cryptography-rpm/src/main/rust/raps/src/raps.rs
+++ b/cryptography/hedera-cryptography-rpm/src/main/rust/raps/src/raps.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use ab_rotation_lib::{
     address_book::{AddressBook, Signatures},
     ed25519::{Signature, SigningKey, VerifyingKey, ENTROPY_SIZE},

--- a/cryptography/hedera-cryptography-rpm/src/main/rust/zkvm_program/src/main.rs
+++ b/cryptography/hedera-cryptography-rpm/src/main/rust/zkvm_program/src/main.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // These two lines are necessary for the program to properly compile.
 //
 // Under the hood, we wrap your main function with some extra code so that it behaves properly


### PR DESCRIPTION
**Description**:
Adding `SPDX-License-Identifier: Apache-2.0` to all source files with older copyright description.
