### PR TITLE
build: change publishing to use maven central publishing portal

### DIFF
--- a/.github/workflows/publish_snapshot_release.yml
+++ b/.github/workflows/publish_snapshot_release.yml
@@ -87,15 +87,9 @@ jobs:
         run: ./gradlew assemble
 
       # The steps below publish the artifacts to the Maven Central Nexus repository.
-      # Set -PpublishTestRelease=true when publishing snapshots
-      - name: Gradle Publish to Maven Central - common
+      # TODO remove -PpublishTestRelease=true for fully automated (non-snapshot) releases
+      - name: Gradle Publish to Maven Central
         env:
           NEXUS_USERNAME: ${{ secrets.SVCS_OSSRH_USER_NAME }}
           NEXUS_PASSWORD: ${{ secrets.SVCS_OSSRH_USER_PASSWORD }}
-        run: ./gradlew releaseMavenCentral -PpublishingPackageGroup=com.hedera.common -PpublishSigningEnabled=true --no-configuration-cache -PpublishTestRelease=true
-
-      - name: Gradle Publish to Maven Central - cryptography
-        env:
-          NEXUS_USERNAME: ${{ secrets.SVCS_OSSRH_USER_NAME }}
-          NEXUS_PASSWORD: ${{ secrets.SVCS_OSSRH_USER_PASSWORD }}
-        run: ./gradlew releaseMavenCentral -PpublishingPackageGroup=com.hedera.cryptography -PpublishSigningEnabled=true --no-configuration-cache -PpublishTestRelease=true
+        run: ./gradlew publishAggregationToCentralPortal -PpublishSigningEnabled=true -PpublishTestRelease=true

--- a/gradle/aggregation/build.gradle.kts
+++ b/gradle/aggregation/build.gradle.kts
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 plugins {
+    id("org.hiero.gradle.feature.publish-maven-central-aggregation")
     id("org.hiero.gradle.report.code-coverage")
     id("org.hiero.gradle.check.spotless")
     id("org.hiero.gradle.check.spotless-kotlin")
 }
 
 dependencies {
-    implementation(project(":hedera-cryptography-hinTS"))
-    implementation(project(":hedera-cryptography-rpm"))
+    published(project(":hedera-cryptography-hinTS"))
+    published(project(":hedera-cryptography-rpm"))
 }


### PR DESCRIPTION
**Description**:


⚠️ Only merge after we made switched the publishing mechanism on the Maven Central side.

For more details see: https://github.com/hiero-ledger/hiero-consensus-node/pull/19567

**Related issue(s)**:

https://github.com/hiero-ledger/hiero-consensus-node/pull/19567
