### PR TITLE
chore: update secret name to central publishing

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -109,8 +109,8 @@ jobs:
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
           GIT_COMMITTER_NAME: ${{ secrets.GIT_USER_NAME }}
           GIT_COMMITTER_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
-          NEXUS_USERNAME: ${{ secrets.SVCS_OSSRH_USER_NAME }}
-          NEXUS_PASSWORD: ${{ secrets.SVCS_OSSRH_USER_PASSWORD }}
+          NEXUS_USERNAME: ${{ secrets.CENTRAL_PUBLISHING_USERNAME }}
+          NEXUS_PASSWORD: ${{ secrets.CENTRAL_PUBLISHING_PASSWORD }}
           # The EDITOR var is required to ensure the tag is signed with the GPG key
           # as semantic-release doesn't support headless annotated signed tags and
           # the process hangs indefinitely awaiting input in the dialogue

--- a/.github/workflows/publish_snapshot_release.yml
+++ b/.github/workflows/publish_snapshot_release.yml
@@ -90,6 +90,6 @@ jobs:
       # TODO remove -PpublishTestRelease=true for fully automated (non-snapshot) releases
       - name: Gradle Publish to Maven Central
         env:
-          NEXUS_USERNAME: ${{ secrets.SVCS_OSSRH_USER_NAME }}
-          NEXUS_PASSWORD: ${{ secrets.SVCS_OSSRH_USER_PASSWORD }}
+          NEXUS_USERNAME: ${{ secrets.CENTRAL_PUBLISHING_USERNAME }}
+          NEXUS_PASSWORD: ${{ secrets.CENTRAL_PUBLISHING_PASSWORD }}
         run: ./gradlew publishAggregationToCentralPortal -PpublishSigningEnabled=true -PpublishTestRelease=true


### PR DESCRIPTION
**Description**:

Update the secrets for Maven central publishing.

**Related Issue(s)**:

Fixes #370
