### PR TITLE
fix: harden hinTS verifyAggregate() and add 1/2 threshold hard-coded version

### DIFF
--- a/cryptography/hedera-cryptography-hints/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
+++ b/cryptography/hedera-cryptography-hints/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
@@ -319,7 +319,8 @@ public class HintsLibraryBridge {
     /**
      * Checks an aggregate signature on a message verifies under a hinTS verification key, where
      * this is only true if the aggregate signature has weight exceeding the specified threshold
-     * or total weight stipulated in the verification key.
+     * of total weight stipulated in the verification key.
+     * It is recommended to use the overloaded version of this method that hard-codes the threshold to 1/2.
      *
      * @param signature the aggregate signature
      * @param message the message
@@ -345,6 +346,21 @@ public class HintsLibraryBridge {
             return false;
         }
         return verifyAggregateImpl(signature, message, verificationKey, thresholdNumerator, thresholdDenominator);
+    }
+
+    /**
+     * Checks an aggregate signature on a message verifies under a hinTS verification key, where
+     * this is only true if the aggregate signature has weight exceeding the 1/2 threshold
+     * of total weight stipulated in the verification key.
+     * This version of the method is recommended over the more generic version that accepts an arbitrary threshold.
+     *
+     * @param signature the aggregate signature
+     * @param message the message
+     * @param verificationKey the verification key
+     * @return true if the signature is valid; false otherwise
+     */
+    public boolean verifyAggregate(final byte[] signature, final byte[] message, final byte[] verificationKey) {
+        return verifyAggregate(signature, message, verificationKey, 1, 2);
     }
 
     private native boolean verifyAggregateImpl(

--- a/cryptography/hedera-cryptography-hints/src/main/rust/hints.rs
+++ b/cryptography/hedera-cryptography-hints/src/main/rust/hints.rs
@@ -288,7 +288,7 @@ impl HinTS {
         })
     }
 
-    /// verifies whether the extended public key (a.k.a. hint) is well-formed for the 
+    /// verifies whether the extended public key (a.k.a. hint) is well-formed for the
     /// given universe size n and index i; note that errors indicate incorrect inputs
     /// while a return value of false indicates that the hint is maliciously crafted
     pub fn verify_hint(
@@ -731,7 +731,11 @@ impl HinTS {
     ) -> Result<bool, HinTSError> {
         // check that the threshold is satisfied
         let (numerator, denominator) = fraction;
-        check_or_return_false!(denominator * π.agg_weight >= numerator * vk.total_weight);
+
+        // The threshold verification uses a strict comparison "greater than" to prevent network
+        // partition where two halves of a disconnected network could both produce valid signatures
+        // with a threshold of 1/2 if verified via a non-strict "greater than or equal to":
+        check_or_return_false!(denominator * π.agg_weight > numerator * vk.total_weight);
 
         // verify the signature first
         let lhs = <Curve as Pairing>::pairing(&π.agg_pk, hash_to_g2(msg)?);

--- a/cryptography/hedera-cryptography-hints/src/test/java/com/hedera/cryptography/hints/HintsLibraryBridgeTest.java
+++ b/cryptography/hedera-cryptography-hints/src/test/java/com/hedera/cryptography/hints/HintsLibraryBridgeTest.java
@@ -569,6 +569,8 @@ public class HintsLibraryBridgeTest {
         assertArrayEquals(HintsConstants.AGGREGATE_SIGNATURE_2, result);
 
         assertTrue(INSTANCE.verifyAggregate(result, HintsConstants.RANDOM_2, keys.verificationKey(), 1, 3));
+        // Also verify if it meets the 1/2 threshold, because it does:
+        assertTrue(INSTANCE.verifyAggregate(result, HintsConstants.RANDOM_2, keys.verificationKey()));
     }
 
     @Test
@@ -605,6 +607,8 @@ public class HintsLibraryBridgeTest {
         assertArrayEquals(HintsConstants.AGGREGATE_SIGNATURE_3, result);
 
         assertFalse(INSTANCE.verifyAggregate(result, HintsConstants.RANDOM_2, keys.verificationKey(), 1, 3));
+        // Also verify if it doesn't meet the 1/2 threshold, because it doesn't:
+        assertFalse(INSTANCE.verifyAggregate(result, HintsConstants.RANDOM_2, keys.verificationKey()));
     }
 
     @Test


### PR DESCRIPTION
**Description**:
1. Replace `>=` with `>` in Hints aggregate signature verification in order to protect from partitioned networks.
2. Provide a convenience overload method for `HintsLibraryBridge.verifyAggregate()` that hard-codes the threshold to 1/2.

**Related issue(s)**:

Fixes #478

**Notes for reviewer**:
Tests were updated to verify the new method.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
