### PR TITLE
feat: support optional memory-on-disk for WRAPS

### DIFF
--- a/cryptography/hedera-cryptography-wraps/build.gradle.kts
+++ b/cryptography/hedera-cryptography-wraps/build.gradle.kts
@@ -28,6 +28,10 @@ tasks.test {
                     .dir("v0.1.0")
                     .asFile
                     .absolutePath,
+
+            // Commented-out just to provide an example of how to enable swap for WRAPS 2.0.
+            // When not set, the proof construction may require up to ~20GB of RAM.
+            // "TSS_LIB_WRAPS_SWAP_FILE" to "/tmp/MemoryMapFile",
         )
     )
 }

--- a/cryptography/hedera-cryptography-wraps/src/main/java/com/hedera/cryptography/wraps/WRAPSLibraryBridge.java
+++ b/cryptography/hedera-cryptography-wraps/src/main/java/com/hedera/cryptography/wraps/WRAPSLibraryBridge.java
@@ -30,6 +30,13 @@ public class WRAPSLibraryBridge {
 
     /**
      * Returns the singleton instance of this library adapter.
+     * <p>
+     * An optional TSS_LIB_WRAPS_SWAP_FILE environment variable may be defined to point to a file name
+     * that will be used as a memory-on-disk for the WRAPS 2.0 native code.
+     * The size of the file is hard-coded in the native code as a static constant due to Rust language specifics.
+     * See src/main/rust/wraps/src/alloc.rs for the definitions.
+     * If the env var is undefined, or the file cannot be open/created/resized, or any other errors occur,
+     * then the library will use the system RAM only.
      *
      * @return the singleton instance of this library adapter.
      */

--- a/cryptography/hedera-cryptography-wraps/src/main/rust/wraps/src/alloc.rs
+++ b/cryptography/hedera-cryptography-wraps/src/main/rust/wraps/src/alloc.rs
@@ -6,7 +6,9 @@ mod bitmap;
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::cell::UnsafeCell;
 use std::sync::Mutex;
-use memmap2::{MmapMut, UncheckedAdvice};
+
+// Commented out on purpose. See a comment below where it's used.
+use memmap2::{MmapMut /*, UncheckedAdvice*/};
 
 use filemap::FileMap;
 use bitmap::BitMap;
@@ -77,7 +79,9 @@ unsafe impl GlobalAlloc for MemmapAllocator {
                 // The below operation is only supported on Linux currently, so we ignore any errors.
                 // Any OS will eventually free this range anyway. This is just a hint:
                 // unwrap() is safe because we checked is_some() above:
-                let _ = self.file_map.get_map().unwrap().unchecked_advise_range(UncheckedAdvice::DontNeed, offset, layout.size());
+                // However, memmap actually doesn't export the UncheckedAdvice and this method on MS Windows,
+                // and we happen to build this code on Windows. So unfortunately, we cannot use this:
+                // let _ = self.file_map.get_map().unwrap().unchecked_advise_range(UncheckedAdvice::DontNeed, offset, layout.size());
 
                 // lock() will block until the mutex is available, so it's safe to unwrap().
                 // If the lock indeed fails and the Result is an Err then we're already in a bigger trouble.

--- a/cryptography/hedera-cryptography-wraps/src/main/rust/wraps/src/alloc.rs
+++ b/cryptography/hedera-cryptography-wraps/src/main/rust/wraps/src/alloc.rs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+
+mod filemap;
+mod bitmap;
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::UnsafeCell;
+use std::sync::Mutex;
+use memmap2::{MmapMut, UncheckedAdvice};
+
+use filemap::FileMap;
+use bitmap::BitMap;
+
+/// Allocate small objects in RAM, larger objects on disk
+const SIZE_THRESHOLD_BYTES: usize = 64 * 1024;
+
+/// Disk file size in bytes. Unfortunately, this must be a compile-time constant.
+const HEAP_SIZE_BYTES: u64 = 20 * 1024 * 1024 * 1024;
+
+/// Allocation unit size in bytes. Heap size must be divisible by the block size.
+const BLOCK_SIZE_BYTES: usize = SIZE_THRESHOLD_BYTES;
+
+/// Number of blocks in the file on disk.
+const NUM_OF_BLOCKS: usize = (HEAP_SIZE_BYTES / BLOCK_SIZE_BYTES as u64) as usize;
+
+/// A memory allocator that attempts to allocate larger objects in a memory mapped file on disk.
+pub struct MemmapAllocator {
+    // BitMap needs to be thread-safe, so it's in a Mutex:
+    bit_map: Mutex<BitMap<NUM_OF_BLOCKS>>,
+    file_map: FileMap,
+}
+
+impl MemmapAllocator {
+    pub const fn new() -> Self {
+        MemmapAllocator {
+            bit_map: Mutex::new(BitMap::new()),
+            file_map: FileMap::new(HEAP_SIZE_BYTES)
+        }
+    }
+}
+
+// Required for allocators defined in static objects.
+unsafe impl Sync for MemmapAllocator {}
+
+/// The actual allocator implementation. In case the layout size is smaller than the threshold
+/// or if any errors occur with the memory on disk, then fall back to using the system memory.
+/// Try to never crash/panic/segfault.
+unsafe impl GlobalAlloc for MemmapAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if layout.size() >= SIZE_THRESHOLD_BYTES && self.file_map.get_map().is_some() {
+            // Try the map
+            let num_of_blocks = (layout.size() + BLOCK_SIZE_BYTES - 1) / BLOCK_SIZE_BYTES;
+
+            // lock() will block until the mutex is available, so it's safe to unwrap().
+            // If the lock indeed fails and the Result is an Err then we're already in a bigger trouble.
+            // Also, put inside {} to release the lock ASAP.
+            let index = { self.bit_map.lock().unwrap().alloc(num_of_blocks) };
+            if index < NUM_OF_BLOCKS {
+                // unwrap() is safe because we checked is_some() above:
+                return self.file_map.get_map().unwrap().as_mut_ptr().add(index * BLOCK_SIZE_BYTES)
+            }
+        }
+        // If size is small or map is full, then use system RAM:
+        System.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if self.file_map.get_map().is_some() {
+            // unwrap() is safe because we checked is_some() above:
+            let start_ptr = self.file_map.get_map().unwrap().as_mut_ptr();
+            let finish_ptr = start_ptr.add(HEAP_SIZE_BYTES as usize);
+            if ptr >= start_ptr && ptr < finish_ptr {
+                let offset = ptr.offset_from(start_ptr) as usize;
+                let index = offset as usize / BLOCK_SIZE_BYTES;
+                let num_of_blocks = (layout.size() + BLOCK_SIZE_BYTES - 1) / BLOCK_SIZE_BYTES;
+
+                // The below operation is only supported on Linux currently, so we ignore any errors.
+                // Any OS will eventually free this range anyway. This is just a hint:
+                // unwrap() is safe because we checked is_some() above:
+                let _ = self.file_map.get_map().unwrap().unchecked_advise_range(UncheckedAdvice::DontNeed, offset, layout.size());
+
+                // lock() will block until the mutex is available, so it's safe to unwrap().
+                // If the lock indeed fails and the Result is an Err then we're already in a bigger trouble.
+                self.bit_map.lock().unwrap().dealloc(index, num_of_blocks);
+                return;
+            }
+        }
+        // If the pointer is outside the map or there's no map at all, then it's system RAM:
+        System.dealloc(ptr, layout);
+    }
+}

