### PR TITLE
hint verification fix

### DIFF
--- a/cryptography/hedera-cryptography-hints/src/main/rust/hints.rs
+++ b/cryptography/hedera-cryptography-hints/src/main/rust/hints.rs
@@ -336,7 +336,7 @@ impl HinTS {
         let lhs = <Curve as Pairing>::pairing(hint.sk_i_l_i_of_tau_com_1, crs.powers_of_h[0]);
         let rhs = <Curve as Pairing>::pairing(hint.pk_i, l_i_of_tau_com);
         check_or_return_false!(lhs == rhs);
-       
+        
         //e([1]_1, [sk_i L_i(τ)]_2) = e([sk_i]_1, [L_i(τ)]_2)
         let lhs2 = <Curve as Pairing>::pairing(crs.powers_of_g[0], hint.sk_i_l_i_of_tau_com_2);
         check_or_return_false!(lhs2 == rhs);
@@ -1096,7 +1096,7 @@ mod tests {
 
         let threshold = (F::from(1), F::from(3)); // 1/3
         assert!(HinTS::verify(msg, &vk, &π, threshold).unwrap());
-
+        
         // attack the proof
         let mut π_attack = π.clone();
         π_attack.agg_weight = F::from(1000000000); // some arbitrary weight

--- a/cryptography/hedera-cryptography-hints/src/main/rust/hints.rs
+++ b/cryptography/hedera-cryptography-hints/src/main/rust/hints.rs
@@ -336,7 +336,7 @@ impl HinTS {
         let lhs = <Curve as Pairing>::pairing(hint.sk_i_l_i_of_tau_com_1, crs.powers_of_h[0]);
         let rhs = <Curve as Pairing>::pairing(hint.pk_i, l_i_of_tau_com);
         check_or_return_false!(lhs == rhs);
-        
+
         //e([1]_1, [sk_i L_i(τ)]_2) = e([sk_i]_1, [L_i(τ)]_2)
         let lhs2 = <Curve as Pairing>::pairing(crs.powers_of_g[0], hint.sk_i_l_i_of_tau_com_2);
         check_or_return_false!(lhs2 == rhs);
@@ -1096,7 +1096,7 @@ mod tests {
 
         let threshold = (F::from(1), F::from(3)); // 1/3
         assert!(HinTS::verify(msg, &vk, &π, threshold).unwrap());
-        
+
         // attack the proof
         let mut π_attack = π.clone();
         π_attack.agg_weight = F::from(1000000000); // some arbitrary weight
@@ -1105,7 +1105,7 @@ mod tests {
         // try a really high threshold of 99%
         assert!(!HinTS::verify(msg, &vk, &π_attack, (F::from(99), F::from(100))).unwrap());
     }
-    
+
     fn sample_signing(
         num_signers: usize,
         msg: &[u8],

--- a/cryptography/hedera-cryptography-hints/src/main/rust/hints.rs
+++ b/cryptography/hedera-cryptography-hints/src/main/rust/hints.rs
@@ -1105,40 +1105,7 @@ mod tests {
         // try a really high threshold of 99%
         assert!(!HinTS::verify(msg, &vk, &π_attack, (F::from(99), F::from(100))).unwrap());
     }
-
-    #[test]
-    fn verify_hint_rejects_corrupted_sk_i_l_i_of_tau_com_2() {
-        // small universe for fast test; must be power of 2
-        let n = 8usize;
-        let i = 0usize;
-
-        // ----- make a CRS -----
-        let init_crs = PowersOfTauProtocol::init(n);
-        let (crs, proof) = PowersOfTauProtocol::contribute(&init_crs, [86u8; 32]).unwrap();
-        assert!(PowersOfTauProtocol::verify_contribution(&init_crs, &crs, &proof));
-
-        // ----- generate a valid hint -----
-        let sk = F::from(42u64); // deterministic, non-zero
-        let hint = HinTS::hint_gen(&crs, n, i, &sk).unwrap();
-
-        // sanity: valid hint should verify
-        assert!(HinTS::verify_hint(&crs, n, i, &hint).unwrap());
-
-        // ----- corrupt ONLY the G2 hint contribution -----
-        let mut bad_hint = hint.clone();
-
-        // Deterministically make it wrong: add the G2 generator so it MUST differ.
-        bad_hint.sk_i_l_i_of_tau_com_2 = bad_hint
-            .sk_i_l_i_of_tau_com_2
-            .add(&G2AffinePoint::generator())
-            .into_affine();
-
-        // With the bug: this returns true (test FAILS).
-        // After the fix: this returns false (test PASSES).
-        assert!(!HinTS::verify_hint(&crs, n, i, &bad_hint).unwrap());
-    }
     
-
     fn sample_signing(
         num_signers: usize,
         msg: &[u8],

--- a/cryptography/hedera-cryptography-hints/src/main/rust/hints.rs
+++ b/cryptography/hedera-cryptography-hints/src/main/rust/hints.rs
@@ -336,6 +336,10 @@ impl HinTS {
         let lhs = <Curve as Pairing>::pairing(hint.sk_i_l_i_of_tau_com_1, crs.powers_of_h[0]);
         let rhs = <Curve as Pairing>::pairing(hint.pk_i, l_i_of_tau_com);
         check_or_return_false!(lhs == rhs);
+       
+        //e([1]_1, [sk_i L_i(τ)]_2) = e([sk_i]_1, [L_i(τ)]_2)
+        let lhs2 = <Curve as Pairing>::pairing(crs.powers_of_g[0], hint.sk_i_l_i_of_tau_com_2);
+        check_or_return_false!(lhs2 == rhs);
 
         for j in 0..n {
             let num: DensePolynomial<F>;
@@ -1101,6 +1105,39 @@ mod tests {
         // try a really high threshold of 99%
         assert!(!HinTS::verify(msg, &vk, &π_attack, (F::from(99), F::from(100))).unwrap());
     }
+
+    #[test]
+    fn verify_hint_rejects_corrupted_sk_i_l_i_of_tau_com_2() {
+        // small universe for fast test; must be power of 2
+        let n = 8usize;
+        let i = 0usize;
+
+        // ----- make a CRS -----
+        let init_crs = PowersOfTauProtocol::init(n);
+        let (crs, proof) = PowersOfTauProtocol::contribute(&init_crs, [86u8; 32]).unwrap();
+        assert!(PowersOfTauProtocol::verify_contribution(&init_crs, &crs, &proof));
+
+        // ----- generate a valid hint -----
+        let sk = F::from(42u64); // deterministic, non-zero
+        let hint = HinTS::hint_gen(&crs, n, i, &sk).unwrap();
+
+        // sanity: valid hint should verify
+        assert!(HinTS::verify_hint(&crs, n, i, &hint).unwrap());
+
+        // ----- corrupt ONLY the G2 hint contribution -----
+        let mut bad_hint = hint.clone();
+
+        // Deterministically make it wrong: add the G2 generator so it MUST differ.
+        bad_hint.sk_i_l_i_of_tau_com_2 = bad_hint
+            .sk_i_l_i_of_tau_com_2
+            .add(&G2AffinePoint::generator())
+            .into_affine();
+
+        // With the bug: this returns true (test FAILS).
+        // After the fix: this returns false (test PASSES).
+        assert!(!HinTS::verify_hint(&crs, n, i, &bad_hint).unwrap());
+    }
+    
 
     fn sample_signing(
         num_signers: usize,


### PR DESCRIPTION
**Description**:

This PR fixes a missing verification check in `verify_hint()` that allowed a malicious or malformed `sk_i_l_i_of_tau_com_2` (G2 hint contribution) to pass validation. As a result, `preprocess()` could construct an invalid `vk.sk_of_tau_com`, leading to verification failures or setup poisoning.

Changes:

* Add missing pairing check to validate `sk_i_l_i_of_tau_com_2` against `pk_i`
* Ensure consistency between G1 and G2 hint contributions

---

**Related issue(s)**:

Fixes #

---

**Notes for reviewer**:

Before this change, corrupting only `sk_i_l_i_of_tau_com_2` did not cause `verify_hint()` or `preprocess()` to fail, demonstrating a validation gap.

After the fix:

* `verify_hint()` correctly rejects inconsistent G2 hint contributions.
* `preprocess()` fails when provided with malformed hints.

This change strengthens setup integrity by preventing malicious G2 hint poisoning.

---

**Checklist**

* [x] Documented (Code comments, README, etc.)
* [x] Tested (unit, integration, etc.)
