### PR TITLE
build: update org.hiero.gradle.build to 0.7.4

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pluginManagement { includeBuild("gradle/plugins") }
 
-plugins { id("org.hiero.gradle.build") version "0.6.3" }
+plugins { id("org.hiero.gradle.build") version "0.7.4" }
 
 rootProject.name = "hedera-cryptography"
 


### PR DESCRIPTION
**Description**:

Follow up to #530 but with the following adjustment:

- revert: downgrade com.gradleup.nmcp:nmcp to 1.2.1 (revert upgrade to 1.4.4)

This should repair the Snapshot publish the earlier update broke.