--- a/cryptography/hedera-cryptography-wraps/src/main/rust/wraps/src/alloc/bitmap.rs
+++ b/cryptography/hedera-cryptography-wraps/src/main/rust/wraps/src/alloc/bitmap.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::cell::UnsafeCell;
+
+/// A map of SIZE bits that allows one to allocate/deallocate continuous regions of bits.
+/// The SIZE must be a compile-time constant because Rust array sizes must be compile-time constants.
+/// The implementation is not thread-safe. A client code is responsible for thread-safety.
+pub struct BitMap<const SIZE: usize> {
+    // For simplicity, and to avoid taking dependencies on bit-handling crates, we use a [bool].
+    // This may not be super efficient. However, with our heap and block sizes, this results
+    // in a very reasonable memory usage. E.g. our current 20GB/64KB=320KB, which is a very
+    // reasonable size for this array. Shrinking it 8 times wouldn't have a noticeable effect.
+    bits: UnsafeCell<[bool; SIZE]>
+}
+
+impl<const SIZE: usize> BitMap<SIZE> {
+    pub const fn new() -> Self {
+        BitMap {
+            bits: UnsafeCell::new([false; SIZE])
+        }
+    }
+
+    /// Allocates `size` bits by flipping them to `true` and returns the start index.
+    /// On error (zero size, "out of memory" - aka out of `false` bits, etc.), return usize::MAX.
+    pub unsafe fn alloc(&self, size: usize) -> usize {
+        if size == 0 {
+            return usize::MAX
+        }
+
+        let bits_pointer = self.bits.get().cast::<bool>();
+
+        // Trying to maintain the tail of the last allocated block and then start the search from
+        // there, and then flip to the head of the map seems like a reasonable approach.
+        // However, it may be complex to compute a proper `to` boundary for the second search from
+        // the head because there may still be free bits at the beginning of the tail.
+        // It would be complex to return two values from the `find` method.
+        // Therefore, for simplicity, we just search the array from 0 to SIZE every time.
+        // The array is reasonably small (provided the block size is reasonably large),
+        // so this shouldn't cause performance problems.
+        let index = self.find_false_bits(bits_pointer, size, 0, SIZE);
+        if index >= SIZE {
+            return usize::MAX
+        }
+
+        for i in index..index+size {
+            *bits_pointer.add(i) = true;
+        }
+        index
+    }
+
+    /// Deallocates `size` bits at `index` by flipping them to `false`.
+    pub unsafe fn dealloc(&self, index: usize, size: usize) {
+        // Try to prevent SEGFAULTs:
+        if index >= SIZE || index+size > SIZE {
+            return;
+        }
+
+        let bits_pointer = self.bits.get().cast::<bool>();
+        for i in index..index+size {
+            *bits_pointer.add(i) = false;
+        }
+    }
+
+    /// Finds `size` continuous `false` bits and returns the start index, or usize::MAX
+    /// from is inclusive, to is exclusive.
+    /// A client code is responsible for not deallocating bits that haven't been allocated in the first place.
+    unsafe fn find_false_bits(&self, bits_pointer: *const bool, size: usize, from: usize, to: usize) -> usize {
+        let mut cur = from;
+        while cur <= to - size {
+            if *bits_pointer.add(cur) {
+                cur += 1;
+                continue
+            }
+
+            // bits[cur] is false here
+
+            // Small optimization for the smallest case to avoid extra loops/conditions below:
+            if size == 1 {
+                return cur
+            }
+
+            // Generic solution for size > 1
+            let start = cur;
+            cur += 1;
+            while cur - start < size && cur < to && !*bits_pointer.add(cur) {
+                cur += 1;
+            }
+            if cur - start == size && cur < to {
+                return start
+            }
+
+            // There's no size `false` bits at start.
+            // Either cur >= to or bits[cur] == true here.
+            // Let's continue search from the next bit:
+            cur += 1
+        }
+
+        usize::MAX
+    }
+}

