### PR TITLE
build: run tests on module path

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-plugins { id("org.hiero.gradle.build") version "0.3.10" }
+plugins { id("org.hiero.gradle.build") version "0.4.0" }
 
 rootProject.name = "hedera-cryptography"
 


### PR DESCRIPTION
**Description**:

Update _hiero-gradle-conventions_ to _0.4.0_ and by that run tests on the _module path_.

See https://github.com/hiero-ledger/hiero-consensus-node/pull/18922 for more details on how that works.