### PR TITLE
perf: fine-tune TSS swap

### DIFF
--- a/cryptography/hedera-cryptography-wraps/src/main/rust/wraps/src/alloc.rs
+++ b/cryptography/hedera-cryptography-wraps/src/main/rust/wraps/src/alloc.rs
@@ -13,11 +13,39 @@ use memmap2::{MmapMut /*, UncheckedAdvice*/};
 use filemap::FileMap;
 use bitmap::BitMap;
 
-/// Allocate small objects in RAM, larger objects on disk
-const SIZE_THRESHOLD_BYTES: usize = 64 * 1024;
+// As of 2025-12-10, RAM usage in GB with various parameters:
+//
+// Threshold \ Swap, GB |     16     |     20     |     24     |     30     |     40
+// --------------------------------------------------------------------------------------
+//    64 KB             |    7       |            |            |            |
+//    32 KB             |    5.7     |            |            |            |
+//    16 KB             |    5.6     |            |            |            |
+//     8 KB             |    4.3     |            |            |            |
+//     4 KB             |    3       |            |            |            |
+//     2 KB             |    3.64    |    2.64    |            |            |
+//     1 KB             |    4.9     |    2.59    |    1.73    |    1.86    |    1.86
+//   512 B              |            |            |            |            |    1.83
+//   256 B              |            |            |            |            |    1.79
+//   128 B              |    5       |    2.69    |            |            |    1.73
+//
+// Note that the code doesn't really use more than about 16 GB of memory in total. However,
+// a larger swap reduces the effect of fragmentation which normally results in allocating RAM
+// instead of a space in the swap file. Hence the reason for testing with swap sizes >16 GB.
+//
+// Note that the system wouldn't run with a threshold of 64 bytes for unknown reason - likely
+// because the bitmap boolean array becomes too large. We could consider switching from bool
+// to u64 and using actual bits, but that would add unwanted complexity.
+//
+// Note that if the WRAPS implementation, or the memory allocator implementation change,
+// some of the numbers may change too.
+//
+// As of now, 24 GB swap with a threshold of 1 KB seems the most reasonable combination:
 
-/// Disk file size in bytes. Unfortunately, this must be a compile-time constant.
-const HEAP_SIZE_BYTES: u64 = 16 * 1024 * 1024 * 1024;
+/// Allocate small objects in RAM, larger objects on disk
+const SIZE_THRESHOLD_BYTES: usize = 1024;
+
+/// Disk file size in bytes, aka swap size. Unfortunately, this must be a compile-time constant.
+const HEAP_SIZE_BYTES: u64 = 24 * 1024 * 1024 * 1024;
 
 /// Allocation unit size in bytes. Heap size must be divisible by the block size.
 const BLOCK_SIZE_BYTES: usize = SIZE_THRESHOLD_BYTES;

--- a/cryptography/hedera-cryptography-wraps/src/main/rust/wraps/src/alloc/bitmap.rs
+++ b/cryptography/hedera-cryptography-wraps/src/main/rust/wraps/src/alloc/bitmap.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::cell::UnsafeCell;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::cmp;
 
 /// A map of SIZE bits that allows one to allocate/deallocate continuous regions of bits.
 /// The SIZE must be a compile-time constant because Rust array sizes must be compile-time constants.
