### PR TITLE
feat: optional cache for ProvingKey

### DIFF
--- a/cryptography/hedera-cryptography-wraps/build.gradle.kts
+++ b/cryptography/hedera-cryptography-wraps/build.gradle.kts
@@ -29,6 +29,10 @@ tasks.test {
                     .asFile
                     .absolutePath,
 
+            // Cache the proving key so we can construct proof multiple times in the same JVM
+            // w/o having to reload the proving key, which takes up to 27 minutes.
+            "TSS_LIB_WRAPS_ARTIFACTS_CACHE_ENABLED" to "true",
+
             // Commented-out just to provide an example of how to enable swap for WRAPS 2.0.
             // When not set, the proof construction may require up to ~16GB of RAM.
             // "TSS_LIB_WRAPS_SWAP_FILE" to "/tmp/MemoryMapFile",

--- a/cryptography/hedera-cryptography-wraps/src/main/rust/wraps/src/jni_wraps.rs
+++ b/cryptography/hedera-cryptography-wraps/src/main/rust/wraps/src/jni_wraps.rs
@@ -362,7 +362,7 @@ pub unsafe extern "system" fn Java_com_hedera_cryptography_wraps_WRAPSLibraryBri
     };
 
     let (uncompressed_proof, compressed_proof): (UncompressedProofSerialized, CompressedProofSerialized) = match WRAPS::construct_wraps_proof(
-            &pk,
+            pk.get_ref(),
             &vk,
             &ab_genesis_hash,
             &prev_ab,

--- a/cryptography/hedera-cryptography-wraps/src/main/rust/wraps/src/utils.rs
+++ b/cryptography/hedera-cryptography-wraps/src/main/rust/wraps/src/utils.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::env;
 use std::fs::File;
+use std::sync::OnceLock;
 use memmap2::Mmap;
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::{FftField, Field, Zero};
@@ -30,8 +31,59 @@ pub fn serialize<T: ark_serialize::CanonicalSerialize>(
 
 const ARTIFACTS_PATH_ENV_VAR: &str = "TSS_LIB_WRAPS_ARTIFACTS_PATH";
 
-/// Gets a ProvingKey.
-pub fn get_proving_key() -> Result<ProvingKey, WRAPSError> {
+/// This env var, when set to "true", enables a cache for the ProvingKey.
+/// The ProvingKey may consume ~6GB of RAM, so the caching is normally not desired because
+/// the key is only used to construct AddressBook rotations proofs. However, it may be useful
+/// in tests running in a single JVM (or an external dedicated JVM hosting the tss-lib) in order
+/// to not waste ~27 minutes loading the key from disk and deserializing it for every proof.
+const ARTIFACTS_CACHE_ENABLED_ENV_VAR: &str = "TSS_LIB_WRAPS_ARTIFACTS_CACHE_ENABLED";
+
+/// A utility for returning the key and freeing memory if necessary.
+/// An owned value will be released once the caller finishes. This is useful when the cache
+/// is disabled and each call loads a new key.
+/// A reference value will not be released because it's a reference to a static (cached) object.
+/// The caller can call `get_ref` and obtain a reference to the value w/o having to know whether
+/// the value is cached or owned.
+pub struct ProvingKeyWrapper {
+    owned_pk: Option<ProvingKey>,
+    ref_pk: Option<&'static ProvingKey>,
+}
+
+impl ProvingKeyWrapper {
+    /// Create a new owned value wrapper.
+    fn new_owned(owned_pk: ProvingKey) -> Self {
+        ProvingKeyWrapper {
+            owned_pk: Some(owned_pk),
+            ref_pk: None
+        }
+    }
+
+    /// Create a new cached value wrapper.
+    fn new_ref(ref_pk: &'static ProvingKey) -> Self {
+        ProvingKeyWrapper {
+            owned_pk: None,
+            ref_pk: Some(ref_pk)
+        }
+    }
+
+    /// Return a reference to the value.
+    pub unsafe fn get_ref(&self) -> &ProvingKey {
+        if self.ref_pk.is_some() {
+            return self.ref_pk.unwrap();
+        }
+        if self.owned_pk.is_some() {
+            return self.owned_pk.as_ref().unwrap();
+        }
+        // Re-iterating: this should never happen as ensured by the `new` constructors above:
+        panic!("Neither ref_pk nor owned_pk exists. This should never happen!");
+    }
+}
+
+/// A holder for a cached key (or empty `Option` when the cache is disabled).
+static PROVING_KEY: OnceLock<Option<ProvingKey>> = OnceLock::new();
+
+/// Loads the key from disk directly.
+fn load_proving_key() -> Result<ProvingKey, WRAPSError> {
     let artifacts_path = match env::var(ARTIFACTS_PATH_ENV_VAR) {
         Ok(val) => val,
         Err(_) => return Err(WRAPSError::BinaryArtifactMissing)
@@ -48,6 +100,35 @@ pub fn get_proving_key() -> Result<ProvingKey, WRAPSError> {
     }.map_err(|_| WRAPSError::BinaryArtifactMissing)?;
 
     WRAPS::setup_prover(nova_pp_map, decider_pp_map)
+}
+
+/// A utility getter for the cached PROVING_KEY that implements its `OnceLock` initialization.
+/// Returns an empty `Option` if the cache is disabled or errors occur during loading the key.
+fn get_cached_proving_key() -> &'static Option<ProvingKey> {
+    PROVING_KEY.get_or_init(|| {
+        let cache_enabled_str = match env::var(ARTIFACTS_CACHE_ENABLED_ENV_VAR) {
+            Ok(val) => val,
+            Err(_) => return None
+        };
+
+        if cache_enabled_str.to_lowercase() != "true" {
+            return None;
+        }
+
+        match load_proving_key() {
+            Ok(val) => Some(val),
+            Err(_) => None
+        }
+    })
+}
+
+/// Gets a ProvingKeyWrapper. May return a cached value if the cache is enabled, or load
+/// a new key otherwise. The ProvingKeyWrapper will take care of releasing memory if needed.
+pub fn get_proving_key() -> Result<ProvingKeyWrapper, WRAPSError> {
+    match get_cached_proving_key() {
+        Some(val) => Ok(ProvingKeyWrapper::new_ref(val)),
+        None => load_proving_key().map(|pk| ProvingKeyWrapper::new_owned(pk))
+    }
 }
 
 /// Gets a VerificationKey.

--- a/cryptography/hedera-cryptography-wraps/src/main/rust/wraps/src/utils.rs
+++ b/cryptography/hedera-cryptography-wraps/src/main/rust/wraps/src/utils.rs
@@ -67,7 +67,7 @@ impl ProvingKeyWrapper {
     }
 
     /// Return a reference to the value.
-    pub unsafe fn get_ref(&self) -> &ProvingKey {
+    pub fn get_ref(&self) -> &ProvingKey {
         if self.ref_pk.is_some() {
             return self.ref_pk.unwrap();
         }

--- a/cryptography/hedera-cryptography-wraps/src/test/java/com/hedera/cryptography/wraps/WRAPSLibraryBridgeTest.java
+++ b/cryptography/hedera-cryptography-wraps/src/test/java/com/hedera/cryptography/wraps/WRAPSLibraryBridgeTest.java
@@ -839,16 +839,12 @@ public class WRAPSLibraryBridgeTest {
         // Note: the compressed proof is non-deterministic, so we can only check the size, and then verify it:
         assertTrue(WRAPS.verifyCompressedProof(proof0.compressed(), genesisAddressBookHash, dummyHintsKey));
 
-        if (true) {
-            // The above test takes ~30 minutes to run.
-            // The below test performs similar actions, simply advancing to the next AB.
-            // But essentially, it executes the same math/crypto logic in native code.
-            // Yet it takes another 30 minutes to run, which may be expensive.
-            // So we short-circuit here, until/unless we:
-            // a) implement optional caching for loading proving and verifying keys
-            // b) use parallelism in the math to make use of all the CPU cores
-            return;
-        }
+        // Now let's test a rotated AddressBook.
+
+        // NOTE: we rely on the TSS_LIB_WRAPS_ARTIFACTS_CACHE_ENABLED env var set to "true" in Gradle.
+        // so that the proving key is cached and the second proof here takes only a few minutes.
+        // Otherwise, this test is going to take ~1 hour because loading the key takes ~27 minutes.
+        // With the cache enabled, both the proofs together take ~30 minutes only.
 
         final Network nextNetwork = new Network(List.of(
                 Node.from(Constants.SEED_0, 1000, 0),
@@ -868,7 +864,8 @@ public class WRAPSLibraryBridgeTest {
                 nextNetwork.publicKeys(), nextNetwork.weights(), nextNetwork.nodeIds(), hintsKeys.verificationKey());
         final SigningProtocolOutput output1 = aggregateSignature(genesisNetwork, message1);
 
-        System.err.println("Computing proof1 which may take up to 30 minutes...");
+        System.err.println(
+                "Computing proof1 which should take only a few minutes because we assume we cache the proving key...");
         final Proof proof1 = WRAPS.constructWrapsProof(
                 genesisAddressBookHash,
                 genesisNetwork.publicKeys(),


### PR DESCRIPTION
**Description**:
Introducing a feature to cache the `ProvingKey` in memory instead of re-loading it from disk for every proof construction. The feature is enabled with the `TSS_LIB_WRAPS_ARTIFACTS_CACHE_ENABLED="true"` env var.

Loading and deserializing the key may take ~27 minutes while the construction of the proof itself only takes a few minutes, which is okay when proofs need to be constructed rarely (once a day or once a month - like in mainnet.) However, various tests may benefit from being able to construct proofs quickly, for example to actually test rotating an AddressBook. This feature enables this.

As a part of this fix, I'm enabling the feature when running unit tests via Gradle and unlocking a test that actually performs an AB rotation and verifies the new proof against the genesis AB hash. Previously this extended test was disabled (under `if(true)return`) because it would add an extra 30 minutes for running the tests making the total runtime close to 1 hour. With the cache enabled, the second proof takes almost no time, and all tests run within the same 30 minutes as today. Yet, we now test a lot more.

**Related issue(s)**:

Fixes #500 

**Notes for reviewer**:
All tests, including the newly unlocked one, should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
