### PR TITLE
build: upgrade cargo to 1.85

### DIFF
--- a/gradle/toolchain-versions.properties
+++ b/gradle/toolchain-versions.properties
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 jdk=21.0.6
-rust=1.83.0
+rust=1.85.0
 cargo-zigbuild=0.19.5
 zig=0.13.0
 xwin=0.6.5


### PR DESCRIPTION
**Description**:
Fixing
```
error: failed to download `base64ct v1.8.0`

Caused by:
  unable to get packages from source

Caused by:
  failed to parse manifest at `/home/runner/_work/hedera-cryptography/hedera-cryptography/build/rust-toolchains/cargo/registry/src/index.crates.io-6f17d22bba15001f/base64ct-1.8.0/Cargo.toml`

Caused by:
  feature `edition2024` is required

  The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.83.0 (5ffbef321 2024-10-29)).
  Consider trying a newer version of Cargo (this may require the nightly release).
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
```

**Related issue(s)**:

Fixes #376 

**Notes for reviewer**:
Build should succeed.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
