### PR TITLE
fix: limit max weights sum

### DIFF
--- a/cryptography/hedera-cryptography-hinTS/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
+++ b/cryptography/hedera-cryptography-hinTS/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
@@ -15,7 +15,7 @@ public class HintsLibraryBridge {
     /** The max number of signers that we can support w/o running into OutOfMemory as the memory usage is quadratic. */
     private static final short MAX_SIGNERS_NUM = (short) 1023;
 
-    /** The max theoretical sum of weights all nodes together can have, which is 2^63 because we use signed long. */
+    /** The max theoretical sum of weights all nodes together can have, which is 2^63-1 because we use signed long. */
     private static final long MAX_SUM_OF_WEIGHTS = Long.MAX_VALUE;
 
     static {
@@ -364,6 +364,7 @@ public class HintsLibraryBridge {
         try {
             long sum = 0;
             for (int i = 0; i < weights.length; i++) {
+                // Math.addExact() throws ArithmeticException if the sum overflows
                 sum = Math.addExact(sum, weights[i]);
             }
             return sum >= 0L && sum <= MAX_SUM_OF_WEIGHTS;

--- a/cryptography/hedera-cryptography-hinTS/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
+++ b/cryptography/hedera-cryptography-hinTS/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
@@ -15,6 +15,9 @@ public class HintsLibraryBridge {
     /** The max number of signers that we can support w/o running into OutOfMemory as the memory usage is quadratic. */
     private static final short MAX_SIGNERS_NUM = (short) 1023;
 
+    /** The max theoretical sum of weights all nodes together can have, which is 2^63 because we use signed long. */
+    private static final long MAX_SUM_OF_WEIGHTS = Long.MAX_VALUE;
+
     static {
         // Open the package to allow access to the native library
         // This can be done in module-info.java as well, but by default the compiler complains since there are no
@@ -155,7 +158,11 @@ public class HintsLibraryBridge {
     public AggregationAndVerificationKeys preprocess(
             final byte[] crs, final int[] parties, final byte[][] hintsPublicKeys, final long[] weights, int n) {
         // Basic sanity
-        if (!validateCRS(crs, n) || parties == null || hintsPublicKeys == null || weights == null) {
+        if (!validateCRS(crs, n)
+                || parties == null
+                || hintsPublicKeys == null
+                || weights == null
+                || !validateWeightsSum(weights)) {
             return null;
         }
         // ensure the arrays modeling the map are good and satisfy the maximum size constraint
@@ -350,5 +357,18 @@ public class HintsLibraryBridge {
     // Returns true if 0 <= partiyId < n && n <= MAX_SIGNERS_NUM.
     private static boolean validatePartyId(final int partyId, final int n) {
         return n <= MAX_SIGNERS_NUM && partyId >= 0 && partyId < n;
+    }
+
+    /** Check if the sum of weights doesn't exceed MAX_SUM_OF_WEIGHTS. */
+    public static boolean validateWeightsSum(final long weights[]) {
+        try {
+            long sum = 0;
+            for (int i = 0; i < weights.length; i++) {
+                sum = Math.addExact(sum, weights[i]);
+            }
+            return sum >= 0L && sum <= MAX_SUM_OF_WEIGHTS;
+        } catch (final ArithmeticException e) {
+            return false;
+        }
     }
 }

--- a/cryptography/hedera-cryptography-hinTS/src/test/java/com/hedera/cryptography/hints/HintsLibraryBridgeTest.java
+++ b/cryptography/hedera-cryptography-hinTS/src/test/java/com/hedera/cryptography/hints/HintsLibraryBridgeTest.java
@@ -241,10 +241,19 @@ public class HintsLibraryBridgeTest {
         assertNull(INSTANCE.preprocess(
                 crs, new int[] {0, 1, 2}, new byte[][] {hints0, hints1, hints2}, new long[] {111, 1, 222}, 4));
 
-        // uncorrupt the hints and do a sanity check
+        // uncorrupt the hints
         hints1[17]--;
         hints1[111]++;
         hints1[302]--;
+        // and check if weights cannot overflow `long`:
+        assertNull(INSTANCE.preprocess(
+                crs,
+                new int[] {0, 1, 2},
+                new byte[][] {hints0, hints1, hints2},
+                new long[] {Long.MAX_VALUE - 1L, 1, 222},
+                4));
+
+        // and finally do a sanity check:
         assertNotNull(INSTANCE.preprocess(
                 crs, new int[] {0, 1, 2}, new byte[][] {hints0, hints1, hints2}, new long[] {111, 1, 222}, 4));
     }

--- a/cryptography/hedera-cryptography-rpm/build.gradle.kts
+++ b/cryptography/hedera-cryptography-rpm/build.gradle.kts
@@ -10,7 +10,7 @@ cargo { libname = "raps" }
 testModuleInfo {
     requires("org.junit.jupiter.api")
     requires("org.junit.jupiter.params")
-    requires("com.hedera.cryptography.hints")
+    runtimeOnly("com.hedera.cryptography.hints")
 }
 
 tasks.test { environment(mapOf("TSS_LIB_NUM_OF_CORES" to "10")) }

--- a/cryptography/hedera-cryptography-rpm/src/main/java/com/hedera/cryptography/rpm/HistoryLibraryBridge.java
+++ b/cryptography/hedera-cryptography-rpm/src/main/java/com/hedera/cryptography/rpm/HistoryLibraryBridge.java
@@ -2,6 +2,7 @@
 package com.hedera.cryptography.rpm;
 
 import com.hedera.common.nativesupport.SingletonLoader;
+import com.hedera.cryptography.hints.HintsLibraryBridge;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -122,7 +123,10 @@ public class HistoryLibraryBridge {
      * @return the hash of the address book
      */
     public byte[] hashAddressBook(final byte[][] verifyingKeys, final long[] weights) {
-        if (verifyingKeys == null || weights == null || verifyingKeys.length != weights.length) {
+        if (verifyingKeys == null
+                || weights == null
+                || verifyingKeys.length != weights.length
+                || !HintsLibraryBridge.validateWeightsSum(weights)) {
             return null;
         }
         return hashAddressBookImpl(verifyingKeys, weights);
@@ -185,7 +189,9 @@ public class HistoryLibraryBridge {
                 || nextAddressBookHintsVerificationKeyHash == null
                 || nextAddressBookHintsVerificationKeyHash.length == 0
                 || signatures == null
-                || signatures.length == 0) {
+                || signatures.length == 0
+                || !HintsLibraryBridge.validateWeightsSum(currentAddressBookWeights)
+                || !HintsLibraryBridge.validateWeightsSum(nextAddressBookWeights)) {
             return null;
         }
         if (currentAddressBookVerifyingKeys.length != currentAddressBookWeights.length

--- a/cryptography/hedera-cryptography-rpm/src/main/java/module-info.java
+++ b/cryptography/hedera-cryptography-rpm/src/main/java/module-info.java
@@ -5,4 +5,5 @@ module com.hedera.cryptography.rpm {
     exports com.hedera.cryptography.rpm;
 
     requires com.hedera.common.nativesupport;
+    requires com.hedera.cryptography.hints;
 }


### PR DESCRIPTION
**Description**:
Limit the maximum sum of weights to 2^63 which doesn't overflow Java signed `long`, and certainly doesn't overflow Rust `u64`.

**Related issue(s)**:

Fixes #350 

**Notes for reviewer**:
A new test is added.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
