### PR TITLE
fix: hints verification optimization

### DIFF
--- a/cryptography/hedera-cryptography-hints/src/main/rust/errors.rs
+++ b/cryptography/hedera-cryptography-hints/src/main/rust/errors.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::error::Error;
-use std::fmt;
 use ark_ec::hashing::HashToCurveError;
 use ark_serialize::SerializationError;
+use std::error::Error;
+use std::fmt;
 
-/// Error enum to wrap underlying failures in HinTS operations, 
+/// Error enum to wrap underlying failures in HinTS operations,
 /// or wrap errors coming from dependencies (namely, arkworks).
 #[derive(Debug)]
 pub enum HinTSError {
@@ -29,10 +29,17 @@ impl fmt::Display for HinTSError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             HinTSError::EncodingError(ref err) => err.fmt(f),
-            HinTSError::InvalidNetworkSize(n) => write!(f, "Network size must be a power of 2. Got {n}"),
-            HinTSError::InsufficientCRS(d) => write!(f, "CRS is insufficient for the operation. Expected degree {d}"),
+            HinTSError::InvalidNetworkSize(n) => {
+                write!(f, "Network size must be a power of 2. Got {n}")
+            }
+            HinTSError::InsufficientCRS(d) => write!(
+                f,
+                "CRS is insufficient for the operation. Expected degree {d}"
+            ),
             HinTSError::InvalidInput(ref s) => write!(f, "Invalid input: {s}"),
-            HinTSError::CryptographyCatastrophe(ref s) => write!(f, "Cryptography catastrophe: {s}"),
+            HinTSError::CryptographyCatastrophe(ref s) => {
+                write!(f, "Cryptography catastrophe: {s}")
+            }
             HinTSError::HashingError(ref err) => err.fmt(f),
         }
     }

