### PR TITLE
fix: bug in constructWrapsProof constraints validation

### DIFF
--- a/cryptography/hedera-cryptography-wraps/src/main/java/com/hedera/cryptography/wraps/WRAPSLibraryBridge.java
+++ b/cryptography/hedera-cryptography-wraps/src/main/java/com/hedera/cryptography/wraps/WRAPSLibraryBridge.java
@@ -409,7 +409,7 @@ public class WRAPSLibraryBridge {
                 || nextSchnorrPublicKeys.length == 0
                 || nextSchnorrPublicKeys.length != nextWeights.length
                 || nextNodeIds == null
-                || prevSchnorrPublicKeys.length != nextNodeIds.length
+                || nextSchnorrPublicKeys.length != nextNodeIds.length
                 || !WRAPSLibraryBridge.validateWeightsSum(nextWeights)
                 || tssVerificationKey == null
                 || tssVerificationKey.length == 0


### PR DESCRIPTION
**Description**:
A wrong constraint validation may prevent the construction of proofs for AB rotations. Just a silly bug/typo thing.

**Related issue(s)**:

Fixes #501 

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
