### PR TITLE
feat: support TSS Ceremony cycles

### DIFF
--- a/cryptography/hedera-cryptography-ceremony/src/main/java/com/hedera/cryptography/ceremony/Orchestrator.java
+++ b/cryptography/hedera-cryptography-ceremony/src/main/java/com/hedera/cryptography/ceremony/Orchestrator.java
@@ -3,10 +3,24 @@ package com.hedera.cryptography.ceremony;
 
 import com.hedera.cryptography.ceremony.s3.S3Client;
 import com.hedera.cryptography.ceremony.s3.S3ClientInitializationException;
+import com.hedera.cryptography.ceremony.s3.S3ResponseException;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+/// TSS Ceremony Orchestrator.
 public class Orchestrator {
+    /// Maximum number of cycles of the ceremony.
+    private static final int MAX_CYCLES = 100;
+
+    /// Make the loop less tight to reduce the number of S3 API calls in case we keep re-running the last cycle.
+    /// Long enough to avoid bombarding S3 with unnecessary requests.
+    /// Short enough to allow a human to start a new cycle by uploading the initial.bin/ready whenever needed.
+    private static final long WAIT_BETWEEN_CYCLES_MILLIS = 15 * 60 * 1000;
+
+    /// Make the loop less tight to avoid 429 TOO_MANY_REQUESTS.
+    private static final long WAIT_IN_DETERMINE_CYCLE_LOOP_MILLIS = 1000;
+
     /**
      * Main class that requires command-line arguments:
      * <p>
@@ -50,13 +64,79 @@ public class Orchestrator {
             System.err.println("Starting Orchestrator for nodeId: " + thisNodeId + " and allNodeIds: " + allNodeIds
                     + " using dataCruncher: " + dataCruncherExecutableFile);
 
-            // Run phase 1
-            new Phase("1", thisNodeId, allNodeIds, new S3DirectoryAccessor(s3Client, "phase1"), dataCruncher, crypto)
-                    .run();
+            while (true) {
+                try {
+                    System.err.println(
+                            "Trying to determine a cycle to run (will keep trying until there's one ready)...");
+                    final String cycle = determineCycle(s3Client);
+                    if (cycle != null) {
+                        System.err.println("Running cycle: " + cycle);
 
-            // Run phase 2
-            new Phase("2", thisNodeId, allNodeIds, new S3DirectoryAccessor(s3Client, "phase2"), dataCruncher, crypto)
-                    .run();
+                        // Run phase 1
+                        new Phase(
+                                        "1",
+                                        thisNodeId,
+                                        allNodeIds,
+                                        new S3DirectoryAccessor(s3Client, cycle + "/phase1"),
+                                        dataCruncher,
+                                        crypto)
+                                .run();
+
+                        // Run phase 2
+                        new Phase(
+                                        "2",
+                                        thisNodeId,
+                                        allNodeIds,
+                                        new S3DirectoryAccessor(s3Client, cycle + "/phase2"),
+                                        dataCruncher,
+                                        crypto)
+                                .run();
+                    }
+                } catch (S3ResponseException | IOException e) {
+                    e.printStackTrace();
+
+                    // An S3 call failed (or maybe a disk read/write failed.) On one hand we could die here.
+                    // On the other hand, this may be an intermittent network failure or throttling of some sort,
+                    // so let's keep running. We have a Thread.sleep() below to avoid bombarding S3 with bad requests
+                    // if it's our fault, actually.
+                    // A NodeOp might want to check logs (our stderr/out redirected to a file) to decide if the
+                    // process should be killed (e.g. if S3 credentials are indeed bad or similar.)
+                }
+
+                try {
+                    Thread.sleep(WAIT_BETWEEN_CYCLES_MILLIS);
+                } catch (InterruptedException ignore) {
+                    // Swallow it to prevent spurious InterruptedExceptions.
+                    // We don't really support a graceful shutdown, so an operator would have to kill the process.
+                }
+            }
         }
+    }
+
+    private static String cycleName(int i) {
+        return "cycle" + i;
+    }
+
+    /// Determine a cycle to run, or null if there's none ready.
+    private static String determineCycle(S3Client s3Client) throws S3ResponseException, IOException {
+        // It would be nice to list all objects and filter out the pattern we like, but S3 API has a hard-limit
+        // of 1000 max_keys for listObject call, and with multiple cycles and phases we could hit the limit.
+        // So we loop instead:
+        int lastCycle = -1;
+        for (int i = 0; i < MAX_CYCLES; i++) {
+            final String name = cycleName(i) + "/phase1/" + Phase.INITIAL_FILE_NAME + ".ready";
+            final List<String> objects = s3Client.listObjects(name, 2);
+            if (objects.size() == 1 && objects.get(0).equals(name)) {
+                lastCycle = i;
+            }
+            try {
+                Thread.sleep(WAIT_IN_DETERMINE_CYCLE_LOOP_MILLIS);
+            } catch (InterruptedException ignore) {
+                // Swallow it to prevent spurious InterruptedExceptions.
+                // We don't really support a graceful shutdown, so an operator would have to kill the process.
+            }
+        }
+
+        return lastCycle == -1 ? null : cycleName(lastCycle);
     }
 }

--- a/cryptography/hedera-cryptography-ceremony/src/main/java/com/hedera/cryptography/ceremony/Phase.java
+++ b/cryptography/hedera-cryptography-ceremony/src/main/java/com/hedera/cryptography/ceremony/Phase.java
@@ -11,9 +11,14 @@ class Phase {
     ///  The phase won't start until the initial file is present. Wait for 1 week because it's manual.
     private static final long WAIT_FOR_INITIAL_FILE_TIMEOUT_MILLIS = 7 * 24 * 60 * 60 * 1000;
 
-    /// Regular processing on a node should be "fast", but we give it 12 hours of timeout before
+    /// Regular processing on a node should be "fast", but we give it 6 hours of timeout before
     /// giving up and trying the previous node's file:
-    private static final long WAIT_FOR_REGULAR_FILE_TIMEOUT_MILLIS = 12 * 60 * 60 * 1000;
+    private static final long WAIT_FOR_REGULAR_FILE_TIMEOUT_MILLIS = 6 * 60 * 60 * 1000;
+
+    /// Make the loop less tight to avoid 429 TOO_MANY_REQUESTS.
+    private static final long WAIT_BETWEEN_CLAIMED_FILES_CHECKS_MILLIS = 500;
+
+    static final String INITIAL_FILE_NAME = "initial";
 
     /// Phase number, e.g. "1", or "2"
     private final String phase;
@@ -41,10 +46,14 @@ class Phase {
     /// @return for -1 - "initial", otherwise the nodeId at the given index.
     private String nameAtIndex(int index) {
         if (index < 0) {
-            return "initial";
+            return INITIAL_FILE_NAME;
         } else {
             return allNodeIds.get(index).toString();
         }
+    }
+
+    private String claimedFileNameAtIndex(int index) {
+        return nameAtIndex(index) + ".claimed";
     }
 
     private String readyFileNameAtIndex(int index) {
@@ -81,7 +90,28 @@ class Phase {
         try {
             System.err.println("Starting phase " + phase + "...");
 
+            // Check if this node or any later nodes have already started processing anything.
+            // If true, then it's no longer our turn, and we won't participate in this phase at all.
+            // This allows us to return fast in case we've been restarted in the middle of a currently running cycle,
+            // or if we're asked to re-run a cycle that has already completed in the past.
+            final int thisIndex = allNodeIds.indexOf(thisNodeId);
+            System.err.println("Checking .claimed files to decide if we should run this phase...");
+            for (int i = thisIndex; i < allNodeIds.size(); i++) {
+                if (s3DirectoryAccessor.doesExist(claimedFileNameAtIndex(i))) {
+                    System.err.println("File " + claimedFileNameAtIndex(i)
+                            + " exists, so this or a later node has started processing already. Skip the phase.");
+                    return;
+                }
+                try {
+                    Thread.sleep(WAIT_BETWEEN_CLAIMED_FILES_CHECKS_MILLIS);
+                } catch (InterruptedException e) {
+                    // Swallow spurious exceptions.
+                }
+            }
+
             // First, wait until the current phase actually starts - the initial file MUST be present.
+            // Note that the cycle selection mechanism in the Orchestrator already checks this condition before
+            // starting a cycle, so the following wait() should be quick. It's here simply as a safety mechanism.
             final String initialReadyFileName = readyFileNameAtIndex(-1);
             System.err.println("Waiting for the initial file: " + initialReadyFileName);
             if (!s3DirectoryAccessor.waitForFile(initialReadyFileName, WAIT_FOR_INITIAL_FILE_TIMEOUT_MILLIS)) {
@@ -91,7 +121,6 @@ class Phase {
             }
 
             // Now wait for the actual input file for this node to process
-            final int thisIndex = allNodeIds.indexOf(thisNodeId);
             final int inputIndex = waitForInputReady(thisIndex);
             if (inputIndex < -1) {
                 System.err.println("Timeout reached while waiting for input data");
@@ -101,8 +130,8 @@ class Phase {
             // We know the input file to process, let's claim it (we don't use the .claimed, it's for manual debugging.)
             final String inputFileName = nameAtIndex(inputIndex);
             final String thisFileName = nameAtIndex(thisIndex);
-            s3DirectoryAccessor.writeText(thisFileName + ".claimed", inputFileName);
-            System.err.println("Wrote: " + thisFileName + ".claimed" + " with inputFileName: " + inputFileName);
+            s3DirectoryAccessor.writeText(claimedFileNameAtIndex(thisIndex), inputFileName);
+            System.err.println("Wrote: " + claimedFileNameAtIndex(thisIndex) + " with inputFileName: " + inputFileName);
 
             System.err.println("Downloading input dir: " + inputFileName + ".bin");
             final Path inputDir;

--- a/cryptography/hedera-cryptography-ceremony/src/test/java/com/hedera/cryptography/ceremony/PhaseTest.java
+++ b/cryptography/hedera-cryptography-ceremony/src/test/java/com/hedera/cryptography/ceremony/PhaseTest.java
@@ -44,6 +44,9 @@ public class PhaseTest {
 
         phase.run();
 
+        verify(s3DirectoryAccessor, times(1)).doesExist("1.claimed");
+        verify(s3DirectoryAccessor, times(1)).doesExist("2.claimed");
+
         verify(s3DirectoryAccessor, times(1)).writeText("1.claimed", "initial");
 
         ArgumentCaptor<Path> outputPathCaptor = ArgumentCaptor.forClass(Path.class);
@@ -72,6 +75,8 @@ public class PhaseTest {
 
         phase.run();
 
+        verify(s3DirectoryAccessor, times(1)).doesExist("2.claimed");
+
         verify(s3DirectoryAccessor, times(1)).writeText("2.claimed", "1");
 
         ArgumentCaptor<Path> outputPathCaptor = ArgumentCaptor.forClass(Path.class);
@@ -99,6 +104,8 @@ public class PhaseTest {
         doReturn(0).when(dataCruncher).execute(eq(PHASE), eq(inputPath), any(Path.class));
 
         phase.run();
+
+        verify(s3DirectoryAccessor, times(1)).doesExist("2.claimed");
 
         verify(s3DirectoryAccessor, times(1)).writeText("2.claimed", "initial");
 


### PR DESCRIPTION
**Description**:
Introducing a concept of the TSS Ceremony cycles to the Orchestrator. This allows us to run multiple cycles in case we're not satisfied with the results of the previous runs.

In S3, the directory structure looks like:
* cycle0/phase1/initial.bin/*
* cycle0/phase1/initial.ready
* ... and the above starts the phase1 of cycle0, nodes populate S3 with data, and run phase1 and then phase2.

Once complete, the Orchestrator will re-run this phase over and over. However, the phase implementation detects existing .claimed files and skips actual data processing. So the data computed at the cycle0 remains intact.

If we aren't satisfied with the results, then the operator (aka @rsinha ) goes and adds the following to S3:
* cycle1/phase1/initial.bin/*
* cycle1/phase1/initial.ready

The Orchestrator will detect this and will run the cycle1.

This can continue up to cycle99 which is the maximum number of supported cycles.

**Related issue(s)**:

Fixes #517

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
