### PR TITLE
feat: add static parameters for TSS Ceremony

### DIFF
--- a/cryptography/hedera-cryptography-ceremony/src/main/java/com/hedera/cryptography/ceremony/DataCruncher.java
+++ b/cryptography/hedera-cryptography-ceremony/src/main/java/com/hedera/cryptography/ceremony/DataCruncher.java
@@ -13,8 +13,12 @@ class DataCruncher {
     /// Full path to the executable
     private final String executableFileName;
 
-    DataCruncher(String executableFileName) {
+    /// Full path to static parameters of the current cycle shared between all phases/nodes/runs.
+    private final Path parametersPath;
+
+    DataCruncher(String executableFileName, Path parametersPath) {
         this.executableFileName = executableFileName;
+        this.parametersPath = parametersPath;
     }
 
     /// Run the data cruncher and return its exit code
@@ -23,6 +27,7 @@ class DataCruncher {
                 .command(
                         executableFileName,
                         phase,
+                        parametersPath.toAbsolutePath().toString(),
                         inputPath.toAbsolutePath().toString(),
                         outputPath.toAbsolutePath().toString());
 

--- a/cryptography/hedera-cryptography-ceremony/src/main/java/com/hedera/cryptography/ceremony/Orchestrator.java
+++ b/cryptography/hedera-cryptography-ceremony/src/main/java/com/hedera/cryptography/ceremony/Orchestrator.java
@@ -44,8 +44,8 @@ public class Orchestrator {
      * create a new "cycle1", or 2, 3, etc. directory in S3.
      * The initial directory structure in S3 looks like this:
      * - cycle0/parameters/* - static parameters shared by all phases/nodes in a given cycle
-     * - cycle0/phase1/initial.bin/* - initial binary files for node0 to pick up as input
-     * - cycle0/phase1/initial.ready - a marker to start the cycle0
+     * - cycle0/phase2/initial.bin/* - initial binary files for node0 to pick up as input
+     * - cycle0/phase2/initial.ready - a marker to start the cycle0
      *
      * @param args the CLI args
      */
@@ -87,20 +87,20 @@ public class Orchestrator {
 
                         // Run phase 1
                         new Phase(
-                                        "1",
+                                        "2",
                                         thisNodeId,
                                         allNodeIds,
-                                        new S3DirectoryAccessor(s3Client, cycle + "/phase1"),
+                                        new S3DirectoryAccessor(s3Client, cycle + "/phase2"),
                                         dataCruncher,
                                         crypto)
                                 .run();
 
                         // Run phase 2
                         new Phase(
-                                        "2",
+                                        "4",
                                         thisNodeId,
                                         allNodeIds,
-                                        new S3DirectoryAccessor(s3Client, cycle + "/phase2"),
+                                        new S3DirectoryAccessor(s3Client, cycle + "/phase4"),
                                         dataCruncher,
                                         crypto)
                                 .run();

--- a/cryptography/hedera-cryptography-ceremony/src/main/java/com/hedera/cryptography/ceremony/Orchestrator.java
+++ b/cryptography/hedera-cryptography-ceremony/src/main/java/com/hedera/cryptography/ceremony/Orchestrator.java
@@ -5,8 +5,11 @@ import com.hedera.cryptography.ceremony.s3.S3Client;
 import com.hedera.cryptography.ceremony.s3.S3ClientInitializationException;
 import com.hedera.cryptography.ceremony.s3.S3ResponseException;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /// TSS Ceremony Orchestrator.
 public class Orchestrator {
@@ -35,6 +38,15 @@ public class Orchestrator {
      *
      * NOTE: TSS_CEREMONY_S3_ACCESS_KEY and TSS_CEREMONY_S3_SECRET_KEY env vars must be defined.
      *
+     * The Orchestrator runs continuously and supports multiple cycles (always keeping re-running the last "ready"
+     * cycle.) Phases check the ".claimed" files to avoid recomputing and overwriting old data in the current cycle.
+     * So continuous re-runs are effectively no-ops after the initial run. To start a new cycle, simply
+     * create a new "cycle1", or 2, 3, etc. directory in S3.
+     * The initial directory structure in S3 looks like this:
+     * - cycle0/parameters/* - static parameters shared by all phases/nodes in a given cycle
+     * - cycle0/phase1/initial.bin/* - initial binary files for node0 to pick up as input
+     * - cycle0/phase1/initial.ready - a marker to start the cycle0
+     *
      * @param args the CLI args
      */
     public static void main(String[] args) throws S3ClientInitializationException {
@@ -59,7 +71,6 @@ public class Orchestrator {
         final String s3AccessKey = System.getenv("TSS_CEREMONY_S3_ACCESS_KEY");
         final String s3SecretKey = System.getenv("TSS_CEREMONY_S3_SECRET_KEY");
 
-        final DataCruncher dataCruncher = new DataCruncher(dataCruncherExecutableFile);
         try (final S3Client s3Client = new S3Client(s3Region, s3Endpoint, s3BucketName, s3AccessKey, s3SecretKey)) {
             System.err.println("Starting Orchestrator for nodeId: " + thisNodeId + " and allNodeIds: " + allNodeIds
                     + " using dataCruncher: " + dataCruncherExecutableFile);
@@ -71,6 +82,8 @@ public class Orchestrator {
                     final String cycle = determineCycle(s3Client);
                     if (cycle != null) {
                         System.err.println("Running cycle: " + cycle);
+                        final Path parametersDir = obtainParameters(s3Client, cycle);
+                        final DataCruncher dataCruncher = new DataCruncher(dataCruncherExecutableFile, parametersDir);
 
                         // Run phase 1
                         new Phase(
@@ -138,5 +151,24 @@ public class Orchestrator {
         }
 
         return lastCycle == -1 ? null : cycleName(lastCycle);
+    }
+
+    // Parameters occupy some 4GB of space. We don't want to keep re-downloading them as we keep re-running
+    // the same cycle again and again because it's wasteful. So we cache them.
+    private static final Map<String, Path> PARAMETERS_PATHS = new HashMap<>();
+
+    /// Download (if not cached yet) static parameters and return their path
+    private static Path obtainParameters(S3Client s3Client, String cycle) throws IOException {
+        // Map.computeIfAbsent() is nice, but propagating checked exceptions from lambdas isn't.
+        if (PARAMETERS_PATHS.containsKey(cycle)) {
+            return PARAMETERS_PATHS.get(cycle);
+        }
+
+        System.err.println("Downloading static parameters...");
+        final S3DirectoryAccessor s3DirectoryAccessor = new S3DirectoryAccessor(s3Client, cycle);
+        final Path parametersDir = s3DirectoryAccessor.downloadDir("parameters");
+        PARAMETERS_PATHS.put(cycle, parametersDir);
+
+        return parametersDir;
     }
 }

--- a/cryptography/hedera-cryptography-ceremony/src/main/java/com/hedera/cryptography/ceremony/Phase.java
+++ b/cryptography/hedera-cryptography-ceremony/src/main/java/com/hedera/cryptography/ceremony/Phase.java
@@ -20,7 +20,7 @@ class Phase {
 
     static final String INITIAL_FILE_NAME = "initial";
 
-    /// Phase number, e.g. "1", or "2"
+    /// Phase number, e.g. "2", or "4" (w/o quotes) - these are the only supported phase numbers.
     private final String phase;
     private final long thisNodeId;
     private final List<Long> allNodeIds;

--- a/cryptography/hedera-cryptography-ceremony/src/test/java/com/hedera/cryptography/ceremony/DataCruncherTest.java
+++ b/cryptography/hedera-cryptography-ceremony/src/test/java/com/hedera/cryptography/ceremony/DataCruncherTest.java
@@ -16,14 +16,14 @@ import org.junit.jupiter.api.condition.OS;
 public class DataCruncherTest {
     @Test
     void testTrue() throws IOException {
-        final DataCruncher dataCruncher = new DataCruncher("/usr/bin/true");
+        final DataCruncher dataCruncher = new DataCruncher("/usr/bin/true", Path.of("."));
         final int status = dataCruncher.execute("", Path.of("."), Path.of("."));
         assertEquals(0, status);
     }
 
     @Test
     void testFalse() throws IOException {
-        final DataCruncher dataCruncher = new DataCruncher("/usr/bin/false");
+        final DataCruncher dataCruncher = new DataCruncher("/usr/bin/false", Path.of("."));
         final int status = dataCruncher.execute("", Path.of("."), Path.of("."));
         assertNotEquals(0, status);
     }


### PR DESCRIPTION
**Description**:
Adding support for static parameters of a TSS Ceremony cycle.
The data cruncher now receives 4 command line arguments:
```shell
$ dataCruncher <phase> <paramsPath> <inputPath> <outputPath>
```
See comments in code for details.

Also, renaming the current phase1 and phase2 to phase2 and phase4 respectively. This is because the data cruncher internally supports phases 1, 3, and 5 for manual runs. Only the phases 2 and 4 are managed by the Orchestrator and are fully automated.

**Related issue(s)**:

Fixes #520 

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