--- a/cryptography/hedera-cryptography-wraps/src/main/rust/wraps/src/alloc/filemap.rs
+++ b/cryptography/hedera-cryptography-wraps/src/main/rust/wraps/src/alloc/filemap.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::borrow::BorrowMut;
+use std::cell::{OnceCell, UnsafeCell};
+use std::env;
+use std::fs::{File, OpenOptions};
+use std::path::Path;
+use std::sync::{Mutex, OnceLock};
+use ark_std::iterable::Iterable;
+use memmap2::MmapMut;
+
+/// An instance holder for an optional mutable memory-mapped file.
+/// If the environment variable doesn't exist or doesn't specify a file name,
+/// then the option is empty.
+/// The implementation is thread-safe.
+pub struct FileMap {
+    file_size: u64,
+
+    // OnceLock to initialize once.
+    // UnsafeCell to be able to get mutable references to the MmapMut.
+    once_option_cell_map: OnceLock<Option<UnsafeCell<MmapMut>>>
+}
+
+// Cannot call env::var inside get_map below because that would want to deallocate the String object
+// which in turn would call dealloc(), and it in turn would call get_map() again, locking forever.
+// So we read the var into a static object here:
+static FILE_NAME: OnceLock<Option<String>> = OnceLock::new();
+fn get_file_name() -> &'static Option<String> {
+    FILE_NAME.get_or_init(|| {
+        match env::var("TSS_LIB_WRAPS_SWAP_FILE") {
+            Ok(val) => Some(val),
+            Err(_) => None
+        }
+    })
+}
+
+impl FileMap {
+    pub const fn new(file_size: u64) -> Self {
+        FileMap {
+            file_size,
+            once_option_cell_map: OnceLock::new()
+        }
+    }
+
+    /// Get an optional mutable reference to the memory mapped file.
+    pub unsafe fn get_map(&self) -> Option<&mut MmapMut> {
+        let option_cell = self.once_option_cell_map.get_or_init(|| {
+            // The tempfile::tempfile() must be using memory allocation/deallocation because
+            // when used here, it produces an infinite hang. A static OnceLock trick doesn't work
+            // for the tempfile either as it does for the file name env var above.
+            // And the NamedTempFile is not guaranteed to be deleted by OS.
+            // So we don't use either of these, and also avoid an extra dependency on tempfile.
+
+            // Instead, we use an env var with a file name to enable the SWAP.
+
+            // If the SWAP file name is undefined, or opening the file or the map fails,
+            // just return None and we won't use the SWAP then. We don't want to crash the process
+            // just yet because the system may in fact have sufficient RAM already.
+            let option_file_name = get_file_name();
+            if option_file_name.is_empty() {
+                return None;
+            }
+            // Safe unwrap() because is_empty() is checked above:
+            let file_name = option_file_name.as_ref().unwrap();
+
+            if file_name.trim().is_empty() {
+                return None;
+            }
+
+            let file = match OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(Path::new(&file_name)) {
+                Ok(file) => file,
+                Err(_) => return None
+            };
+
+            if file.set_len(self.file_size).is_err() {
+                return None
+            }
+
+            let map = match MmapMut::map_mut(&file) {
+                Ok(val) => val,
+                Err(_) => return None
+            };
+
+            Some(UnsafeCell::new(map))
+        });
+
+        // Convert Option<UnsafeCell<MmapMut>> to Option<&mut MmapMut>:
+        option_cell.as_ref().map(|cell| &mut *cell.get())
+    }
+}