@@ -8,15 +10,18 @@ use std::cell::UnsafeCell;
 pub struct BitMap<const SIZE: usize> {
     // For simplicity, and to avoid taking dependencies on bit-handling crates, we use a [bool].
     // This may not be super efficient. However, with our heap and block sizes, this results
-    // in a very reasonable memory usage. E.g. our current 20GB/64KB=320KB, which is a very
-    // reasonable size for this array. Shrinking it 8 times wouldn't have a noticeable effect.
-    bits: UnsafeCell<[bool; SIZE]>
+    // in a very reasonable memory usage. E.g. our current 24GB/1KB=24MB, which is reasonable.
+    bits: UnsafeCell<[bool; SIZE]>,
+
+    // The tail index of the last allocated block.
+    last_index: AtomicUsize
 }
 
 impl<const SIZE: usize> BitMap<SIZE> {
     pub const fn new() -> Self {
         BitMap {
-            bits: UnsafeCell::new([false; SIZE])
+            bits: UnsafeCell::new([false; SIZE]),
+            last_index: AtomicUsize::new(0)
         }
     }
 
@@ -29,26 +34,46 @@ impl<const SIZE: usize> BitMap<SIZE> {
 
         let bits_pointer = self.bits.get().cast::<bool>();
 
-        // Trying to maintain the tail of the last allocated block and then start the search from
-        // there, and then flip to the head of the map seems like a reasonable approach.
-        // However, it may be complex to compute a proper `to` boundary for the second search from
-        // the head because there may still be free bits at the beginning of the tail.
-        // It would be complex to return two values from the `find` method.
-        // Therefore, for simplicity, we just search the array from 0 to SIZE every time.
-        // The array is reasonably small (provided the block size is reasonably large),
-        // so this shouldn't cause performance problems.
-        let index = self.find_false_bits(bits_pointer, size, 0, SIZE);
+        // The search is generally O(N). However, if we always search from the very beginning after
+        // having allocated a lot of memory, this effectively becomes an O(n^2) search for the
+        // application as a whole.
+        // So we maintain the `last_index` which points to the tail of the last allocated block,
+        // i.e. it points to the first free block of memory, and we start the search from there.
+        // This makes the effective complexity being O(N). In fact, in many cases, the application
+        // experiences a complexity of O(1) when calling this search because we're likely to start
+        // the search with the very beginning of the block being allocated. Provided we have enough
+        // free blocks starting at this index, of course. Otherwise it's an honest O(N) search.
+        // Experiments show that this does in fact improve the overall performance of the allocator,
+        // especially as the block size becomes smaller, and hence the size of the bitmap becomes larger.
+        let last_index_value = self.last_index.load(Ordering::Relaxed);
+        // Search the tail first:
+        let (mut index, first_true_index) = self.find_false_bits(bits_pointer, size, last_index_value, SIZE);
+        if index >= SIZE && last_index_value != 0 {
+            // If not found and we didn't start with 0 before, then search the head:
+            (index, _) = self.find_false_bits(bits_pointer, size, 0, cmp::min(first_true_index, SIZE));
+        }
+
         if index >= SIZE {
             return usize::MAX
         }
 
-        for i in index..index+size {
+        // Remember where the allocated block ends. Next time, start search from there:
+        let the_end = index + size;
+        if the_end >= SIZE {
+            self.last_index.store(0, Ordering::Relaxed);
+        } else {
+            self.last_index.store(the_end, Ordering::Relaxed);
+        }
+
+        for i in index..the_end {
             *bits_pointer.add(i) = true;
         }
+
         index
     }
 
     /// Deallocates `size` bits at `index` by flipping them to `false`.
+    /// A client code is responsible for not deallocating bits that haven't been allocated in the first place.
     pub unsafe fn dealloc(&self, index: usize, size: usize) {
         // Try to prevent SEGFAULTs:
         if index >= SIZE || index+size > SIZE {
@@ -61,40 +86,52 @@ impl<const SIZE: usize> BitMap<SIZE> {
         }
     }
 
-    /// Finds `size` continuous `false` bits and returns the start index, or usize::MAX
-    /// from is inclusive, to is exclusive.
-    /// A client code is responsible for not deallocating bits that haven't been allocated in the first place.
-    unsafe fn find_false_bits(&self, bits_pointer: *const bool, size: usize, from: usize, to: usize) -> usize {
+    /// Finds `size` continuous `false` bits and returns the start index, or usize::MAX.
+    /// Argument `from` is inclusive, `to` is exclusive.
+    /// Returns (the start index, the first true bit index)
+    unsafe fn find_false_bits(&self, bits_pointer: *const bool, size: usize, from: usize, to: usize) -> (usize, usize) {
+        // For safety:
+        if to < from || size > to - from {
+            return (usize::MAX, usize::MAX);
+        }
+
         let mut cur = from;
-        while cur <= to - size {
+
+        // Where to finish the second search later, if there's one:
+        let mut first_true_index = usize::MAX;
+
+        // Use + , don't use - , because unsigned values! If size > to, then to-size overflows.
+        while cur + size <= to {
             if *bits_pointer.add(cur) {
+                if first_true_index == usize::MAX {
+                    first_true_index = cur;
+                }
                 cur += 1;
                 continue
             }
 
-            // bits[cur] is false here
+            // bits[cur] is false here, so `cur` is a candidate start index now.
 
             // Small optimization for the smallest case to avoid extra loops/conditions below:
             if size == 1 {
-                return cur
+                return (cur, first_true_index)
             }
 
             // Generic solution for size > 1
             let start = cur;
             cur += 1;
-            while cur - start < size && cur < to && !*bits_pointer.add(cur) {
+            while cur < start + size && cur < to && !*bits_pointer.add(cur) {
                 cur += 1;
             }
-            if cur - start == size && cur < to {
-                return start
+            if cur == start + size && cur < to {
+                return (start, first_true_index)
             }
 
-            // There's no size `false` bits at start.
+            // There's no `size` `false` bits at `start`.
             // Either cur >= to or bits[cur] == true here.
-            // Let's continue search from the next bit:
-            cur += 1
+            // The loop condition and the `true` check at the top will handle that.
         }
 
-        usize::MAX
+        (usize::MAX, first_true_index)
     }
 }


### PR DESCRIPTION
**Description**:
1. Optimizing our custom memory allocator in Rust to be performant with smaller swap block/threshold sizes. And also hardening it by avoiding unsigned integer math overflows.
2. Testing various combinations of parameters and adding a table with the results.
3. Setting the swap size to 24 GB and the threshold/block size to 1 KB.

With the current settings, when the swap is enabled, the library should use only 1.73 GB of RAM (let's call it 2 GB), with the rest of the memory being allocated in our custom swap file, which requires 24 GB of disk space.

If/when our RAM/disk requirements change, we can refer to the added table to fine-tune the parameters further.

**Related issue(s)**:

Fixes #474

**Notes for reviewer**:
All tests should pass. The fix only modifies the code path that runs when the TSS swap is enabled. Locally, with the swap enabled, all tests pass too.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
