### PR TITLE
chore(ci): add commit-analyzer preset to releaserc file

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -43,9 +43,6 @@
       "name": "main"
     },
     {
-      "name": "452-semantic-release-workflow-does-not-identify-bang-as-breaking-change"
-    },
-    {
       "name": "release/([0-9]+).([0-9]+)",
       "channel": "${name.replace(/release\\//g, '').split('.')[0]}.${name.replace(/release\\//g, '').split('.')[1]}.x",
       "range": "${name.replace(/release\\//g, '').split('.')[0]}.${name.replace(/release\\//g, '').split('.')[1]}.x"

--- a/.releaserc
+++ b/.releaserc
@@ -41,7 +41,8 @@
   ],
   "branches":[
     {
-      "name": "main"
+      "name": "main",
+      "name": "452-semantic-release-workflow-does-not-identify-bang-as-breaking-change"
     },
     {
       "name": "release/([0-9]+).([0-9]+)",

--- a/.releaserc
+++ b/.releaserc
@@ -45,7 +45,7 @@
     },
     {
       "name": "452-semantic-release-workflow-does-not-identify-bang-as-breaking-change"
-    }
+    },
     {
       "name": "release/([0-9]+).([0-9]+)",
       "channel": "${name.replace(/release\\//g, '').split('.')[0]}.${name.replace(/release\\//g, '').split('.')[1]}.x",

--- a/.releaserc
+++ b/.releaserc
@@ -41,9 +41,11 @@
   ],
   "branches":[
     {
-      "name": "main",
-      "name": "452-semantic-release-workflow-does-not-identify-bang-as-breaking-change"
+      "name": "main"
     },
+    {
+      "name": "452-semantic-release-workflow-does-not-identify-bang-as-breaking-change"
+    }
     {
       "name": "release/([0-9]+).([0-9]+)",
       "channel": "${name.replace(/release\\//g, '').split('.')[0]}.${name.replace(/release\\//g, '').split('.')[1]}.x",

--- a/.releaserc
+++ b/.releaserc
@@ -1,8 +1,7 @@
 {
   "plugins": [
-    "@semantic-release/commit-analyzer",
     [
-      "@semantic-release/release-notes-generator",
+      "@semantic-release/commit-analyzer",
       {
         "preset": "conventionalcommits"
       }

--- a/.releaserc
+++ b/.releaserc
@@ -7,6 +7,12 @@
         "preset": "conventionalcommits"
       }
     ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
     "@semantic-release/git",
     "@semantic-release/github"
   ],


### PR DESCRIPTION
**Description**:

Update the `.releaserc` file for semantic release to correctly identify a bang as a major version roll.

Example run [here](https://github.com/hashgraph/hedera-cryptography/actions/runs/19150578811/job/54739437883) showing version roll to `v3.0.0`.
`[9:36:08 PM] [semantic-release] › ⚠  Skip v3.0.0 tag creation in dry-run mode`

**Related Issue(s)**:

Fixes #452
