### PR TITLE
chore(non-code): Update CODEOWNERS to include new maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,7 +33,7 @@ gradlew                                                 @hashgraph/platform-ci @
 gradlew.bat                                             @hashgraph/platform-ci @hashgraph/platform-ci-committers
 **/build-logic/                                         @hashgraph/platform-ci @hashgraph/platform-ci-committers
 **/gradle.*                                             @hashgraph/platform-ci @hashgraph/platform-ci-committers
-**/*.gradle.*                                           @hashgraph/platform-ci @hashgraph/platform-ci-committers
+**/*.gradle.*                                           @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/hedera-cryptography-maintainers
 
 # Codacy Tool Configurations
 /config/                                                @hashgraph/platform-ci @hashgraph/release-engineering-managers
@@ -43,7 +43,7 @@ gradlew.bat                                             @hashgraph/platform-ci @
 /CODEOWNERS                                             @hashgraph/release-engineering-managers
 
 # Protect the repository root files
-/README.md                                              @hashgraph/platform-ci @hashgraph/release-engineering-managers
+/README.md                                              @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/hedera-cryptography-maintainers
 **/LICENSE                                              @hashgraph/release-engineering-managers
 
 # CodeCov configuration


### PR DESCRIPTION
## Description

This pull request updates the `.github/CODEOWNERS` file to expand code ownership for certain files and patterns. The main change is the addition of the `@hashgraph/hedera-cryptography-maintainers` team as code owners for Gradle-related files and the `README.md` file.

Ownership updates:

* Added `@hashgraph/hedera-cryptography-maintainers` as code owners for all files matching the `**/*.gradle.*` pattern, in addition to the existing owners.
* Added `@hashgraph/hedera-cryptography-maintainers` as a code owner for `README.md`, alongside the existing owners.

## Related Issue(s)

Closes #495 