### PR TITLE
test: download WRAPS artifact and enable proof tests

### DIFF
--- a/buildSrc/src/main/kotlin/DownloadWrapsArtifactTask.gradle.kts
+++ b/buildSrc/src/main/kotlin/DownloadWrapsArtifactTask.gradle.kts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+import java.net.URI
+import org.gradle.api.internal.file.FileOperations
+
+// Support the proof construction and verification test in WRAPS 2.0 by preparing a large binary artifact:
+val wrapsArtifactDir = layout.buildDirectory.dir("wraps-artifact")
+
+abstract class DownloadWrapsArtifactTask : DefaultTask() {
+    @get:Inject protected abstract val files: FileOperations
+
+    @get:OutputDirectories abstract val wrapsDir: DirectoryProperty
+
+    @TaskAction
+    fun action() {
+        val out = wrapsDir.get().dir("v0.1.0")
+        files.mkdir(out)
+
+        // This is a 3GB download, so we only do this if we must:
+        val filename = "wraps-v0.1.0.tar.gz"
+        val uri = "https://builds.hedera.com/tss/hiero/wraps/v0.1/$filename"
+        val url = URI(uri).toURL()
+        val tarball = wrapsDir.get().file(filename).asFile
+        if (!tarball.exists()) {
+            println("Downloading $uri to ${tarball.absolutePath}")
+            // file.writeBytes(url.readBytes()) runs out of heap space, so we copy streams instead:
+            url.openStream().use { input ->
+                tarball.outputStream().use { output -> input.copyTo(output) }
+            }
+        } else {
+            println("$uri has already been downloaded as: ${tarball.absolutePath}")
+        }
+        // Just one of the artifact files, good enough for a quick test:
+        val testArtifactFileName = "decider_pp.bin"
+        if (!files.file(out.file(testArtifactFileName)).exists()) {
+            println("Extracting ${tarball.absolutePath} to ${out.asFile.absolutePath}")
+            files.sync {
+                from(files.tarTree(tarball))
+                into(out)
+            }
+        } else {
+            println(
+                "Not extracting Wraps artifact as it already exists: e.g. ${out.file(testArtifactFileName).asFile.absolutePath}"
+            )
+        }
+    }
+}
+
+tasks.register<DownloadWrapsArtifactTask>("downloadWrapsArtifactTask") {
+    wrapsDir.convention(wrapsArtifactDir)
+}

--- a/cryptography/hedera-cryptography-WRAPS/build.gradle.kts
+++ b/cryptography/hedera-cryptography-WRAPS/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("org.hiero.gradle.module.library")
     id("org.hiero.gradle.feature.rust")
     id("org.hiero.gradle.feature.test-multios")
+    id("DownloadWrapsArtifactTask")
 }
 
 cargo { libname = "wraps" }
@@ -13,15 +14,20 @@ testModuleInfo {
 }
 
 tasks.test {
+    dependsOn("downloadWrapsArtifactTask")
     environment(
         mapOf(
             // For the TSS lib:
-            "TSS_LIB_NUM_OF_CORES" to "10"
+            "TSS_LIB_NUM_OF_CORES" to "10",
 
             // Path to nova_pp.bin, decider_pp.bin, nova_vp.bin, and decider_vp.bin :
-            // FUTURE WORK: once CI team uploads the artifacts to CDN, download them and set the
-            // path here:
-            // "TSS_LIB_WRAPS_ARTIFACTS_PATH" to "<some-path>",
+            "TSS_LIB_WRAPS_ARTIFACTS_PATH" to
+                (tasks.named("downloadWrapsArtifactTask").get().property("wrapsDir")
+                        as DirectoryProperty)
+                    .get()
+                    .dir("v0.1.0")
+                    .asFile
+                    .absolutePath,
         )
     )
 }

--- a/cryptography/hedera-cryptography-WRAPS/src/test/java/com/hedera/cryptography/wraps/WRAPSLibraryBridgeTest.java
+++ b/cryptography/hedera-cryptography-WRAPS/src/test/java/com/hedera/cryptography/wraps/WRAPSLibraryBridgeTest.java
@@ -647,6 +647,7 @@ public class WRAPSLibraryBridgeTest {
 
         assertEquals(30331352, proof0.uncompressed().length);
         assertEquals(704, proof0.compressed().length);
+
         // Note: the compressed proof is non-deterministic, so we can only check the size, and then verify it:
         assertTrue(WRAPS.verifyCompressedProof(proof0.compressed()));
 


### PR DESCRIPTION
**Description**:
1. Adding a Gradle task to download and extract WRAPS binary artifacts
2. Modify the `test` target in the WRAPS module to use the downloaded artifacts, and hence enable proof construction and verification tests.

**Related issue(s)**:

Fixes #438

**Notes for reviewer**:
With this fix, we should see something like `Computing proof0 which may take up to 30 minutes...` on the `test` target `stderr`, and the tests should succeed (after those 30 minutes, that is.) Logs in GitHub don't seem to show the tests' `stderr`. However, here's what they do show at https://github.com/hashgraph/hedera-cryptography/actions/runs/18950250452/job/54120504786?pr=440 :
```
> Task :hedera-cryptography-WRAPS:test

  10 passing (34m 57s)
```

Note that all the other tests in this module run very fast. The reason it took them more than 30 minutes is exactly the result of running the proof construction and verification tests. And they pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
