### PR TITLE
feat: add jpackage support

### DIFF
--- a/cryptography/hedera-cryptography-ceremony/build.gradle.kts
+++ b/cryptography/hedera-cryptography-ceremony/build.gradle.kts
@@ -36,6 +36,7 @@ javaModulePackaging {
         architecture = MachineArchitecture.X86_64
     }
 
-    // Bouncy Castle JARs fail as: jlink failed with: Error: signed modular JAR is currently not supported:
-    jlinkOptions.addAll("--ignore-signing-information");
+    // Bouncy Castle JARs fail as: jlink failed with: Error: signed modular JAR is currently not
+    // supported:
+    jlinkOptions.addAll("--ignore-signing-information")
 }

--- a/cryptography/hedera-cryptography-ceremony/build.gradle.kts
+++ b/cryptography/hedera-cryptography-ceremony/build.gradle.kts
@@ -2,6 +2,7 @@
 plugins {
     id("org.hiero.gradle.module.application")
     id("org.hiero.gradle.feature.shadow")
+    id("org.gradlex.java-module-packaging") version "1.2"
 }
 
 testModuleInfo {
@@ -12,3 +13,29 @@ testModuleInfo {
 }
 
 application.mainClass = "com.hedera.cryptography.ceremony.Orchestrator"
+
+javaModulePackaging {
+    target("linux-x86_64") {
+        operatingSystem = OperatingSystemFamily.LINUX
+        architecture = MachineArchitecture.X86_64
+    }
+    target("linux-aarch64") {
+        operatingSystem = OperatingSystemFamily.LINUX
+        architecture = MachineArchitecture.ARM64
+    }
+    target("darwin-aarch64") {
+        operatingSystem = OperatingSystemFamily.MACOS
+        architecture = MachineArchitecture.ARM64
+    }
+    target("darwin-x86_64") {
+        operatingSystem = OperatingSystemFamily.MACOS
+        architecture = MachineArchitecture.X86_64
+    }
+    target("windows-x86_64") {
+        operatingSystem = OperatingSystemFamily.WINDOWS
+        architecture = MachineArchitecture.X86_64
+    }
+
+    // Bouncy Castle JARs fail as: jlink failed with: Error: signed modular JAR is currently not supported:
+    jlinkOptions.addAll("--ignore-signing-information");
+}


### PR DESCRIPTION
**Description**:
Adding support for `./gradlew jpackage` which can produce installable packages for target operating systems.

I was able to produce a .dmg package on my Mac by running: `./gradlew jpackageDarwin-aarch64` and it can be installed, and then I can simply run it as:

```shell
$ /Applications/hedera-cryptography-ceremony.app/Contents/MacOS/hedera-cryptography-ceremony
Usage: Orchestrator thisNodeId nodeId1,nodeId2,... dataCruncherExecutableFile s3Region s3Endpoint s3BucketName keyStorePath keyStorePassword
```

(the usage output is printed by our Orchestrator class.)

**Related issue(s)**:

Fixes #524 

**Notes for reviewer**:
This is a manually run target, so its presence shouldn't affect anything already setup in the build. All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
