### PR TITLE
chore(ci): add write permissions to release workflow

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -30,7 +30,7 @@ defaults:
     shell: bash
 
 permissions:
-  contents: read
+  contents: write
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
**Description**:

The release workflow was not able to apply a tag in the repository because it did not have write permissions.

Test run [here](https://github.com/hashgraph/hedera-cryptography/actions/runs/19149841753/job/54736956506)
Log shows attempting to create the tag:
`[9:07:18 PM] [semantic-release] › ⚠  Skip v2.1.1 tag creation in dry-run mode`

**Related Issue(s)**:

Fixes #451