--- a/cryptography/hedera-cryptography-hints/src/main/rust/hints.rs
+++ b/cryptography/hedera-cryptography-hints/src/main/rust/hints.rs
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-
 use ark_bls12_381::{g1::Config as G1Config, g2::Config as G2Config, Bls12_381};
 use ark_ec::hashing::{
     curve_maps::wb::WBMap, map_to_curve_hasher::MapToCurveBasedHasher, HashToCurve,
@@ -169,8 +168,6 @@ pub struct VerificationKey {
     h_0: G2AffinePoint,
     /// second G1 element from the KZG CRS (for first power of tau)
     h_1: G2AffinePoint,
-    /// third G1 element from the KZG CRS (for second power of tau)
-    h_2: G2AffinePoint,
     /// commitment to the L_{n-1} polynomial
     l_n_minus_1_of_tau_com: G1AffinePoint,
     /// commitment to the W polynomial
@@ -179,8 +176,7 @@ pub struct VerificationKey {
     sk_of_tau_com: G2AffinePoint,
     /// commitment to the vanishing polynomial Z(x) = x^n - 1
     z_of_tau_com: G2AffinePoint,
-    /// commitment to the f(x) = x, which equals [\tau]_2
-    tau_com: G2AffinePoint,
+   
 }
 
 pub struct HinTS;
@@ -457,7 +453,7 @@ impl HinTS {
         }
 
         let z_of_x = utils::compute_vanishing_poly(n);
-        let x_monomial = utils::compute_x_monomial();
+        
         let l_n_minus_1_of_x = utils::lagrange_poly(n, n - 1).ok_or(
             HinTSError::CryptographyCatastrophe(
                 format!("Unable to compute Lagrange<n,i>(x) for i = {}, n = {}", n - 1, n)
@@ -472,12 +468,10 @@ impl HinTS {
             g_0: crs.powers_of_g[0],
             h_0: crs.powers_of_h[0],
             h_1: crs.powers_of_h[1],
-            h_2: crs.powers_of_h[2],
             l_n_minus_1_of_tau_com: KZG::commit_g1(&crs, &l_n_minus_1_of_x)?,
             w_of_tau_com: KZG::commit_g1(&crs, &w_of_x)?,
             sk_of_tau_com: add::<G2AffinePoint>(sk_l_of_tau_coms),
             z_of_tau_com: KZG::commit_g2(&crs, &z_of_x)?,
-            tau_com: KZG::commit_g2(&crs, &x_monomial)?,
         };
 
         let ak = AggregationKey {
@@ -779,10 +773,11 @@ impl HinTS {
         let l_n_minus_1_of_r =
             (ω_pow_n_minus_1 / F::from(vk.n as u64)) * (vanishing_of_r / (r - ω_pow_n_minus_1));
 
-        //assert polynomial identity B(x) SK(x) = ask + Q_z(x) Z(x) + Q_x(x) x
+        //assert polynomial identity B(x) SK(x) = ask + Q_z(x) Z(x) + Q_x(x) x using the following pairing equation
+        // e([SK(τ)]_1, [B(τ)]_2) = e([Qz(τ)]_1,[Qx(τ)]_2) * e([Qx(τ)]_1,[τ]_2) * e(avk,[1]_2)
         let lhs = <Curve as Pairing>::pairing(&π.b_of_tau_com, &vk.sk_of_tau_com);
         let x1 = <Curve as Pairing>::pairing(&π.qz_of_tau_com, &vk.z_of_tau_com);
-        let x2 = <Curve as Pairing>::pairing(&π.qx_of_tau_com, &vk.tau_com);
+        let x2 = <Curve as Pairing>::pairing(&π.qx_of_tau_com, &vk.h_1);
         let x3 = <Curve as Pairing>::pairing(&π.agg_pk, &vk.h_0);
         let rhs = x1.add(x2).add(x3);
         check_or_return_false!(lhs == rhs);
@@ -811,8 +806,9 @@ impl HinTS {
         check_or_return_false!(lhs == rhs);
 
         //run the degree check e([Qx(τ)]_1, [τ]_2) ?= e([Qx(τ)·τ]_1, [1]_2)
-        let lhs = <Curve as Pairing>::pairing(&π.qx_of_tau_com, &vk.h_2);
-        let rhs = <Curve as Pairing>::pairing(&π.qx_of_tau_mul_tau_com, &vk.h_1);
+        // lhs is already computed above and is stored in x2
+        let lhs = x2;
+        let rhs = <Curve as Pairing>::pairing(&π.qx_of_tau_mul_tau_com, &vk.h_0);
 
         check_or_return_false!(lhs == rhs);
 
@@ -1066,8 +1062,12 @@ mod tests {
         println!("crs size: {}", serialized_crs.len());
     }
 
+
+    
     #[test]
     fn it_works() {
+        use std::time::Instant; // Add this import
+
         let universe_n = 32;
         let num_signers = universe_n - 1;
         let msg = b"hello";
@@ -1091,7 +1091,18 @@ mod tests {
         let π = HinTS::aggregate(&crs, &ak, &vk, &sigs).unwrap();
 
         let threshold = (F::from(1), F::from(3)); // 1/3
-        assert!(HinTS::verify(msg, &vk, &π, threshold).unwrap());
+
+        // --- START MEASUREMENT ---
+        let start = Instant::now();
+        
+        let verification_result = HinTS::verify(msg, &vk, &π, threshold).unwrap();
+        
+        let duration = start.elapsed();
+        // --- END MEASUREMENT ---
+
+        println!("\nVerification logic alone took: {:?}", duration);
+
+        assert!(verification_result);
 
         // attack the proof
         let mut π_attack = π.clone();

--- a/cryptography/hedera-cryptography-hints/src/main/rust/hints.rs
+++ b/cryptography/hedera-cryptography-hints/src/main/rust/hints.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+
 use ark_bls12_381::{g1::Config as G1Config, g2::Config as G2Config, Bls12_381};
 use ark_ec::hashing::{
     curve_maps::wb::WBMap, map_to_curve_hasher::MapToCurveBasedHasher, HashToCurve,
@@ -8,18 +9,21 @@ use ark_ec::{
     short_weierstrass::{Affine, Projective},
     AffineRepr, CurveGroup,
 };
-use ark_ff::{field_hashers::{DefaultFieldHasher, HashToField}, Field};
+use ark_ff::{
+    field_hashers::{DefaultFieldHasher, HashToField},
+    Field,
+};
 use ark_poly::{univariate::DensePolynomial, Polynomial};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::collections::HashMap;
 use ark_std::{ops::*, UniformRand};
-use sha2::Sha256;
 use rand_chacha::rand_core::SeedableRng;
+use sha2::Sha256;
 
 // hinTS depends on the utils and kzg modules
+use crate::errors::*;
 use crate::kzg;
 use crate::utils;
-use crate::errors::*;
 
 /// The size of input randomness
 pub const RANDOM_SIZE: usize = 32;
@@ -56,7 +60,6 @@ macro_rules! check_or_return_false {
         }
     };
 }
-
 
 #[derive(Clone, Debug, PartialEq, CanonicalDeserialize, CanonicalSerialize)]
 /// hinTS aggregate signature
@@ -176,16 +179,13 @@ pub struct VerificationKey {
     sk_of_tau_com: G2AffinePoint,
     /// commitment to the vanishing polynomial Z(x) = x^n - 1
     z_of_tau_com: G2AffinePoint,
-   
 }
 
 pub struct HinTS;
 
 impl HinTS {
     /// generates a random secret key using a PRNG seeded by the input entropy
-    pub fn keygen(
-        seed: [u8; 32]
-    ) -> SecretKey {
+    pub fn keygen(seed: [u8; 32]) -> SecretKey {
         let mut rng = rand_chacha::ChaCha8Rng::from_seed(seed);
         F::rand(&mut rng)
     }
@@ -196,7 +196,7 @@ impl HinTS {
         crs: &CRS,
         n: usize,
         i: usize,
-        sk: &SecretKey
+        sk: &SecretKey,
     ) -> Result<ExtendedPublicKey, HinTSError> {
         // let us first perform sanity checks on the input
 
@@ -207,9 +207,10 @@ impl HinTS {
 
         // obviously, i must be less than n
         if i >= n {
-            return Err(HinTSError::InvalidInput(
-                format!("Invalid index i = {} greater than n = {}", i, n))
-            );
+            return Err(HinTSError::InvalidInput(format!(
+                "Invalid index i = {} greater than n = {}",
+                i, n
+            )));
         }
 
         // CRS must be large enough to support the operation
@@ -219,11 +220,11 @@ impl HinTS {
         }
 
         //let us compute the q1 term
-        let l_i_of_x = utils::lagrange_poly(n, i).ok_or(
-            HinTSError::CryptographyCatastrophe(
-                format!("Unable to compute Lagrange<n,i>(x) for i = {}, n = {}", i, n)
-            )
-        )?;
+        let l_i_of_x =
+            utils::lagrange_poly(n, i).ok_or(HinTSError::CryptographyCatastrophe(format!(
+                "Unable to compute Lagrange<n,i>(x) for i = {}, n = {}",
+                i, n
+            )))?;
         let z_of_x = utils::compute_vanishing_poly(n);
 
         let mut qz_terms = vec![];
@@ -235,9 +236,10 @@ impl HinTS {
             } else {
                 //cross-terms
                 let l_j_of_x = utils::lagrange_poly(n, j).ok_or(
-                    HinTSError::CryptographyCatastrophe(
-                        format!("Unable to compute Lagrange<n,j>(x) for j = {}, n = {}", j, n)
-                    )
+                    HinTSError::CryptographyCatastrophe(format!(
+                        "Unable to compute Lagrange<n,j>(x) for j = {}, n = {}",
+                        j, n
+                    )),
                 )?;
                 num = l_j_of_x.mul(&l_i_of_x);
             }
@@ -293,7 +295,7 @@ impl HinTS {
         crs: &CRS,
         n: usize,
         i: usize,
-        hint: &ExtendedPublicKey
+        hint: &ExtendedPublicKey,
     ) -> Result<bool, HinTSError> {
         // sanity check on the inputs
 
@@ -304,9 +306,10 @@ impl HinTS {
 
         // obviously, i must be less than n
         if i >= n {
-            return Err(HinTSError::InvalidInput(
-                format!("Invalid index i = {} greater than n = {}", i, n))
-            );
+            return Err(HinTSError::InvalidInput(format!(
+                "Invalid index i = {} greater than n = {}",
+                i, n
+            )));
         }
 
         // CRS must be large enough to support the operation
@@ -321,11 +324,11 @@ impl HinTS {
         check_or_return_false!(n == hint.qz_i_terms.len());
 
         //e([sk_i L_i(τ)]1, [1]2) = e([sk_i]1, [L_i(τ)]2)
-        let l_i_of_x = utils::lagrange_poly(n, i).ok_or(
-            HinTSError::CryptographyCatastrophe(
-                format!("Unable to compute Lagrange<n,i>(x) for i = {}, n = {}", i, n)
-            )
-        )?;
+        let l_i_of_x =
+            utils::lagrange_poly(n, i).ok_or(HinTSError::CryptographyCatastrophe(format!(
+                "Unable to compute Lagrange<n,i>(x) for i = {}, n = {}",
+                i, n
+            )))?;
         let z_of_x = utils::compute_vanishing_poly(n);
 
         let l_i_of_tau_com = KZG::commit_g2(&crs, &l_i_of_x)?;
@@ -340,9 +343,10 @@ impl HinTS {
             } else {
                 //cross-terms
                 let l_j_of_x = utils::lagrange_poly(n, j).ok_or(
-                    HinTSError::CryptographyCatastrophe(
-                        format!("Unable to compute Lagrange<n,j>(x) for j = {}, n = {}", j, n)
-                    )
+                    HinTSError::CryptographyCatastrophe(format!(
+                        "Unable to compute Lagrange<n,j>(x) for j = {}, n = {}",
+                        j, n
+                    )),
                 )?;
                 num = l_j_of_x.mul(&l_i_of_x);
             }
@@ -413,14 +417,16 @@ impl HinTS {
         for i in 0..n {
             if let Some((weight, hint)) = signer_info.get(&i) {
                 if hint.n != n {
-                    return Err(HinTSError::InvalidInput(
-                        format!("Invalid hint: got hint.n = {}, expected n = {}", hint.n, n))
-                    );
+                    return Err(HinTSError::InvalidInput(format!(
+                        "Invalid hint: got hint.n = {}, expected n = {}",
+                        hint.n, n
+                    )));
                 }
-                if ! Self::verify_hint(crs, n, i, hint)? {
-                    return Err(HinTSError::InvalidInput(
-                        format!("Invalid hint: hint verification failed for i = {}", i))
-                    );
+                if !Self::verify_hint(crs, n, i, hint)? {
+                    return Err(HinTSError::InvalidInput(format!(
+                        "Invalid hint: hint verification failed for i = {}",
+                        i
+                    )));
                 }
                 weights.push(weight.clone());
                 epks.push(hint.clone());
@@ -431,9 +437,10 @@ impl HinTS {
         }
 
         let w_of_x = utils::interpolate_poly_over_mult_subgroup(&weights).ok_or(
-            HinTSError::CryptographyCatastrophe(
-                format!("Unable to construct Radix2EvaluationDomain for n = {}", weights.len())
-            )
+            HinTSError::CryptographyCatastrophe(format!(
+                "Unable to construct Radix2EvaluationDomain for n = {}",
+                weights.len()
+            )),
         )?;
 
         //allocate space to collect setup material from all n-1 parties
@@ -453,12 +460,13 @@ impl HinTS {
         }
 
         let z_of_x = utils::compute_vanishing_poly(n);
-        
-        let l_n_minus_1_of_x = utils::lagrange_poly(n, n - 1).ok_or(
-            HinTSError::CryptographyCatastrophe(
-                format!("Unable to compute Lagrange<n,i>(x) for i = {}, n = {}", n - 1, n)
-            )
-        )?;
+
+        let l_n_minus_1_of_x =
+            utils::lagrange_poly(n, n - 1).ok_or(HinTSError::CryptographyCatastrophe(format!(
+                "Unable to compute Lagrange<n,i>(x) for i = {}, n = {}",
+                n - 1,
+                n
+            )))?;
 
         let total_weight = weights.iter().fold(F::from(0), |acc, &x| acc + x);
 
@@ -487,10 +495,7 @@ impl HinTS {
     }
 
     /// signs a message using the signer's secret key, producing a partial signature
-    pub fn sign(
-        msg: &[u8],
-        sk: &SecretKey
-    ) -> Result<PartialSignature, HinTSError> {
+    pub fn sign(msg: &[u8], sk: &SecretKey) -> Result<PartialSignature, HinTSError> {
         Ok(hash_to_g2(msg)?.mul(sk).into_affine())
     }
 
@@ -499,13 +504,15 @@ impl HinTS {
         msg: &[u8],
         ak: &AggregationKey,
         party_id: usize,
-        sig: &PartialSignature
+        sig: &PartialSignature,
     ) -> Result<bool, HinTSError> {
         // party_id can only be between 0 and n-2, inclusive
-        if party_id >= ak.n - 1 { // usize ensures non-negative
-            return Err(HinTSError::InvalidInput(
-                format!("signer_id {} out of range", party_id))
-            );
+        if party_id >= ak.n - 1 {
+            // usize ensures non-negative
+            return Err(HinTSError::InvalidInput(format!(
+                "signer_id {} out of range",
+                party_id
+            )));
         }
 
         let lhs = <Curve as Pairing>::pairing(ak.pks[party_id], hash_to_g2(msg)?);
@@ -587,29 +594,30 @@ impl HinTS {
         bitmap[n - 1] = F::from(1);
 
         //compute all the scalars we will need in the prover
-        let ω: F = utils::nth_root_of_unity(n).ok_or(
-            HinTSError::CryptographyCatastrophe(
-                format!("Unable to construct Radix2EvaluationDomain for n = {}", n)
-            )
-        )?;
+        let ω: F = utils::nth_root_of_unity(n).ok_or(HinTSError::CryptographyCatastrophe(
+            format!("Unable to construct Radix2EvaluationDomain for n = {}", n),
+        ))?;
         let ω_inv: F = F::from(1) / ω;
 
         //compute all the polynomials we will need in the prover
         let z_of_x = utils::compute_vanishing_poly(n); //returns Z(X) = X^n - 1
-        let l_n_minus_1_of_x = utils::lagrange_poly(n, n - 1).ok_or(
-            HinTSError::CryptographyCatastrophe(
-                format!("Unable to compute Lagrange<n,i>(x) for i = {}, n = {}", n - 1, n)
-            )
-        )?;
+        let l_n_minus_1_of_x =
+            utils::lagrange_poly(n, n - 1).ok_or(HinTSError::CryptographyCatastrophe(format!(
+                "Unable to compute Lagrange<n,i>(x) for i = {}, n = {}",
+                n - 1,
+                n
+            )))?;
         let w_of_x = utils::interpolate_poly_over_mult_subgroup(&weights).ok_or(
-            HinTSError::CryptographyCatastrophe(
-                format!("Unable to construct Radix2EvaluationDomain for n = {}", weights.len())
-            )
+            HinTSError::CryptographyCatastrophe(format!(
+                "Unable to construct Radix2EvaluationDomain for n = {}",
+                weights.len()
+            )),
         )?;
         let b_of_x = utils::interpolate_poly_over_mult_subgroup(&bitmap).ok_or(
-            HinTSError::CryptographyCatastrophe(
-                format!("Unable to construct Radix2EvaluationDomain for n = {}", bitmap.len())
-            )
+            HinTSError::CryptographyCatastrophe(format!(
+                "Unable to construct Radix2EvaluationDomain for n = {}",
+                bitmap.len()
+            )),
         )?;
         let psw_of_x = compute_psw_poly(&weights, &bitmap)?;
         let psw_of_x_div_ω = utils::poly_domain_mult_ω(&psw_of_x, &ω_inv);
@@ -740,11 +748,11 @@ impl HinTS {
         check_or_return_false!(lhs == rhs);
 
         // compute nth root of unity
-        let ω: F = utils::nth_root_of_unity(vk.n).ok_or(
-            HinTSError::CryptographyCatastrophe(
-                format!("Unable to construct Radix2EvaluationDomain for n = {}", vk.n)
-            )
-        )?;
+        let ω: F =
+            utils::nth_root_of_unity(vk.n).ok_or(HinTSError::CryptographyCatastrophe(format!(
+                "Unable to construct Radix2EvaluationDomain for n = {}",
+                vk.n
+            )))?;
 
         //RO(SK, W, B, ParSum, Qx, Qz, Qx(τ ) · τ, Q1, Q2, Q3, Q4)
         let r = random_oracle(
@@ -868,7 +876,7 @@ fn verify_opening(
 fn verify_openings_in_proof(
     vk: &VerificationKey,
     π: &ThresholdSignature,
-    r: F
+    r: F,
 ) -> Result<bool, HinTSError> {
     //adjust the w_of_x_com
     let adjustment = F::from(0) - π.agg_weight;
@@ -896,11 +904,11 @@ fn verify_openings_in_proof(
     let rhs = <Curve as Pairing>::pairing(π.opening_proof_r, vk.h_1 - vk.h_0.mul(r).into_affine());
     check_or_return_false!(lhs == rhs);
 
-    let ω: F = utils::nth_root_of_unity(vk.n).ok_or(
-        HinTSError::CryptographyCatastrophe(
-            format!("Unable to construct Radix2EvaluationDomain for n = {}", vk.n)
-        )
-    )?;
+    let ω: F =
+        utils::nth_root_of_unity(vk.n).ok_or(HinTSError::CryptographyCatastrophe(format!(
+            "Unable to construct Radix2EvaluationDomain for n = {}",
+            vk.n
+        )))?;
     let r_div_ω: F = r / ω;
 
     Ok(verify_opening(
@@ -912,9 +920,7 @@ fn verify_openings_in_proof(
     ))
 }
 
-fn preprocess_qz_contributions(
-    q1_contributions: &Vec<Vec<G1AffinePoint>>
-) -> Vec<G1AffinePoint> {
+fn preprocess_qz_contributions(q1_contributions: &Vec<Vec<G1AffinePoint>>) -> Vec<G1AffinePoint> {
     let n = q1_contributions.len();
     let mut q1_coms = vec![];
 
@@ -937,7 +943,7 @@ fn preprocess_qz_contributions(
 
 fn compute_psw_poly(
     weights: &Vec<Weight>,
-    bitmap: &Vec<F>
+    bitmap: &Vec<F>,
 ) -> Result<DensePolynomial<F>, HinTSError> {
     let n = weights.len(); // assumes power of 2 size
 
@@ -948,18 +954,16 @@ fn compute_psw_poly(
         evals.push(parsum);
     }
 
-    utils::interpolate_poly_over_mult_subgroup(&evals).ok_or(
-        HinTSError::CryptographyCatastrophe(
-            format!("Unable to construct Radix2EvaluationDomain for n = {}", evals.len())
-        )
-    )
+    utils::interpolate_poly_over_mult_subgroup(&evals).ok_or(HinTSError::CryptographyCatastrophe(
+        format!(
+            "Unable to construct Radix2EvaluationDomain for n = {}",
+            evals.len()
+        ),
+    ))
 }
 
 /// computes the inner product between a vector of group elements and bitvector
-fn inner_product<T: AffineRepr>(
-    elements: &Vec<T>,
-    bitmap: &Vec<F>
-) -> T {
+fn inner_product<T: AffineRepr>(elements: &Vec<T>, bitmap: &Vec<F>) -> T {
     elements
         .iter()
         .zip(bitmap.iter())
@@ -975,21 +979,19 @@ fn add<T: AffineRepr>(elements: impl IntoIterator<Item = T>) -> T {
 }
 
 /// hashes a byte array to an elliptic curve group element
-pub fn hash_to_g2(
-    msg: impl AsRef<[u8]>
-) -> Result<G2AffinePoint, HinTSError> {
+pub fn hash_to_g2(msg: impl AsRef<[u8]>) -> Result<G2AffinePoint, HinTSError> {
     const DST_G2: &str = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
     let g2_mapper = MapToCurveBasedHasher::<
         G2ProjectivePoint,
         DefaultFieldHasher<Sha256, 128>,
         WBMap<G2Config>,
     >::new(DST_G2.as_bytes())?;
-    g2_mapper.hash(msg.as_ref()).map_err(|e| HinTSError::HashingError(e))
+    g2_mapper
+        .hash(msg.as_ref())
+        .map_err(|e| HinTSError::HashingError(e))
 }
 
-pub fn serialize<T: CanonicalSerialize>(
-    t: &T
-) -> Result<Vec<u8>, HinTSError> {
+pub fn serialize<T: CanonicalSerialize>(t: &T) -> Result<Vec<u8>, HinTSError> {
     let mut buf = Vec::new();
     // unwrap() should be safe because we serialize into a variable-size vector.
     // However, it might fail if the `t` is invalid somehow, although this
@@ -1062,11 +1064,9 @@ mod tests {
         println!("crs size: {}", serialized_crs.len());
     }
 
-
-    
-    #[test]
+   #[test]
     fn it_works() {
-        use std::time::Instant; // Add this import
+        use std::time::Instant;
 
         let universe_n = 32;
         let num_signers = universe_n - 1;
@@ -1079,14 +1079,13 @@ mod tests {
             assert!(HinTS::partial_verify(msg, &ak, *i, sig).unwrap());
         }
 
-        assert!(
-            HinTS::partial_verify_batch(
-                msg,
-                &ak,
-                sigs.keys().cloned().collect::<Vec<usize>>(),
-                sigs.values().cloned().collect::<Vec<PartialSignature>>()
-            ).unwrap()
-        );
+        assert!(HinTS::partial_verify_batch(
+            msg,
+            &ak,
+            sigs.keys().cloned().collect::<Vec<usize>>(),
+            sigs.values().cloned().collect::<Vec<PartialSignature>>()
+        )
+        .unwrap());
 
         let π = HinTS::aggregate(&crs, &ak, &vk, &sigs).unwrap();
 
@@ -1094,9 +1093,9 @@ mod tests {
 
         // --- START MEASUREMENT ---
         let start = Instant::now();
-        
+
         let verification_result = HinTS::verify(msg, &vk, &π, threshold).unwrap();
-        
+
         let duration = start.elapsed();
         // --- END MEASUREMENT ---
 
@@ -1155,7 +1154,9 @@ mod tests {
         // -------------- sample universe specific values ---------------
         //sample random keys
         // WARN: supply a random seed, not a fixed one as shown here.
-        let sks: Vec<SecretKey> = (0..num_signers).map(|_| HinTS::keygen([42u8; 32])).collect();
+        let sks: Vec<SecretKey> = (0..num_signers)
+            .map(|_| HinTS::keygen([42u8; 32]))
+            .collect();
 
         let epks = (0..num_signers)
             .map(|i| HinTS::hint_gen(&crs, n, i, &sks[i]).unwrap())

--- a/cryptography/hedera-cryptography-hints/src/main/rust/jni_crs.rs
+++ b/cryptography/hedera-cryptography-hints/src/main/rust/jni_crs.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use jni::objects::{JByteArray, JObject};
-use jni::sys::{jbyteArray, jboolean, jshort};
-use jni::JNIEnv;
-use crate::setup::{ContributionProof, PowersOfTauProtocol};
 use crate::hints::{serialize, CRS};
 use crate::jni_util;
+use crate::setup::{ContributionProof, PowersOfTauProtocol};
+use jni::objects::{JByteArray, JObject};
+use jni::sys::{jboolean, jbyteArray, jshort};
+use jni::JNIEnv;
 
 /// JNI function to create a new CRS object
 /// # Arguments
@@ -23,7 +23,7 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_ini
     let crs = PowersOfTauProtocol::init(signers_num as usize);
     match jni_util::serialize_object(&env, &crs) {
         Ok(val) => val,
-        Err(_) => std::ptr::null_mut()
+        Err(_) => std::ptr::null_mut(),
     }
 }
 
@@ -42,28 +42,28 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_upd
     prev_crs_array: JByteArray,
     random_array: JByteArray,
 ) -> jbyteArray {
-    let prev_crs :CRS = match jni_util::deserialize_jbyte_array(&env, &prev_crs_array) {
+    let prev_crs: CRS = match jni_util::deserialize_jbyte_array(&env, &prev_crs_array) {
         Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
 
     let random_arr = match jni_util::build_entropy_array(&env, &random_array) {
         Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
 
     let (crs, contribution_proof) = match PowersOfTauProtocol::contribute(&prev_crs, random_arr) {
         Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
 
     let serialized_crs = match serialize(&crs) {
         Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
     let serialized_contribution_proof = match serialize(&contribution_proof) {
         Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
 
     jni_util::two_u8_vec_to_jbyte_array(&env, &serialized_crs, &serialized_contribution_proof)
@@ -86,22 +86,27 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_ver
     next_crs_array: JByteArray,
     contribution_proof_array: JByteArray,
 ) -> jboolean {
-    let prev_crs :CRS = match jni_util::deserialize_jbyte_array(&env, &prev_crs_array) {
+    let prev_crs: CRS = match jni_util::deserialize_jbyte_array(&env, &prev_crs_array) {
         Ok(val) => val,
-        Err(_) => return jboolean::from(false)
+        Err(_) => return jboolean::from(false),
     };
 
-    let next_crs :CRS = match jni_util::deserialize_jbyte_array(&env, &next_crs_array) {
+    let next_crs: CRS = match jni_util::deserialize_jbyte_array(&env, &next_crs_array) {
         Ok(val) => val,
-        Err(_) => return jboolean::from(false)
+        Err(_) => return jboolean::from(false),
     };
 
-    let contribution_proof: ContributionProof = match jni_util::deserialize_jbyte_array(&env, &contribution_proof_array) {
-        Ok(val) => val,
-        Err(_) => return jboolean::from(false)
-    };
+    let contribution_proof: ContributionProof =
+        match jni_util::deserialize_jbyte_array(&env, &contribution_proof_array) {
+            Ok(val) => val,
+            Err(_) => return jboolean::from(false),
+        };
 
-    jboolean::from(PowersOfTauProtocol::verify_contribution(&prev_crs, &next_crs, &contribution_proof))
+    jboolean::from(PowersOfTauProtocol::verify_contribution(
+        &prev_crs,
+        &next_crs,
+        &contribution_proof,
+    ))
 }
 
 /// JNI for HintsLibraryBridge.pruneCRSImpl
@@ -112,18 +117,18 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_pru
     prev_crs_array: JByteArray,
     signers_num: jshort,
 ) -> jbyteArray {
-    let prev_crs :CRS = match jni_util::deserialize_jbyte_array(&env, &prev_crs_array) {
+    let prev_crs: CRS = match jni_util::deserialize_jbyte_array(&env, &prev_crs_array) {
         Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
 
-    let crs :CRS = match PowersOfTauProtocol::prune_crs(&prev_crs, signers_num as usize) {
+    let crs: CRS = match PowersOfTauProtocol::prune_crs(&prev_crs, signers_num as usize) {
         Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
 
     match jni_util::serialize_object(&env, &crs) {
         Ok(val) => val,
-        Err(_) => std::ptr::null_mut()
+        Err(_) => std::ptr::null_mut(),
     }
 }

--- a/cryptography/hedera-cryptography-hints/src/main/rust/jni_hints.rs
+++ b/cryptography/hedera-cryptography-hints/src/main/rust/jni_hints.rs
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use jni::JNIEnv;
+use crate::hints::{
+    AggregationKey, ExtendedPublicKey, HinTS, PartialSignature, SecretKey, ThresholdSignature,
+    VerificationKey, Weight, CRS, F,
+};
+use crate::jni_util;
 use jni::objects::{JByteArray, JIntArray, JLongArray, JObject, JObjectArray, JValue};
 use jni::sys::{jboolean, jbyteArray, jint, jlong, jobject, jsize};
-use crate::hints::{AggregationKey, ExtendedPublicKey, HinTS, PartialSignature, SecretKey, ThresholdSignature, VerificationKey, Weight, CRS, F};
-use crate::jni_util;
+use jni::JNIEnv;
+use std::collections::HashMap;
 
 /// JNI for HintsLibraryBridge.generateSecretKey
 #[no_mangle]
@@ -16,13 +19,13 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_gen
 ) -> jbyteArray {
     let random_arr = match jni_util::build_entropy_array(&env, &random_jarray) {
         Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
 
     let secret_key = HinTS::keygen(random_arr);
     match jni_util::serialize_object(&env, &secret_key) {
         Ok(val) => val,
-        Err(_) => std::ptr::null_mut()
+        Err(_) => std::ptr::null_mut(),
     }
 }
 
@@ -38,21 +41,21 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_com
 ) -> jbyteArray {
     let crs: CRS = match jni_util::deserialize_jbyte_array(&env, &crs_jarray) {
         Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
 
     let secret_key: SecretKey = match jni_util::deserialize_jbyte_array(&env, &secret_key_jarray) {
         Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
 
     let hint = match HinTS::hint_gen(&crs, n as usize, party_id as usize, &secret_key) {
         Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
     match jni_util::serialize_object(&env, &hint) {
         Ok(val) => val,
-        Err(_) => std::ptr::null_mut()
+        Err(_) => std::ptr::null_mut(),
     }
 }
 
@@ -68,18 +71,20 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_val
 ) -> jboolean {
     let crs: CRS = match jni_util::deserialize_jbyte_array(&env, &crs_jarray) {
         Ok(val) => val,
-        Err(_) => return jboolean::from(false)
+        Err(_) => return jboolean::from(false),
     };
 
     let hints: ExtendedPublicKey = match jni_util::deserialize_jbyte_array(&env, &hints_jarray) {
         Ok(val) => val,
-        Err(_) => return jboolean::from(false)
+        Err(_) => return jboolean::from(false),
     };
 
-    jboolean::from(match HinTS::verify_hint(&crs, n as usize, party_id as usize, &hints) {
-        Ok(val) => val,
-        Err(_) => return jboolean::from(false)
-    })
+    jboolean::from(
+        match HinTS::verify_hint(&crs, n as usize, party_id as usize, &hints) {
+            Ok(val) => val,
+            Err(_) => return jboolean::from(false),
+        },
+    )
 }
 
 /// JNI for HintsLibraryBridge.preprocess
@@ -95,70 +100,83 @@ pub unsafe extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBri
 ) -> jobject {
     let crs: CRS = match jni_util::deserialize_jbyte_array(&env, &crs_jarray) {
         Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
 
     // ------------------------------------------------------------------------
     // build HashMap<usize, (Weight, ExtendedPublicKey)>
     let num_of_keys = match env.get_array_length(&parties_jarray) {
         Ok(len) => len,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
-    let mut keys :Vec<jint> = vec![0; num_of_keys as usize];
+    let mut keys: Vec<jint> = vec![0; num_of_keys as usize];
     match env.get_int_array_region(parties_jarray, 0, keys.as_mut_slice()) {
-        Ok(()) => {},
-        Err(_) => return std::ptr::null_mut()
+        Ok(()) => {}
+        Err(_) => return std::ptr::null_mut(),
     };
 
-    let mut weights :Vec<jlong> = vec![0; num_of_keys as usize];
+    let mut weights: Vec<jlong> = vec![0; num_of_keys as usize];
     match env.get_long_array_region(weights_jarray, 0, weights.as_mut_slice()) {
-        Ok(()) => {},
-        Err(_) => return std::ptr::null_mut()
+        Ok(()) => {}
+        Err(_) => return std::ptr::null_mut(),
     };
 
-    let mut hints_array:Vec<ExtendedPublicKey> = Vec::with_capacity(num_of_keys as usize);
+    let mut hints_array: Vec<ExtendedPublicKey> = Vec::with_capacity(num_of_keys as usize);
     for i in 0..num_of_keys as usize {
         let jobj = match env.get_object_array_element(&hints_jarray, i as jsize) {
             Ok(val) => val,
-            Err(_) => return std::ptr::null_mut()
+            Err(_) => return std::ptr::null_mut(),
         };
 
-        let hints: ExtendedPublicKey = match jni_util::deserialize_jbyte_array(&env, &JByteArray::from(jobj)) {
-            Ok(val) => val,
-            Err(_) => return std::ptr::null_mut()
-        };
+        let hints: ExtendedPublicKey =
+            match jni_util::deserialize_jbyte_array(&env, &JByteArray::from(jobj)) {
+                Ok(val) => val,
+                Err(_) => return std::ptr::null_mut(),
+            };
 
         hints_array.push(hints);
     }
 
-    let mut signer_info: HashMap<usize, (Weight, ExtendedPublicKey)> = HashMap::with_capacity(num_of_keys as usize);
+    let mut signer_info: HashMap<usize, (Weight, ExtendedPublicKey)> =
+        HashMap::with_capacity(num_of_keys as usize);
     for i in 0..num_of_keys as usize {
-        signer_info.insert(keys[i] as usize, (Weight::from(weights[i] as i64), hints_array[i].clone()));
+        signer_info.insert(
+            keys[i] as usize,
+            (Weight::from(weights[i] as i64), hints_array[i].clone()),
+        );
     }
     // finished building the map
     // ------------------------------------------------------------------------
 
     let (vk, ak) = match HinTS::preprocess(n as usize, &crs, &signer_info) {
         Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
 
     let serialized_vk = match jni_util::serialize_object(&env, &vk) {
         Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
     let serialized_ak = match jni_util::serialize_object(&env, &ak) {
         Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
 
-    let keys_clz = match env.find_class("com/hedera/cryptography/hints/AggregationAndVerificationKeys") {
+    let keys_clz =
+        match env.find_class("com/hedera/cryptography/hints/AggregationAndVerificationKeys") {
+            Ok(val) => val,
+            Err(_) => return std::ptr::null_mut(),
+        };
+    let keys_obj = match env.new_object(
+        keys_clz,
+        "([B[B)V",
+        &[
+            JValue::from(&JObject::from_raw(serialized_vk)),
+            JValue::from(&JObject::from_raw(serialized_ak)),
+        ],
+    ) {
         Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
-    };
-    let keys_obj = match env.new_object(keys_clz, "([B[B)V", &[JValue::from(&JObject::from_raw(serialized_vk)), JValue::from(&JObject::from_raw(serialized_ak))]) {
-        Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
 
     keys_obj.into_raw()
@@ -174,21 +192,21 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_sig
 ) -> jbyteArray {
     let message = match env.convert_byte_array(&message_jarray) {
         Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
 
     let secret_key: SecretKey = match jni_util::deserialize_jbyte_array(&env, &secret_key_jarray) {
         Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
 
     let signature = match HinTS::sign(&message, &secret_key) {
         Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
     match jni_util::serialize_object(&env, &signature) {
         Ok(val) => val,
-        Err(_) => std::ptr::null_mut()
+        Err(_) => std::ptr::null_mut(),
     }
 }
 
@@ -200,27 +218,31 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_ver
     signature_jarray: JByteArray,
     message_jarray: JByteArray,
     aggregation_key_jarray: JByteArray,
-    party_id: jint
+    party_id: jint,
 ) -> jboolean {
     let message = match env.convert_byte_array(&message_jarray) {
         Ok(val) => val,
-        Err(_) => return jboolean::from(false)
+        Err(_) => return jboolean::from(false),
     };
 
-    let aggregation_key: AggregationKey = match jni_util::deserialize_jbyte_array(&env, &aggregation_key_jarray) {
-        Ok(val) => val,
-        Err(_) => return jboolean::from(false)
-    };
+    let aggregation_key: AggregationKey =
+        match jni_util::deserialize_jbyte_array(&env, &aggregation_key_jarray) {
+            Ok(val) => val,
+            Err(_) => return jboolean::from(false),
+        };
 
-    let signature: PartialSignature = match jni_util::deserialize_jbyte_array(&env, &signature_jarray) {
-        Ok(val) => val,
-        Err(_) => return jboolean::from(false)
-    };
+    let signature: PartialSignature =
+        match jni_util::deserialize_jbyte_array(&env, &signature_jarray) {
+            Ok(val) => val,
+            Err(_) => return jboolean::from(false),
+        };
 
-    jboolean::from(match HinTS::partial_verify(&message, &aggregation_key, party_id as usize, &signature) {
-        Ok(val) => val,
-        Err(_) => return jboolean::from(false)
-    })
+    jboolean::from(
+        match HinTS::partial_verify(&message, &aggregation_key, party_id as usize, &signature) {
+            Ok(val) => val,
+            Err(_) => return jboolean::from(false),
+        },
+    )
 }
 
 /// JNI for HintsLibraryBridge.verifyBlsBatch
@@ -231,48 +253,58 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_ver
     message_jarray: JByteArray,
     aggregation_key_jarray: JByteArray,
     parties_jarray: JIntArray,
-    partial_signatures_jarray: JObjectArray
+    partial_signatures_jarray: JObjectArray,
 ) -> jboolean {
     let message = match env.convert_byte_array(&message_jarray) {
         Ok(val) => val,
-        Err(_) => return jboolean::from(false)
+        Err(_) => return jboolean::from(false),
     };
 
-    let aggregation_key: AggregationKey = match jni_util::deserialize_jbyte_array(&env, &aggregation_key_jarray) {
-        Ok(val) => val,
-        Err(_) => return jboolean::from(false)
-    };
+    let aggregation_key: AggregationKey =
+        match jni_util::deserialize_jbyte_array(&env, &aggregation_key_jarray) {
+            Ok(val) => val,
+            Err(_) => return jboolean::from(false),
+        };
 
     let num_of_keys = match env.get_array_length(&parties_jarray) {
         Ok(len) => len,
-        Err(_) => return jboolean::from(false)
+        Err(_) => return jboolean::from(false),
     };
-    let mut keys :Vec<jint> = vec![0; num_of_keys as usize];
+    let mut keys: Vec<jint> = vec![0; num_of_keys as usize];
     match env.get_int_array_region(parties_jarray, 0, keys.as_mut_slice()) {
-        Ok(()) => {},
-        Err(_) => return jboolean::from(false)
+        Ok(()) => {}
+        Err(_) => return jboolean::from(false),
     };
     let keys_usize: Vec<usize> = keys.iter().map(|&x| x as usize).collect();
 
-    let mut partial_signatures_array:Vec<PartialSignature> = Vec::with_capacity(num_of_keys as usize);
+    let mut partial_signatures_array: Vec<PartialSignature> =
+        Vec::with_capacity(num_of_keys as usize);
     for i in 0..num_of_keys as usize {
         let jobj = match env.get_object_array_element(&partial_signatures_jarray, i as jsize) {
             Ok(val) => val,
-            Err(_) => return jboolean::from(false)
+            Err(_) => return jboolean::from(false),
         };
 
-        let partial_signature: PartialSignature = match jni_util::deserialize_jbyte_array(&env, &JByteArray::from(jobj)) {
-            Ok(val) => val,
-            Err(_) => return jboolean::from(false)
-        };
+        let partial_signature: PartialSignature =
+            match jni_util::deserialize_jbyte_array(&env, &JByteArray::from(jobj)) {
+                Ok(val) => val,
+                Err(_) => return jboolean::from(false),
+            };
 
         partial_signatures_array.push(partial_signature);
     }
 
-    jboolean::from(match HinTS::partial_verify_batch(&message, &aggregation_key, &keys_usize, &partial_signatures_array) {
-        Ok(val) => val,
-        Err(_) => return jboolean::from(false)
-    })
+    jboolean::from(
+        match HinTS::partial_verify_batch(
+            &message,
+            &aggregation_key,
+            &keys_usize,
+            &partial_signatures_array,
+        ) {
+            Ok(val) => val,
+            Err(_) => return jboolean::from(false),
+        },
+    )
 }
 
 /// JNI for HintsLibraryBridge.aggregateSignatures
@@ -288,60 +320,70 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_agg
 ) -> jbyteArray {
     let crs: CRS = match jni_util::deserialize_jbyte_array(&env, &crs_jarray) {
         Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
 
-    let aggregation_key: AggregationKey = match jni_util::deserialize_jbyte_array(&env, &aggregation_key_jarray) {
-        Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
-    };
+    let aggregation_key: AggregationKey =
+        match jni_util::deserialize_jbyte_array(&env, &aggregation_key_jarray) {
+            Ok(val) => val,
+            Err(_) => return std::ptr::null_mut(),
+        };
 
-    let verification_key: VerificationKey = match jni_util::deserialize_jbyte_array(&env, &verification_key_jarray) {
-        Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
-    };
+    let verification_key: VerificationKey =
+        match jni_util::deserialize_jbyte_array(&env, &verification_key_jarray) {
+            Ok(val) => val,
+            Err(_) => return std::ptr::null_mut(),
+        };
 
     // ------------------------------------------------------------------------
     // build HashMap<usize, PartialSignature>
     let num_of_keys = match env.get_array_length(&parties_jarray) {
         Ok(len) => len,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
-    let mut keys :Vec<jint> = vec![0; num_of_keys as usize];
+    let mut keys: Vec<jint> = vec![0; num_of_keys as usize];
     match env.get_int_array_region(parties_jarray, 0, keys.as_mut_slice()) {
-        Ok(()) => {},
-        Err(_) => return std::ptr::null_mut()
+        Ok(()) => {}
+        Err(_) => return std::ptr::null_mut(),
     };
 
-    let mut partial_signatures_array:Vec<PartialSignature> = Vec::with_capacity(num_of_keys as usize);
+    let mut partial_signatures_array: Vec<PartialSignature> =
+        Vec::with_capacity(num_of_keys as usize);
     for i in 0..num_of_keys as usize {
         let jobj = match env.get_object_array_element(&partial_signatures_jarray, i as jsize) {
             Ok(val) => val,
-            Err(_) => return std::ptr::null_mut()
+            Err(_) => return std::ptr::null_mut(),
         };
 
-        let partial_signature: PartialSignature = match jni_util::deserialize_jbyte_array(&env, &JByteArray::from(jobj)) {
-            Ok(val) => val,
-            Err(_) => return std::ptr::null_mut()
-        };
+        let partial_signature: PartialSignature =
+            match jni_util::deserialize_jbyte_array(&env, &JByteArray::from(jobj)) {
+                Ok(val) => val,
+                Err(_) => return std::ptr::null_mut(),
+            };
 
         partial_signatures_array.push(partial_signature);
     }
 
-    let mut partial_signatures: HashMap<usize, PartialSignature> = HashMap::with_capacity(num_of_keys as usize);
+    let mut partial_signatures: HashMap<usize, PartialSignature> =
+        HashMap::with_capacity(num_of_keys as usize);
     for i in 0..num_of_keys as usize {
         partial_signatures.insert(keys[i] as usize, partial_signatures_array[i].clone());
     }
     // finished building the map
     // ------------------------------------------------------------------------
 
-    let threshold_signature = match HinTS::aggregate(&crs, &aggregation_key, &verification_key, &partial_signatures) {
+    let threshold_signature = match HinTS::aggregate(
+        &crs,
+        &aggregation_key,
+        &verification_key,
+        &partial_signatures,
+    ) {
         Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
     match jni_util::serialize_object(&env, &threshold_signature) {
         Ok(val) => val,
-        Err(_) => std::ptr::null_mut()
+        Err(_) => std::ptr::null_mut(),
     }
 }
 
@@ -356,23 +398,32 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_ver
     threshold_numerator: jlong,
     threshold_denominator: jlong,
 ) -> jboolean {
-    let signature: ThresholdSignature = match jni_util::deserialize_jbyte_array(&env, &signature_jarray) {
-        Ok(val) => val,
-        Err(_) => return jboolean::from(false)
-    };
+    let signature: ThresholdSignature =
+        match jni_util::deserialize_jbyte_array(&env, &signature_jarray) {
+            Ok(val) => val,
+            Err(_) => return jboolean::from(false),
+        };
 
     let message = match env.convert_byte_array(&message_jarray) {
         Ok(val) => val,
-        Err(_) => return jboolean::from(false)
+        Err(_) => return jboolean::from(false),
     };
 
-    let verification_key: VerificationKey = match jni_util::deserialize_jbyte_array(&env, &verification_key_jarray) {
-        Ok(val) => val,
-        Err(_) => return jboolean::from(false)
-    };
+    let verification_key: VerificationKey =
+        match jni_util::deserialize_jbyte_array(&env, &verification_key_jarray) {
+            Ok(val) => val,
+            Err(_) => return jboolean::from(false),
+        };
 
-    jboolean::from(match HinTS::verify(&message, &verification_key, &signature, (F::from(threshold_numerator), F::from(threshold_denominator))) {
-        Ok(val) => val,
-        Err(_) => return jboolean::from(false)
-    })
+    jboolean::from(
+        match HinTS::verify(
+            &message,
+            &verification_key,
+            &signature,
+            (F::from(threshold_numerator), F::from(threshold_denominator)),
+        ) {
+            Ok(val) => val,
+            Err(_) => return jboolean::from(false),
+        },
+    )
 }

--- a/cryptography/hedera-cryptography-hints/src/main/rust/jni_util.rs
+++ b/cryptography/hedera-cryptography-hints/src/main/rust/jni_util.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::any::Any;
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use jni::JNIEnv;
-use jni::objects::{JByteArray, JObject};
-use jni::sys::{jbyte, jbyteArray};
 use crate::errors::HinTSError;
 use crate::hints::{serialize, RANDOM_SIZE};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use jni::objects::{JByteArray, JObject};
+use jni::sys::{jbyte, jbyteArray};
+use jni::JNIEnv;
+use std::any::Any;
 
 /// Creates a jbyteArray out of a Vec<jbyte> object.
 /// # Arguments
@@ -17,7 +17,7 @@ use crate::hints::{serialize, RANDOM_SIZE};
 pub fn jbyte_vec_to_jbyte_array(env: &JNIEnv, vec: &Vec<jbyte>) -> jbyteArray {
     let array = match env.new_byte_array(vec.len() as i32) {
         Ok(val) => val,
-        Err(_) => return std::ptr::null_mut()
+        Err(_) => return std::ptr::null_mut(),
     };
     match env.set_byte_array_region(&array, 0, &vec) {
         Ok(()) => array.into_raw(),
@@ -47,10 +47,13 @@ pub fn u8_vec_to_jbyte_array(env: &JNIEnv, vec: &Vec<u8>) -> jbyteArray {
 /// # Returns
 /// *   a byte array with all the vectors written one after another, or null on error
 pub fn two_u8_vec_to_jbyte_array(env: &JNIEnv, vec1: &Vec<u8>, vec2: &Vec<u8>) -> jbyteArray {
-    let jbyte_vec = vec1.iter().chain(vec2.iter()).map(|&x| x as jbyte).collect();
+    let jbyte_vec = vec1
+        .iter()
+        .chain(vec2.iter())
+        .map(|&x| x as jbyte)
+        .collect();
     jbyte_vec_to_jbyte_array(env, &jbyte_vec)
 }
-
 
 /// Creates a `[u8; RANDOM_SIZE]` array out of a given Java byte array,
 /// which must be of size RANDOM_SIZE (currently 32).
@@ -59,35 +62,44 @@ pub fn two_u8_vec_to_jbyte_array(env: &JNIEnv, vec1: &Vec<u8>, vec2: &Vec<u8>) -
 /// * `random_array` the Java byte array of size RANDOM_SIZE
 /// # Returns
 /// *   an entropy array as accepted by the CRS/HinTS implementation, or Err
-pub fn build_entropy_array(env: &JNIEnv, random_array: &JByteArray) -> Result<[u8; RANDOM_SIZE], ()> {
+pub fn build_entropy_array(
+    env: &JNIEnv,
+    random_array: &JByteArray,
+) -> Result<[u8; RANDOM_SIZE], ()> {
     let random_vec = match env.convert_byte_array(&random_array) {
         Ok(val) => val,
-        Err(_) => return Result::Err(())
+        Err(_) => return Result::Err(()),
     };
-    let random_arr :[u8; RANDOM_SIZE] = match random_vec.try_into() {
+    let random_arr: [u8; RANDOM_SIZE] = match random_vec.try_into() {
         Ok(val) => val,
-        Err(_) => return Result::Err(())
+        Err(_) => return Result::Err(()),
     };
     Ok(random_arr)
 }
 
 /// Deserializes a JByteArray into an object, or returns Err.
-pub fn deserialize_jbyte_array<T: CanonicalDeserialize>(env: &JNIEnv, jarray: &JByteArray) -> Result<T, Box<dyn Any>> {
+pub fn deserialize_jbyte_array<T: CanonicalDeserialize>(
+    env: &JNIEnv,
+    jarray: &JByteArray,
+) -> Result<T, Box<dyn Any>> {
     let vec = match env.convert_byte_array(&jarray) {
         Ok(val) => val,
-        Err(err) => return Err(Box::new(err))
+        Err(err) => return Err(Box::new(err)),
     };
     match T::deserialize_uncompressed(&*vec) {
         Ok(val) => Ok(val),
-        Err(err) => Err(Box::new(err))
+        Err(err) => Err(Box::new(err)),
     }
 }
 
 /// Serializes an object into a jbyteArray.
-pub fn serialize_object<T: CanonicalSerialize>(env: &JNIEnv, obj: &T) -> Result<jbyteArray, HinTSError> {
+pub fn serialize_object<T: CanonicalSerialize>(
+    env: &JNIEnv,
+    obj: &T,
+) -> Result<jbyteArray, HinTSError> {
     let vec = match serialize(obj) {
         Ok(val) => val,
-        Err(e) => return Err(e)
+        Err(e) => return Err(e),
     };
     Ok(u8_vec_to_jbyte_array(env, &vec))
 }

--- a/cryptography/hedera-cryptography-hints/src/main/rust/kzg.rs
+++ b/cryptography/hedera-cryptography-hints/src/main/rust/kzg.rs
@@ -70,7 +70,10 @@ where
         pp
     }
 
-    pub fn commit_g1(params: &UniversalParams<E>, polynomial: &P) -> Result<E::G1Affine, HinTSError> {
+    pub fn commit_g1(
+        params: &UniversalParams<E>,
+        polynomial: &P,
+    ) -> Result<E::G1Affine, HinTSError> {
         let d = polynomial.degree();
         if d >= params.powers_of_g.len() {
             return Err(HinTSError::InsufficientCRS(d));
@@ -80,11 +83,15 @@ where
             convert_to_bigints(&polynomial.coeffs());
 
         let powers_of_g = &params.powers_of_g[..=d].to_vec();
-        let commitment = <E::G1 as VariableBaseMSM>::msm_bigint(&powers_of_g[..], plain_coeffs.as_slice());
+        let commitment =
+            <E::G1 as VariableBaseMSM>::msm_bigint(&powers_of_g[..], plain_coeffs.as_slice());
         Ok(commitment.into_affine())
     }
 
-    pub fn commit_g2(params: &UniversalParams<E>, polynomial: &P) -> Result<E::G2Affine, HinTSError> {
+    pub fn commit_g2(
+        params: &UniversalParams<E>,
+        polynomial: &P,
+    ) -> Result<E::G2Affine, HinTSError> {
         let d = polynomial.degree();
         if d >= params.powers_of_h.len() {
             return Err(HinTSError::InsufficientCRS(d));
@@ -94,7 +101,8 @@ where
             convert_to_bigints(&polynomial.coeffs());
 
         let powers_of_h = &params.powers_of_h[..=d].to_vec();
-        let commitment = <E::G2 as VariableBaseMSM>::msm_bigint(&powers_of_h[..], plain_coeffs.as_slice());
+        let commitment =
+            <E::G2 as VariableBaseMSM>::msm_bigint(&powers_of_h[..], plain_coeffs.as_slice());
 
         Ok(commitment.into_affine())
     }
@@ -127,9 +135,6 @@ fn skip_leading_zeros_and_convert_to_bigints<F: PrimeField, P: DenseUVPolynomial
 }
 
 fn convert_to_bigints<F: PrimeField>(p: &[F]) -> Vec<F::BigInt> {
-    let coeffs = p
-        .into_iter()
-        .map(|s| s.into_bigint())
-        .collect::<Vec<_>>();
+    let coeffs = p.into_iter().map(|s| s.into_bigint()).collect::<Vec<_>>();
     coeffs
 }

--- a/cryptography/hedera-cryptography-hints/src/main/rust/lib.rs
+++ b/cryptography/hedera-cryptography-hints/src/main/rust/lib.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod errors;
 pub mod hints;
 pub mod jni_crs;
 pub mod jni_hints;
 pub mod setup;
-pub mod errors;
 
+mod jni_util;
 mod kzg;
 mod utils;
-mod jni_util;

--- a/cryptography/hedera-cryptography-hints/src/main/rust/setup.rs
+++ b/cryptography/hedera-cryptography-hints/src/main/rust/setup.rs
@@ -3,7 +3,10 @@
 /// module responsible for generating the CRS
 /// implements the algorithm in https://eprint.iacr.org/2022/1592.pdf
 use ark_ec::{pairing::Pairing, AffineRepr, CurveGroup, VariableBaseMSM};
-use ark_ff::{field_hashers::{DefaultFieldHasher, HashToField}, Field, PrimeField};
+use ark_ff::{
+    field_hashers::{DefaultFieldHasher, HashToField},
+    Field, PrimeField,
+};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{ops::*, UniformRand};
 use rand::Rng;
@@ -81,12 +84,7 @@ impl PowersOfTauProtocol {
             powers_of_h,
         };
 
-        let proof = schnorr_nizk(
-            &crs.powers_of_g[1],
-            &next_crs.powers_of_g[1],
-            &r,
-            &mut rng,
-        )?;
+        let proof = schnorr_nizk(&crs.powers_of_g[1], &next_crs.powers_of_g[1], &r, &mut rng)?;
 
         Ok((next_crs, proof))
     }
@@ -96,13 +94,13 @@ impl PowersOfTauProtocol {
         let c1 = {
             match check1(&prev_crs.powers_of_g[1], &next_crs.powers_of_g[1], proof) {
                 Ok(c1) => c1,
-                Err(_) => false
+                Err(_) => false,
             }
         };
         let c2 = {
             match check2(next_crs) {
                 Ok(c2) => c2,
-                Err(_) => false
+                Err(_) => false,
             }
         };
         let c3 = check3(next_crs);
@@ -130,7 +128,11 @@ fn schnorr_nizk<R: Rng>(
 }
 
 /// verify the Schnorr proof of knowledge of discrete logarithm of next_p1 w.r.t. prev_p1
-fn check1(prev_p1: &G1AffinePoint, next_p1: &G1AffinePoint, proof: &ContributionProof) -> Result<bool, HinTSError> {
+fn check1(
+    prev_p1: &G1AffinePoint,
+    next_p1: &G1AffinePoint,
+    proof: &ContributionProof,
+) -> Result<bool, HinTSError> {
     let h = random_oracle(prev_p1, next_p1, &proof.p1_mul_z)?;
     let lhs = prev_p1.mul(&proof.z_plus_hr).into_affine();
     let rhs = proof.p1_mul_z.add(next_p1.mul(h)).into_affine();
@@ -177,7 +179,7 @@ fn check2(crs: &CRS) -> Result<bool, usize> {
     let mut crs_bytes = Vec::new();
     match crs.serialize_uncompressed(&mut crs_bytes) {
         Ok(_) => (),
-        Err(_) => return Err(0)
+        Err(_) => return Err(0),
     };
 
     // use random oracle with domain separators
@@ -195,14 +197,16 @@ fn check2(crs: &CRS) -> Result<bool, usize> {
         &(0..=n - 1)
             .map(|i| rho1.pow(&[i as u64]))
             .collect::<Vec<F>>(),
-    )?.into_affine();
+    )?
+    .into_affine();
 
     let lhs_rhs = <<Curve as Pairing>::G2 as VariableBaseMSM>::msm(
         &crs.powers_of_h[1..=n - 1],
         &(1..=n - 1)
             .map(|i| rho2.pow(&[i as u64]))
             .collect::<Vec<F>>(),
-    )?.add(crs.powers_of_h[0])
+    )?
+    .add(crs.powers_of_h[0])
     .into_affine();
 
     let rhs_lhs = <<Curve as Pairing>::G1 as VariableBaseMSM>::msm(
@@ -210,7 +214,8 @@ fn check2(crs: &CRS) -> Result<bool, usize> {
         &(1..=n - 1)
             .map(|i| rho1.pow(&[i as u64]))
             .collect::<Vec<F>>(),
-    )?.add(crs.powers_of_g[0])
+    )?
+    .add(crs.powers_of_g[0])
     .into_affine();
 
     let rhs_rhs = <<Curve as Pairing>::G2 as VariableBaseMSM>::msm(
@@ -218,7 +223,8 @@ fn check2(crs: &CRS) -> Result<bool, usize> {
         &(0..=n - 1)
             .map(|i| rho2.pow(&[i as u64]))
             .collect::<Vec<F>>(),
-    )?.into_affine();
+    )?
+    .into_affine();
 
     let lhs = <Curve as Pairing>::pairing(lhs_lhs, lhs_rhs);
     let rhs = <Curve as Pairing>::pairing(rhs_lhs, rhs_rhs);
@@ -267,7 +273,8 @@ mod tests {
             next_next_crs,
             CRS::deserialize_uncompressed(
                 crate::hints::serialize(&next_next_crs).unwrap().as_slice()
-            ).unwrap()
+            )
+            .unwrap()
         );
     }
 }

--- a/cryptography/hedera-cryptography-hints/src/main/rust/utils.rs
+++ b/cryptography/hedera-cryptography-hints/src/main/rust/utils.rs
@@ -8,9 +8,7 @@ use ark_std::ops::*;
 
 /// returns the vanishing polynomial for a multiplicative subgroup of size n;
 /// when n is a power of 2, this is equivalent to t(X) = X^n - 1
-pub fn compute_vanishing_poly<F: PrimeField + From<u64>>(
-    n: usize
-) -> DensePolynomial<F> {
+pub fn compute_vanishing_poly<F: PrimeField + From<u64>>(n: usize) -> DensePolynomial<F> {
     let mut coeffs = vec![];
     for i in 0..n + 1 {
         if i == 0 {
@@ -30,18 +28,14 @@ pub fn compute_vanishing_poly<F: PrimeField + From<u64>>(
 pub fn interpolate_poly_over_mult_subgroup<F: PrimeField + From<u64>>(
     evals: &Vec<F>,
 ) -> Option<DensePolynomial<F>> {
-    Radix2EvaluationDomain::<F>::new(evals.len()).map(|d| {
-        Evaluations::from_vec_and_domain(evals.clone(), d).interpolate()
-    })
+    Radix2EvaluationDomain::<F>::new(evals.len())
+        .map(|d| Evaluations::from_vec_and_domain(evals.clone(), d).interpolate())
 }
 
 /// outputs the Lagrange polynomial for the ith location in a multiplicative subgroup
 /// of size n, defined to be 1 at omega^i and 0 elsewhere on domain
 /// {omega^i}_{i \in [n]} (where omega is the n-th root of unity)
-pub fn lagrange_poly<F: PrimeField + From<u64>>(
-    n: usize,
-    i: usize
-) -> Option<DensePolynomial<F>> {
+pub fn lagrange_poly<F: PrimeField + From<u64>>(n: usize, i: usize) -> Option<DensePolynomial<F>> {
     // see sec 3 of https://eprint.iacr.org/2023/567.pdf
     nth_root_of_unity::<F>(n).map(|ω| {
         let factor = ω.pow([i as u64]) / F::from(n as u64);
@@ -90,7 +84,9 @@ pub fn poly_eval_mult_c<F: PrimeField>(f: &DensePolynomial<F>, c: &F) -> DensePo
         return f.clone();
     }
 
-    DensePolynomial { coeffs: f.coeffs.iter().map(|a| a.clone() * c.clone()).collect() }
+    DensePolynomial {
+        coeffs: f.coeffs.iter().map(|a| a.clone() * c.clone()).collect(),
+    }
 }
 
 /// outputs a generator of the multiplicative subgroup of input size n
@@ -102,7 +98,6 @@ pub fn nth_root_of_unity<F: PrimeField>(n: usize) -> Option<F> {
 pub fn is_n_valid(n: usize) -> bool {
     n > 1 && (n & (n - 1)) == 0
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -118,16 +113,19 @@ mod tests {
         assert!(result.coeffs.is_empty());
         assert_eq!(result.degree(), 0);
 
-        let poly = DensePolynomial::<F> { coeffs: vec![F::from(1u64)] };
+        let poly = DensePolynomial::<F> {
+            coeffs: vec![F::from(1u64)],
+        };
         let result = super::poly_eval_mult_c(&poly, &c);
         assert_eq!(result.coeffs.len(), 1);
         assert_eq!(result.coeffs[0], F::from(2u64));
 
-        let poly = DensePolynomial::<F> { coeffs: vec![F::from(1u64), F::from(2u64)] };
+        let poly = DensePolynomial::<F> {
+            coeffs: vec![F::from(1u64), F::from(2u64)],
+        };
         let result = super::poly_eval_mult_c(&poly, &c);
         assert_eq!(result.coeffs.len(), 2);
         assert_eq!(result.coeffs[0], F::from(2u64));
         assert_eq!(result.coeffs[1], F::from(4u64));
     }
-
 }


### PR DESCRIPTION
Description: This PR optimizes the hinTS verification process by reducing the aggregated verification key size and eliminating a pairing computation.

- Remove one element from the aggregated verification key

- Eliminate one pairing computation from the verification logic

- Update the test suite to separately report the time taken for verification

Related issue(s):
Fixes #513

Notes for reviewer: The optimization results in the following performance improvements:

Storage: 192 bytes saved.

Speed: Verification is approximately 1.5 msec faster.

Logs: The test output now explicitly prints the standalone verification time.

Checklist

[x] Documented (Code comments, README, etc.)

[x] Tested (unit, integration, etc.)