### PR TITLE
fix: removing use of CRS in partial signature verification

### DIFF
--- a/cryptography/hedera-cryptography-hinTS/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
+++ b/cryptography/hedera-cryptography-hinTS/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
@@ -193,7 +193,6 @@ public class HintsLibraryBridge {
     /**
      * Checks that a signature on a message verifies under a BLS public key.
      *
-     * @param crs the CRS object
      * @param signature the signature
      * @param message the message
      * @param aggregationKey the extended public key
@@ -201,36 +200,24 @@ public class HintsLibraryBridge {
      * @return true if the signature is valid; false otherwise
      */
     public boolean verifyBls(
-            final byte[] crs,
-            final byte[] signature,
-            final byte[] message,
-            final byte[] aggregationKey,
-            final int partyId) {
-        if (crs == null
-                || crs.length == 0
-                || signature == null
+            final byte[] signature, final byte[] message, final byte[] aggregationKey, final int partyId) {
+        if (signature == null
                 || signature.length == 0
                 || message == null
                 || message.length == 0
                 || aggregationKey == null
-                || aggregationKey.length == 0
-                || !validatePartyId(partyId, inferNFromCRSLength(crs))) {
+                || aggregationKey.length == 0) {
             return false;
         }
-        return verifyBlsImpl(crs, signature, message, aggregationKey, partyId);
+        return verifyBlsImpl(signature, message, aggregationKey, partyId);
     }
 
     private native boolean verifyBlsImpl(
-            final byte[] crs,
-            final byte[] signature,
-            final byte[] message,
-            final byte[] aggregationKey,
-            final int partyId);
+            final byte[] signature, final byte[] message, final byte[] aggregationKey, final int partyId);
 
     /**
      * Checks that a batch of signatures on a message verifies under a BLS public key.
      *
-     * @param crs the CRS object
      * @param message the message
      * @param aggregationKey the extended public key
      * @param parties the party ids for the partialSignatures array
@@ -238,14 +225,8 @@ public class HintsLibraryBridge {
      * @return true if the signature is valid; false otherwise
      */
     public boolean verifyBlsBatch(
-            final byte[] crs,
-            final byte[] message,
-            final byte[] aggregationKey,
-            final int[] parties,
-            final byte[][] partialSignatures) {
-        if (crs == null
-                || crs.length == 0
-                || message == null
+            final byte[] message, final byte[] aggregationKey, final int[] parties, final byte[][] partialSignatures) {
+        if (message == null
                 || message.length == 0
                 || aggregationKey == null
                 || aggregationKey.length == 0
@@ -256,15 +237,11 @@ public class HintsLibraryBridge {
                 || parties.length != partialSignatures.length) {
             return false;
         }
-        return verifyBlsBatchImpl(crs, message, aggregationKey, parties, partialSignatures);
+        return verifyBlsBatchImpl(message, aggregationKey, parties, partialSignatures);
     }
 
     private native boolean verifyBlsBatchImpl(
-            final byte[] crs,
-            final byte[] message,
-            final byte[] aggregationKey,
-            final int[] parties,
-            final byte[][] partialSignatures);
+            final byte[] message, final byte[] aggregationKey, final int[] parties, final byte[][] partialSignatures);
 
     /**
      * Aggregates the signatures for party ids using hinTS aggregation and verification keys.

--- a/cryptography/hedera-cryptography-hinTS/src/main/rust/hints.rs
+++ b/cryptography/hedera-cryptography-hinTS/src/main/rust/hints.rs
@@ -489,20 +489,18 @@ impl HinTS {
 
     /// verifies the partial signature under the signer's public key
     pub fn partial_verify(
-        crs: &CRS,
         msg: &[u8],
         ak: &AggregationKey,
         party_id: usize,
         sig: &PartialSignature
     ) -> Result<bool, HinTSError> {
         let lhs = <Curve as Pairing>::pairing(ak.pks[party_id], hash_to_g2(msg)?);
-        let rhs = <Curve as Pairing>::pairing(crs.powers_of_g[0], sig);
+        let rhs = <Curve as Pairing>::pairing(G1AffinePoint::generator(), sig);
         Ok(lhs == rhs)
     }
 
     /// verifies the list of partial signatures from a list of signers
     pub fn partial_verify_batch(
-        crs: &CRS,
         msg: &[u8],
         ak: &AggregationKey,
         signer_ids: impl AsRef<[usize]>,
@@ -514,7 +512,7 @@ impl HinTS {
         let agg_sig = add::<G2AffinePoint>(signatures.as_ref().iter().map(|sig| sig.clone()));
 
         let lhs = <Curve as Pairing>::pairing(apk, hash_to_g2(msg)?);
-        let rhs = <Curve as Pairing>::pairing(crs.powers_of_g[0], agg_sig);
+        let rhs = <Curve as Pairing>::pairing(G1AffinePoint::generator(), agg_sig);
         Ok(lhs == rhs)
     }
 
@@ -1039,12 +1037,11 @@ mod tests {
         let sigs = sample_signing(num_signers, msg, &sks);
 
         for (i, sig) in sigs.iter() {
-            assert!(HinTS::partial_verify(&crs, msg, &ak, *i, sig).unwrap());
+            assert!(HinTS::partial_verify(msg, &ak, *i, sig).unwrap());
         }
 
         assert!(
             HinTS::partial_verify_batch(
-                &crs,
                 msg,
                 &ak,
                 sigs.keys().cloned().collect::<Vec<usize>>(),

--- a/cryptography/hedera-cryptography-hinTS/src/main/rust/hints.rs
+++ b/cryptography/hedera-cryptography-hinTS/src/main/rust/hints.rs
@@ -399,6 +399,11 @@ impl HinTS {
             return Err(HinTSError::InvalidNetworkSize(n));
         }
 
+        // we need at least one reserved location for hinTS
+        if signer_info.len() + 1 > n {
+            return Err(HinTSError::InvalidNetworkSize(n));
+        }
+
         // CRS must be large enough to support the operation
         // NOTE: CRS must also be valid, but we assume that here!
         if crs.powers_of_g.len() - 1 < n {
@@ -494,6 +499,13 @@ impl HinTS {
         party_id: usize,
         sig: &PartialSignature
     ) -> Result<bool, HinTSError> {
+        // party_id can only be between 0 and n-2, inclusive
+        if party_id >= ak.n - 1 { // usize ensures non-negative
+            return Err(HinTSError::InvalidInput(
+                format!("signer_id {} out of range", party_id))
+            );
+        }
+
         let lhs = <Curve as Pairing>::pairing(ak.pks[party_id], hash_to_g2(msg)?);
         let rhs = <Curve as Pairing>::pairing(G1AffinePoint::generator(), sig);
         Ok(lhs == rhs)
@@ -506,6 +518,13 @@ impl HinTS {
         signer_ids: impl AsRef<[usize]>,
         signatures: impl AsRef<[PartialSignature]>,
     ) -> Result<bool, HinTSError> {
+        // ensure all signer_ids are within the valid range
+        if signer_ids.as_ref().iter().any(|&id| id >= ak.n - 1) {
+            return Err(HinTSError::InvalidInput(
+                "One or more signer_ids are out of range".to_string(),
+            ));
+        }
+
         // compute aggregate public key of all signers
         let apk = add::<G1AffinePoint>(signer_ids.as_ref().iter().map(|&x| ak.pks[x]));
         // compute aggregate signature

--- a/cryptography/hedera-cryptography-hinTS/src/main/rust/jni_hints.rs
+++ b/cryptography/hedera-cryptography-hinTS/src/main/rust/jni_hints.rs
@@ -197,17 +197,11 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_sig
 pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_verifyBlsImpl(
     env: JNIEnv,
     _instance: JObject,
-    crs_jarray: JByteArray,
     signature_jarray: JByteArray,
     message_jarray: JByteArray,
     aggregation_key_jarray: JByteArray,
     party_id: jint
 ) -> jboolean {
-    let crs: CRS = match jni_util::deserialize_jbyte_array(&env, &crs_jarray) {
-        Ok(val) => val,
-        Err(_) => return jboolean::from(false)
-    };
-
     let message = match env.convert_byte_array(&message_jarray) {
         Ok(val) => val,
         Err(_) => return jboolean::from(false)
@@ -223,7 +217,7 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_ver
         Err(_) => return jboolean::from(false)
     };
 
-    jboolean::from(match HinTS::partial_verify(&crs, &message, &aggregation_key, party_id as usize, &signature) {
+    jboolean::from(match HinTS::partial_verify(&message, &aggregation_key, party_id as usize, &signature) {
         Ok(val) => val,
         Err(_) => return jboolean::from(false)
     })
@@ -234,17 +228,11 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_ver
 pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_verifyBlsBatchImpl(
     mut env: JNIEnv,
     _instance: JObject,
-    crs_jarray: JByteArray,
     message_jarray: JByteArray,
     aggregation_key_jarray: JByteArray,
     parties_jarray: JIntArray,
     partial_signatures_jarray: JObjectArray
 ) -> jboolean {
-    let crs: CRS = match jni_util::deserialize_jbyte_array(&env, &crs_jarray) {
-        Ok(val) => val,
-        Err(_) => return jboolean::from(false)
-    };
-
     let message = match env.convert_byte_array(&message_jarray) {
         Ok(val) => val,
         Err(_) => return jboolean::from(false)
@@ -281,7 +269,7 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_ver
         partial_signatures_array.push(partial_signature);
     }
 
-    jboolean::from(match HinTS::partial_verify_batch(&crs, &message, &aggregation_key, &keys_usize, &partial_signatures_array) {
+    jboolean::from(match HinTS::partial_verify_batch(&message, &aggregation_key, &keys_usize, &partial_signatures_array) {
         Ok(val) => val,
         Err(_) => return jboolean::from(false)
     })

--- a/cryptography/hedera-cryptography-hinTS/src/test/java/com/hedera/cryptography/hints/HintsLibraryBridgeTest.java
+++ b/cryptography/hedera-cryptography-hinTS/src/test/java/com/hedera/cryptography/hints/HintsLibraryBridgeTest.java
@@ -311,8 +311,8 @@ public class HintsLibraryBridgeTest {
         assertFalse(INSTANCE.verifyBls(signature, EMPTY, keys.aggregationKey(), partyId));
         assertFalse(INSTANCE.verifyBls(signature, HintsConstants.RANDOM_2, null, partyId));
         assertFalse(INSTANCE.verifyBls(signature, HintsConstants.RANDOM_2, EMPTY, partyId));
-        // assertFalse(INSTANCE.verifyBls(signature, HintsConstants.RANDOM_2, keys.aggregationKey(), -1));
-        // assertFalse(INSTANCE.verifyBls(signature, HintsConstants.RANDOM_2, keys.aggregationKey(), 666));
+        assertFalse(INSTANCE.verifyBls(signature, HintsConstants.RANDOM_2, keys.aggregationKey(), -1));
+        assertFalse(INSTANCE.verifyBls(signature, HintsConstants.RANDOM_2, keys.aggregationKey(), 666));
 
         // Corrupt the signature
         signature[23]++;

--- a/cryptography/hedera-cryptography-hinTS/src/test/java/com/hedera/cryptography/hints/HintsLibraryBridgeTest.java
+++ b/cryptography/hedera-cryptography-hinTS/src/test/java/com/hedera/cryptography/hints/HintsLibraryBridgeTest.java
@@ -292,7 +292,7 @@ public class HintsLibraryBridgeTest {
         final byte[] signature = INSTANCE.signBls(HintsConstants.RANDOM_2, secretKey);
         assertArrayEquals(HintsConstants.SIGNATURE, signature);
 
-        assertTrue(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
+        assertTrue(INSTANCE.verifyBls(signature, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
     }
 
     @Test
@@ -305,30 +305,18 @@ public class HintsLibraryBridgeTest {
                 INSTANCE.preprocess(crs, new int[] {partyId}, new byte[][] {hints}, new long[] {111}, 4);
         final byte[] signature = INSTANCE.signBls(HintsConstants.RANDOM_2, secretKey);
 
-        assertFalse(INSTANCE.verifyBls(null, signature, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
-        assertFalse(INSTANCE.verifyBls(EMPTY, signature, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
-        assertFalse(INSTANCE.verifyBls(crs, null, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
-        assertFalse(INSTANCE.verifyBls(crs, EMPTY, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
-        assertFalse(INSTANCE.verifyBls(crs, signature, null, keys.aggregationKey(), partyId));
-        assertFalse(INSTANCE.verifyBls(crs, signature, EMPTY, keys.aggregationKey(), partyId));
-        assertFalse(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, null, partyId));
-        assertFalse(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, EMPTY, partyId));
-        assertFalse(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, keys.aggregationKey(), -1));
-        assertFalse(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, keys.aggregationKey(), 666));
+        assertFalse(INSTANCE.verifyBls(null, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
+        assertFalse(INSTANCE.verifyBls(EMPTY, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
+        assertFalse(INSTANCE.verifyBls(signature, null, keys.aggregationKey(), partyId));
+        assertFalse(INSTANCE.verifyBls(signature, EMPTY, keys.aggregationKey(), partyId));
+        assertFalse(INSTANCE.verifyBls(signature, HintsConstants.RANDOM_2, null, partyId));
+        assertFalse(INSTANCE.verifyBls(signature, HintsConstants.RANDOM_2, EMPTY, partyId));
+        // assertFalse(INSTANCE.verifyBls(signature, HintsConstants.RANDOM_2, keys.aggregationKey(), -1));
+        // assertFalse(INSTANCE.verifyBls(signature, HintsConstants.RANDOM_2, keys.aggregationKey(), 666));
 
-        // corrupt the CRS
-        crs[27]++;
-        crs[172]--;
-        crs[387]++;
-        assertFalse(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
-
-        // uncorrupt the CRS...
-        crs[27]--;
-        crs[172]++;
-        crs[387]--;
-        // and corrupt the signature
+        // Corrupt the signature
         signature[23]++;
-        assertFalse(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
+        assertFalse(INSTANCE.verifyBls(signature, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
 
         // undo the signature...
         signature[23]--;
@@ -336,13 +324,13 @@ public class HintsLibraryBridgeTest {
         keys.aggregationKey()[17]++;
         keys.aggregationKey()[111]--;
         keys.aggregationKey()[302]++;
-        assertFalse(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
+        assertFalse(INSTANCE.verifyBls(signature, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
 
         // uncorrupt the aggregationKey and do a sanity check
         keys.aggregationKey()[17]--;
         keys.aggregationKey()[111]++;
         keys.aggregationKey()[302]--;
-        assertTrue(INSTANCE.verifyBls(crs, signature, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
+        assertTrue(INSTANCE.verifyBls(signature, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
     }
 
     @Test
@@ -366,7 +354,7 @@ public class HintsLibraryBridgeTest {
                 crs, new int[] {partyId0, partyId2}, new byte[][] {hints0, hints2}, new long[] {111, 222}, 4);
 
         assertTrue(INSTANCE.verifyBlsBatch(
-                crs, HintsConstants.RANDOM_2, keys.aggregationKey(), new int[] {partyId0, partyId2}, new byte[][] {
+                HintsConstants.RANDOM_2, keys.aggregationKey(), new int[] {partyId0, partyId2}, new byte[][] {
                     signature0, signature2
                 }));
     }
@@ -389,50 +377,27 @@ public class HintsLibraryBridgeTest {
                 INSTANCE.preprocess(crs, new int[] {0, 2}, new byte[][] {hints0, hints2}, new long[] {111, 222}, 4);
 
         assertFalse(INSTANCE.verifyBlsBatch(
-                null, HintsConstants.RANDOM_2, keys.aggregationKey(), new int[] {0, 2}, new byte[][] {
-                    signature2, signature0
-                }));
+                null, keys.aggregationKey(), new int[] {0, 2}, new byte[][] {signature2, signature0}));
         assertFalse(INSTANCE.verifyBlsBatch(
-                EMPTY, HintsConstants.RANDOM_2, keys.aggregationKey(), new int[] {0, 2}, new byte[][] {
-                    signature2, signature0
-                }));
+                EMPTY, keys.aggregationKey(), new int[] {0, 2}, new byte[][] {signature2, signature0}));
         assertFalse(INSTANCE.verifyBlsBatch(
-                crs, null, keys.aggregationKey(), new int[] {0, 2}, new byte[][] {signature2, signature0}));
+                HintsConstants.RANDOM_2, null, new int[] {0, 2}, new byte[][] {signature2, signature0}));
         assertFalse(INSTANCE.verifyBlsBatch(
-                crs, EMPTY, keys.aggregationKey(), new int[] {0, 2}, new byte[][] {signature2, signature0}));
+                HintsConstants.RANDOM_2, EMPTY, new int[] {0, 2}, new byte[][] {signature2, signature0}));
         assertFalse(INSTANCE.verifyBlsBatch(
-                crs, HintsConstants.RANDOM_2, null, new int[] {0, 2}, new byte[][] {signature2, signature0}));
+                HintsConstants.RANDOM_2, keys.aggregationKey(), null, new byte[][] {signature2, signature0}));
         assertFalse(INSTANCE.verifyBlsBatch(
-                crs, HintsConstants.RANDOM_2, EMPTY, new int[] {0, 2}, new byte[][] {signature2, signature0}));
+                HintsConstants.RANDOM_2, keys.aggregationKey(), new int[0], new byte[][] {signature2, signature0}));
+        assertFalse(INSTANCE.verifyBlsBatch(HintsConstants.RANDOM_2, keys.aggregationKey(), new int[] {0, 2}, null));
         assertFalse(INSTANCE.verifyBlsBatch(
-                crs, HintsConstants.RANDOM_2, keys.aggregationKey(), null, new byte[][] {signature2, signature0}));
+                HintsConstants.RANDOM_2, keys.aggregationKey(), new int[] {0, 2}, new byte[][] {}));
         assertFalse(INSTANCE.verifyBlsBatch(
-                crs, HintsConstants.RANDOM_2, keys.aggregationKey(), new int[0], new byte[][] {signature2, signature0
-                }));
-        assertFalse(
-                INSTANCE.verifyBlsBatch(crs, HintsConstants.RANDOM_2, keys.aggregationKey(), new int[] {0, 2}, null));
-        assertFalse(INSTANCE.verifyBlsBatch(
-                crs, HintsConstants.RANDOM_2, keys.aggregationKey(), new int[] {0, 2}, new byte[][] {}));
-        assertFalse(INSTANCE.verifyBlsBatch(
-                crs, HintsConstants.RANDOM_2, keys.aggregationKey(), new int[] {0, 2}, new byte[][] {signature2}));
+                HintsConstants.RANDOM_2, keys.aggregationKey(), new int[] {0, 2}, new byte[][] {signature2}));
 
-        // corrupt the CRS
-        crs[27]++;
-        crs[172]--;
-        crs[387]++;
-        assertFalse(INSTANCE.verifyBlsBatch(
-                crs, HintsConstants.RANDOM_2, keys.aggregationKey(), new int[] {0, 2}, new byte[][] {
-                    signature2, signature0
-                }));
-        // uncorrupt the CRS...
-        crs[27]--;
-        crs[172]++;
-        crs[387]--;
-        // and corrupt the aggregationKey
+        // Corrupt the aggregationKey
         keys.aggregationKey()[11]++;
         assertFalse(INSTANCE.verifyBlsBatch(
-                crs, HintsConstants.RANDOM_2, keys.aggregationKey(), new int[] {0, 2}, new byte[][] {
-                    signature2, signature0
+                HintsConstants.RANDOM_2, keys.aggregationKey(), new int[] {0, 2}, new byte[][] {signature2, signature0
                 }));
 
         // uncorrupt the aggregationKey...
@@ -440,15 +405,13 @@ public class HintsLibraryBridgeTest {
         // corrupt a signature instead
         signature2[17]++;
         assertFalse(INSTANCE.verifyBlsBatch(
-                crs, HintsConstants.RANDOM_2, keys.aggregationKey(), new int[] {0, 2}, new byte[][] {
-                    signature2, signature0
+                HintsConstants.RANDOM_2, keys.aggregationKey(), new int[] {0, 2}, new byte[][] {signature2, signature0
                 }));
 
         // undo the damage and run a sanity check
         signature2[17]--;
         assertTrue(INSTANCE.verifyBlsBatch(
-                crs, HintsConstants.RANDOM_2, keys.aggregationKey(), new int[] {0, 2}, new byte[][] {
-                    signature2, signature0
+                HintsConstants.RANDOM_2, keys.aggregationKey(), new int[] {0, 2}, new byte[][] {signature2, signature0
                 }));
     }
 


### PR DESCRIPTION
**Description**:
This PR removes the use of CRS in partial signature verification. This is to avoid the penalty of deserializing the CRS on every call, which can happen several times for each threshold signing process.