### PR TITLE
feat: introduce ProofCompressor

### DIFF
--- a/common/hedera-common-nativesupport/src/main/java/com/hedera/common/nativesupport/ProcessAPI.java
+++ b/common/hedera-common-nativesupport/src/main/java/com/hedera/common/nativesupport/ProcessAPI.java
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.common.nativesupport;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * An AutoCloseable native process runner that allows one to interact with it via stdin/stdout by means
+ * of sending and receiving byte arrays using public methods in this class.
+ */
+public class ProcessAPI implements AutoCloseable {
+    private final Process process;
+
+    /**
+     * Create a new ProcessAPI instance and start the process.
+     * The process should normally exit once it'd done its job - e.g. completed an API call.
+     * However, applications may also call `ProcessAPI.close()` or use a try-with-resources to
+     * `Process.destroy()` the underlying process.
+     *
+     * @param clz a class that is in the Java module where the executable belongs to
+     * @param executableName a name of the executable file as present in the JAR file
+     * @throws IOException if any errors occur when extracting the executable or starting the process
+     */
+    public ProcessAPI(final Class<?> clz, final String executableName) throws IOException {
+        final NativeBinary executableBinary =
+                new NativeBinary(executableName, Map.of(), Map.of(OperatingSystem.WINDOWS, "exe"));
+        final Path path = executableBinary.extract(clz);
+        final ProcessBuilder pb =
+                new ProcessBuilder().command(path.toAbsolutePath().toString());
+        this.process = pb.start();
+    }
+
+    @Override
+    public void close() throws Exception {
+        // The process is supposed to exit on its own once it emits the reply, so this will likely be a no-op.
+        // But it's here in case we catch an exception before the process had a chance to receive any input.
+        // This should help prevent a memory leak in case we keep spawning new processes and erroring out
+        // continuously due to a bug or similar.
+        this.process.destroy();
+    }
+
+    /**
+     * Send a byte array by writing a BIG_ENDIAN 4 bytes integer length followed by the array bytes.
+     * @param array a byte array to send
+     */
+    public void sendArray(final byte[] array) throws IOException {
+        final OutputStream os = process.getOutputStream();
+
+        os.write(intToArray(array.length));
+        os.flush();
+        os.write(array);
+        os.flush();
+    }
+
+    /**
+     * Receive a byte array by reading a BIG_ENDIAN 4 bytes integer length followed by the array bytes.
+     * @return the received array, or null if the InputStream is closed before receiving all the bytes
+     */
+    public byte[] receiveArray() throws IOException {
+        final InputStream is = process.getInputStream();
+
+        final byte[] lenBytes = is.readNBytes(4);
+        final int len = arrayToInt(lenBytes);
+        final byte[] output = is.readNBytes(len);
+        if (output.length != len) {
+            return null;
+        }
+
+        return output;
+    }
+
+    /** Return BIG_ENDIAN-encoded integer bytes. */
+    private static byte[] intToArray(final int value) {
+        return new byte[] {(byte) (value >> 24), (byte) (value >> 16), (byte) (value >> 8), (byte) value};
+    }
+
+    /** Unencode a BIG_ENDIAN integer from a byte array. */
+    private static int arrayToInt(final byte[] array) {
+        return ((array[0] & 0xFF) << 24)
+                | ((array[1] & 0xFF) << 16)
+                | ((array[2] & 0xFF) << 8)
+                | ((array[3] & 0xFF) << 0);
+    }
+}

--- a/cryptography/hedera-cryptography-rpm/src/main/java/com/hedera/cryptography/rpm/ProofCompressor.java
+++ b/cryptography/hedera-cryptography-rpm/src/main/java/com/hedera/cryptography/rpm/ProofCompressor.java
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.cryptography.rpm;
 