--- a/cryptography/hedera-cryptography-wraps/src/main/rust/wraps/src/lib.rs
+++ b/cryptography/hedera-cryptography-wraps/src/main/rust/wraps/src/lib.rs
@@ -12,6 +12,7 @@ mod random_oracle;
 mod utils;
 mod jni_util;
 mod jni_wraps;
+mod alloc;
 
 use digest::typenum::bit;
 use signature::{*};
@@ -178,6 +179,10 @@ struct ProofData {
     pub u_i_commitments: Vec<G1>,
     pub proof: EthProof<G1, KZG<'static, PairingCurve>, Groth16<PairingCurve>>,
 }
+
+/********************************* Custom GlobalAlloc *********************************/
+#[global_allocator]
+static ALLOCATOR: crate::alloc::MemmapAllocator = crate::alloc::MemmapAllocator::new();
 
 /********************************* Useful Definitions *********************************/
 
@@ -1008,7 +1013,7 @@ impl WRAPS {
         )?;
         Ok(verified)
     }
-        
+
 }
 
 #[cfg(test)]

--- a/cryptography/hedera-cryptography-wraps/src/main/rust/wraps/src/lib.rs
+++ b/cryptography/hedera-cryptography-wraps/src/main/rust/wraps/src/lib.rs
@@ -1013,7 +1013,6 @@ impl WRAPS {
         )?;
         Ok(verified)
     }
-
 }
 
 #[cfg(test)]


### PR DESCRIPTION
**Description**:
WRAPS 2.0 may use up to 20 GB memory when constructing an AddressBook change proof. This is measured by the unit test ~which uses very small ABs. So I presume the code may require even more memory with real-sized ABs. Regardless, even~ the 20 GB may be too large for smaller environments such as Solo use-cases and similar. So we want to have an option to use a file on disk for memory used by the WRAPS 2.0 code.

Introducing a `MemmapAllocator` that implements a `GlobalAlloc` memory allocator in Rust for the WRAPS 2.0 native code. The allocator uses a memory-mapped file on disk to allocate memory for the library. See the head of the `alloc.rs` for constant size definitions. The allocator uses two utility objects:
* `FileMap` that holds a reference to the memory-mapped file itself
* `BitMap` that maintains a bit-map of (un)allocated blocks in the `FileMap`.

This feature is off by default and the library uses the system RAM by default. To enable the on-disk memory, one needs to specify the `TSS_LIB_WRAPS_SWAP_FILE` environment variable with a name of the file where that on-disk memory will be located. If any errors occur (or if we run out of the memory on-disk), then the allocator will fall back to using the system RAM again.

I've only been able to test this on my developer laptop which has a lot of free RAM. So even with this feature enabled and allocations actually happening in the memory-mapped file, the OS probably didn't touch the actual disk too much. Runtime-wise, running tests took pretty much the exact same time as without this custom allocator enabled. However, memory usage in the System Monitor clearly showed that the system RAM usage for the `java` process was almost always around 100MB and only briefly spiked to something like 6 GB, while the process kept using some 20 GB of the total memory - that was our on-disk file usage.

**Related issue(s)**:

Fixes #444

**Notes for reviewer**:
The feature is disabled by default, so there's no any breaking changes.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
