### PR TITLE
fix: use short signersNum in initCRS

### DIFF
--- a/cryptography/hedera-cryptography-hinTS/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
+++ b/cryptography/hedera-cryptography-hinTS/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
@@ -50,7 +50,7 @@ public class HintsLibraryBridge {
      * @param signersNum the number of signers plus 1
      * @return the CRS object
      */
-    public byte[] initCRS(long signersNum) {
+    public byte[] initCRS(short signersNum) {
         // Support a degenerate case of 0 signers, or a normal case with more signers. Otherwise, error out.
         if (signersNum < 1) {
             return null;
@@ -58,7 +58,7 @@ public class HintsLibraryBridge {
         return initCRSImpl(signersNum);
     }
 
-    private native byte[] initCRSImpl(long signersNum);
+    private native byte[] initCRSImpl(short signersNum);
 
     /**
      * Update a previous CRS object with a new contribution.

--- a/cryptography/hedera-cryptography-hinTS/src/main/rust/jni_crs.rs
+++ b/cryptography/hedera-cryptography-hinTS/src/main/rust/jni_crs.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use jni::objects::{JByteArray, JObject};
-use jni::sys::{jlong, jbyteArray, jboolean};
+use jni::sys::{jbyteArray, jboolean, jshort};
 use jni::JNIEnv;
 use crate::setup::{ContributionProof, PowersOfTauProtocol};
 use crate::hints::{serialize, CRS};
@@ -18,7 +18,7 @@ use crate::jni_util;
 pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_initCRSImpl(
     env: JNIEnv,
     _instance: JObject,
-    signers_num: jlong,
+    signers_num: jshort,
 ) -> jbyteArray {
     let crs = PowersOfTauProtocol::init(signers_num as usize);
     match jni_util::serialize_object(&env, &crs) {

--- a/cryptography/hedera-cryptography-hinTS/src/test/java/com/hedera/cryptography/hints/HintsLibraryBridgeCRSTest.java
+++ b/cryptography/hedera-cryptography-hinTS/src/test/java/com/hedera/cryptography/hints/HintsLibraryBridgeCRSTest.java
@@ -21,7 +21,7 @@ public class HintsLibraryBridgeCRSTest {
     private static final int CONTRIBUTION_PROOF_LENGTH = 128;
 
     private byte[] initAndVerifyCRS() {
-        final byte[] crs = INSTANCE.initCRS(4);
+        final byte[] crs = INSTANCE.initCRS((short) 4);
 
         assertNotNull(crs);
         assertEquals(CRS_4_LENGTH, crs.length);
@@ -37,15 +37,15 @@ public class HintsLibraryBridgeCRSTest {
 
     @Test
     void testInitCRSConstraints() {
-        assertNull(INSTANCE.initCRS(0));
-        assertNull(INSTANCE.initCRS(-2));
-        assertNull(INSTANCE.initCRS(Long.MIN_VALUE));
+        assertNull(INSTANCE.initCRS((short) 0));
+        assertNull(INSTANCE.initCRS((short) -2));
+        assertNull(INSTANCE.initCRS(Short.MIN_VALUE));
     }
 
     @ParameterizedTest
     @ValueSource(ints = {1, 2, 11, 101, 1024})
     void testInitCRSLength(final int n) {
-        assertEquals(304 + n * 288, INSTANCE.initCRS(n).length);
+        assertEquals(304 + n * 288, INSTANCE.initCRS((short) n).length);
     }
 
     private byte[] updateAndVerifyCRS(final byte[] prevCRS) {

--- a/cryptography/hedera-cryptography-hinTS/src/test/java/com/hedera/cryptography/hints/HintsLibraryBridgeTest.java
+++ b/cryptography/hedera-cryptography-hinTS/src/test/java/com/hedera/cryptography/hints/HintsLibraryBridgeTest.java
@@ -38,7 +38,7 @@ public class HintsLibraryBridgeTest {
 
     @Test
     void testComputeHints() {
-        final byte[] crs = INSTANCE.initCRS(4);
+        final byte[] crs = INSTANCE.initCRS((short) 4);
         assertArrayEquals(CRSConstants.INIT_CRS_4, crs);
 
         final byte[] secretKey = INSTANCE.generateSecretKey(HintsConstants.RANDOM_2);
@@ -51,7 +51,7 @@ public class HintsLibraryBridgeTest {
 
     @Test
     void testComputeHintsConstraints() {
-        final byte[] crs = INSTANCE.initCRS(4);
+        final byte[] crs = INSTANCE.initCRS((short) 4);
         final byte[] secretKey = INSTANCE.generateSecretKey(HintsConstants.RANDOM_2);
 
         // n must be power of two
@@ -97,7 +97,7 @@ public class HintsLibraryBridgeTest {
 
     @Test
     void testValidateHintsKey() {
-        final byte[] crs = INSTANCE.initCRS(4);
+        final byte[] crs = INSTANCE.initCRS((short) 4);
         assertArrayEquals(CRSConstants.INIT_CRS_4, crs);
 
         final byte[] secretKey = INSTANCE.generateSecretKey(HintsConstants.RANDOM_2);
@@ -111,7 +111,7 @@ public class HintsLibraryBridgeTest {
 
     @Test
     void testValidateHintsConstraints() {
-        final byte[] crs = INSTANCE.initCRS(4);
+        final byte[] crs = INSTANCE.initCRS((short) 4);
         final byte[] secretKey = INSTANCE.generateSecretKey(HintsConstants.RANDOM_2);
         final byte[] hints = INSTANCE.computeHints(crs, secretKey, 2, 4);
 
@@ -157,7 +157,7 @@ public class HintsLibraryBridgeTest {
 
     @Test
     void testPreprocess() {
-        final byte[] crs = INSTANCE.initCRS(4);
+        final byte[] crs = INSTANCE.initCRS((short) 4);
         assertArrayEquals(CRSConstants.INIT_CRS_4, crs);
 
         final byte[] secretKey = INSTANCE.generateSecretKey(HintsConstants.RANDOM_2);
@@ -174,7 +174,7 @@ public class HintsLibraryBridgeTest {
 
     @Test
     void testPreprocessConstraints() {
-        final byte[] crs = INSTANCE.initCRS(4);
+        final byte[] crs = INSTANCE.initCRS((short) 4);
 
         final byte[] secretKey0 = INSTANCE.generateSecretKey(HintsConstants.RANDOM_0);
         final byte[] hints0 = INSTANCE.computeHints(crs, secretKey0, 0, 4);
@@ -274,7 +274,7 @@ public class HintsLibraryBridgeTest {
 
     @Test
     void testVerifyBls() {
-        final byte[] crs = INSTANCE.initCRS(4);
+        final byte[] crs = INSTANCE.initCRS((short) 4);
         assertArrayEquals(CRSConstants.INIT_CRS_4, crs);
 
         final byte[] secretKey = INSTANCE.generateSecretKey(HintsConstants.RANDOM_2);
@@ -297,7 +297,7 @@ public class HintsLibraryBridgeTest {
 
     @Test
     void testVerifyBlsConstraints() {
-        final byte[] crs = INSTANCE.initCRS(4);
+        final byte[] crs = INSTANCE.initCRS((short) 4);
         final byte[] secretKey = INSTANCE.generateSecretKey(HintsConstants.RANDOM_2);
         final int partyId = 2;
         final byte[] hints = INSTANCE.computeHints(crs, secretKey, partyId, 4);
@@ -335,7 +335,7 @@ public class HintsLibraryBridgeTest {
 
     @Test
     void testVerifyBlsBatch() {
-        final byte[] crs = INSTANCE.initCRS(4);
+        final byte[] crs = INSTANCE.initCRS((short) 4);
         assertArrayEquals(CRSConstants.INIT_CRS_4, crs);
 
         final int partyId0 = 0;
@@ -361,7 +361,7 @@ public class HintsLibraryBridgeTest {
 
     @Test
     void testVerifyBlsBatchConstraints() {
-        final byte[] crs = INSTANCE.initCRS(4);
+        final byte[] crs = INSTANCE.initCRS((short) 4);
 
         // partyId 0
         final byte[] secretKey0 = INSTANCE.generateSecretKey(HintsConstants.RANDOM_0);
@@ -417,7 +417,7 @@ public class HintsLibraryBridgeTest {
 
     @Test
     void testAggregateSignatures() {
-        final byte[] crs = INSTANCE.initCRS(4);
+        final byte[] crs = INSTANCE.initCRS((short) 4);
         assertArrayEquals(CRSConstants.INIT_CRS_4, crs);
 
         // partyId 2
@@ -447,7 +447,7 @@ public class HintsLibraryBridgeTest {
 
     @Test
     void testAggregateSignaturesConstraints() {
-        final byte[] crs = INSTANCE.initCRS(4);
+        final byte[] crs = INSTANCE.initCRS((short) 4);
 
         // partyId 0
         final byte[] secretKey0 = INSTANCE.generateSecretKey(HintsConstants.RANDOM_0);
@@ -528,7 +528,7 @@ public class HintsLibraryBridgeTest {
 
     @Test
     void testVerifyAggregate_meetsThreshold() {
-        final byte[] crs = INSTANCE.initCRS(4);
+        final byte[] crs = INSTANCE.initCRS((short) 4);
         assertArrayEquals(CRSConstants.INIT_CRS_4, crs);
 
         // partyId 2
@@ -564,7 +564,7 @@ public class HintsLibraryBridgeTest {
 
     @Test
     void testVerifyAggregate_doesNotMeetThreshold() {
-        final byte[] crs = INSTANCE.initCRS(4);
+        final byte[] crs = INSTANCE.initCRS((short) 4);
         assertArrayEquals(CRSConstants.INIT_CRS_4, crs);
 
         // partyId 2
@@ -600,7 +600,7 @@ public class HintsLibraryBridgeTest {
 
     @Test
     void testVerifyAggregateConstraints() {
-        final byte[] crs = INSTANCE.initCRS(4);
+        final byte[] crs = INSTANCE.initCRS((short) 4);
 
         final byte[] secretKey0 = INSTANCE.generateSecretKey(HintsConstants.RANDOM_0);
         final byte[] hints0 = INSTANCE.computeHints(crs, secretKey0, 0, 4);

--- a/cryptography/hedera-cryptography-rpm/src/test/java/com/hedera/cryptography/rpm/HistoryLibraryBridgeTest.java
+++ b/cryptography/hedera-cryptography-rpm/src/test/java/com/hedera/cryptography/rpm/HistoryLibraryBridgeTest.java
@@ -225,7 +225,7 @@ public class HistoryLibraryBridgeTest {
         final byte[] nextAddressBookHash =
                 HISTORY.hashAddressBook(nextAddressBook.verifyingKeys(), nextAddressBook.weights());
 
-        final byte[] crs = HINTS.initCRS(SIGNERS_NUM);
+        final byte[] crs = HINTS.initCRS((short) SIGNERS_NUM);
 
         // partyId 0
         final byte[] secretKey0 = HINTS.generateSecretKey(HistoryConstants.RANDOM_0);
@@ -525,7 +525,7 @@ public class HistoryLibraryBridgeTest {
         final byte[] nextAddressBookHash =
                 HISTORY.hashAddressBook(nextAddressBook.verifyingKeys(), nextAddressBook.weights());
 
-        final byte[] crs = HINTS.initCRS(SIGNERS_NUM);
+        final byte[] crs = HINTS.initCRS((short) SIGNERS_NUM);
 
         // partyId 0
         final byte[] secretKey0 = HINTS.generateSecretKey(HistoryConstants.RANDOM_0);


### PR DESCRIPTION
**Description**:
Use `short` `signersNum` in `initCRS()` so as to limit the maximum number of signers and avoid OutOfMemory conditions.

**Related issue(s)**:

Fixes #339

**Notes for reviewer**:
All tests should continue to pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