-import com.hedera.common.nativesupport.NativeBinary;
-import com.hedera.common.nativesupport.OperatingSystem;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.file.Path;
-import java.util.Map;
+import com.hedera.common.nativesupport.ProcessAPI;
 
 /**
  * A WRAPS proof compressor.
@@ -15,75 +10,32 @@ import java.util.Map;
  * to include them into frequently produced pieces of data, such as blocks in the Hiero block stream, they need to be
  * compressed to a reasonable size - around 1 KB or so.
  * <p>
- * The current implementation starts a native process using a compiled binary executable from the JAR file,
- * and interacts with the process via stdin/stdout by sending a request, and then reading a reply.
- * Both the request and the reply are essentially a byte array. It's represented on a binary stdin/stdout
- * as a BIG_ENDIAN-encoded 4 bytes length integer prefix followed by the bytes themselves.
+ * The current implementation uses the ProcessAPI class to run the compression as a separate process. See JavaDoc
+ * for that class for details on the binary representation of the byte arrays in stdin/stdout.
  */
 public class ProofCompressor {
-    private static final NativeBinary COMPRESSOR_EXECUTABLE = new NativeBinary(
-            // FUTURE WORK: finalize the actual name of the executable once the Rust/Go build produces it
-            // and Gradle packs it into the JAR, same way as it does with our hints and raps libraries.
-            // Also, once the actual binary is available, create unit tests for this class.
-            "wrapscompressor", Map.of(), Map.of(OperatingSystem.WINDOWS, "exe"));
-
     /**
      * Compress the given WRAPS proof.
      *
-     * @param input a WRAPS proof as obtained from `HistoryLibraryBridge.proveChainOfTrust()`
+     * @param proverKey the prover key for the compression zkVM
+     * @param verificationKey the verification key for the uncompressed zkVM
+     * @param uncompressedProof a WRAPS proof as obtained from `HistoryLibraryBridge.proveChainOfTrust()`
      * @return a compressed version of the proof, or null if any errors occur
      */
-    public static byte[] compressProof(final byte[] input) {
-        Process process = null;
-        try {
-            // Start the process
-            final Path path = COMPRESSOR_EXECUTABLE.extract(ProofCompressor.class);
-            final ProcessBuilder pb =
-                    new ProcessBuilder().command(path.toAbsolutePath().toString());
-            process = pb.start();
+    public static byte[] compressProof(
+            final byte[] proverKey, final byte[] verificationKey, final byte[] uncompressedProof) {
+        // FUTURE WORK: finalize the actual name of the executable once the Rust/Go build produces it
+        // and Gradle packs it into the JAR, same way as it does with our hints and raps libraries.
+        // Also, once the actual binary is available, create unit tests for this class.
+        try (final ProcessAPI processAPI = new ProcessAPI(ProofCompressor.class, "wrapscompressor")) {
+            processAPI.sendArray(proverKey);
+            processAPI.sendArray(verificationKey);
+            processAPI.sendArray(uncompressedProof);
 
-            // Send the input by writing a BIG_ENDIAN 4 bytes integer length followed by the input bytes
-            final OutputStream os = process.getOutputStream();
-            os.write(intToArray(input.length));
-            os.flush();
-            os.write(input);
-            os.flush();
-
-            // Receive the output by reading a BIG_ENDIAN 4 bytes integer length followed by the output bytes
-            final InputStream is = process.getInputStream();
-            final byte[] lenBytes = is.readNBytes(4);
-            final int len = arrayToInt(lenBytes);
-            final byte[] output = is.readNBytes(len);
-            if (output.length != len) {
-                return null;
-            }
-
-            return output;
+            return processAPI.receiveArray();
         } catch (Exception e) {
-            // This is mostly for the IOException, but the NativeBinary, ProcessBuilder, and our arrayToInt() may throw
-            // various exceptions, too, so we catch all of them here.
+            // Previously we agreed to return `null` in case of any errors, so:
             return null;
-        } finally {
-            if (process != null) {
-                // The process is supposed to exit on its own once it emits the reply, so this will likely be a no-op.
-                // But it's here in case we catch an exception before the process had a chance to receive any input.
-                // This should help prevent a memory leak in case we keep spawning new processes and erroring out
-                // continuously due to a bug or similar.
-                process.destroy();
-            }
         }
-    }
-
-    /** Return BIG_ENDIAN-encoded integer bytes. */
-    private static byte[] intToArray(final int value) {
-        return new byte[] {(byte) (value >> 24), (byte) (value >> 16), (byte) (value >> 8), (byte) value};
-    }
-
-    /** Unencode a BIG_ENDIAN integer from a byte array. */
-    private static int arrayToInt(final byte[] array) {
-        return ((array[0] & 0xFF) << 24)
-                | ((array[1] & 0xFF) << 16)
-                | ((array[2] & 0xFF) << 8)
-                | ((array[3] & 0xFF) << 0);
     }
 }

--- a/cryptography/hedera-cryptography-rpm/src/main/java/com/hedera/cryptography/rpm/ProofCompressor.java
+++ b/cryptography/hedera-cryptography-rpm/src/main/java/com/hedera/cryptography/rpm/ProofCompressor.java
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.cryptography.rpm;
+
+import com.hedera.common.nativesupport.NativeBinary;
+import com.hedera.common.nativesupport.OperatingSystem;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * A WRAPS proof compressor.
+ * <p>
+ * Proofs produced by `HistoryLibraryBridge.proveChainOfTrust()` may be large - 1.5 MB or more. In order to be able
+ * to include them into frequently produced pieces of data, such as blocks in the Hiero block stream, they need to be
+ * compressed to a reasonable size - around 1 KB or so.
+ * <p>
+ * The current implementation starts a native process using a compiled binary executable from the JAR file,
+ * and interacts with the process via stdin/stdout by sending a request, and then reading a reply.
+ * Both the request and the reply are essentially a byte array. It's represented on a binary stdin/stdout
+ * as a BIG_ENDIAN-encoded 4 bytes length integer prefix followed by the bytes themselves.
+ */
+public class ProofCompressor {
+    private static final NativeBinary COMPRESSOR_EXECUTABLE = new NativeBinary(
+            // FUTURE WORK: finalize the actual name of the executable once the Rust/Go build produces it
+            // and Gradle packs it into the JAR, same way as it does with our hints and raps libraries.
+            // Also, once the actual binary is available, create unit tests for this class.
+            "wrapscompressor", Map.of(), Map.of(OperatingSystem.WINDOWS, "exe"));
+
+    /**
+     * Compress the given WRAPS proof.
+     *
+     * @param input a WRAPS proof as obtained from `HistoryLibraryBridge.proveChainOfTrust()`
+     * @return a compressed version of the proof, or null if any errors occur
+     */
+    public static byte[] compressProof(final byte[] input) {
+        Process process = null;
+        try {
+            // Start the process
+            final Path path = COMPRESSOR_EXECUTABLE.extract(ProofCompressor.class);
+            final ProcessBuilder pb =
+                    new ProcessBuilder().command(path.toAbsolutePath().toString());
+            process = pb.start();
+
+            // Send the input by writing a BIG_ENDIAN 4 bytes integer length followed by the input bytes
+            final OutputStream os = process.getOutputStream();
+            os.write(intToArray(input.length));
+            os.flush();
+            os.write(input);
+            os.flush();
+
+            // Receive the output by reading a BIG_ENDIAN 4 bytes integer length followed by the output bytes
+            final InputStream is = process.getInputStream();
+            final byte[] lenBytes = is.readNBytes(4);
+            final int len = arrayToInt(lenBytes);
+            final byte[] output = is.readNBytes(len);
+            if (output.length != len) {
+                return null;
+            }
+
+            return output;
+        } catch (Exception e) {
+            // This is mostly for the IOException, but the NativeBinary, ProcessBuilder, and our arrayToInt() may throw
+            // various exceptions, too, so we catch all of them here.
+            return null;
+        } finally {
+            if (process != null) {
+                // The process is supposed to exit on its own once it emits the reply, so this will likely be a no-op.
+                // But it's here in case we catch an exception before the process had a chance to receive any input.
+                // This should help prevent a memory leak in case we keep spawning new processes and erroring out
+                // continuously due to a bug or similar.
+                process.destroy();
+            }
+        }
+    }
+
+    /** Return BIG_ENDIAN-encoded integer bytes. */
+    private static byte[] intToArray(final int value) {
+        return new byte[] {(byte) (value >> 24), (byte) (value >> 16), (byte) (value >> 8), (byte) value};
+    }
+
+    /** Unencode a BIG_ENDIAN integer from a byte array. */
+    private static int arrayToInt(final byte[] array) {
+        return ((array[0] & 0xFF) << 24)
+                | ((array[1] & 0xFF) << 16)
+                | ((array[2] & 0xFF) << 8)
+                | ((array[3] & 0xFF) << 0);
+    }
+}


### PR DESCRIPTION
**Description**:
Introducing a `ProofCompressor` class that uses the `NativeBinary` to extract the compressor from the JAR and run it as a process, and interact with it via stdin/stdout.

Please see javadoc and comments in the class for more details on the format of the data transmitted via stdin/stdout.

**Revision 2:**
* Introducing a generic `ProcessAPI` that allows us to implement any API using an external process, and then using it in the `ProofCompressor` for this new concrete API implementation.
* Making the API accept 3 arguments - the prover key, verifying key, and the uncompressed proof.

**Related issue(s)**:

Fixes #333 

**Notes for reviewer**:
This class requires the binary to be present. So we'll create unit tests for this class under a separate issue https://github.com/hashgraph/hedera-cryptography/issues/334 once the binary is available at a later time.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
