### PR TITLE
feat: publish TSS Ceremony fat jar

### DIFF
--- a/cryptography/hedera-cryptography-ceremony/build.gradle.kts
+++ b/cryptography/hedera-cryptography-ceremony/build.gradle.kts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 plugins {
     id("org.hiero.gradle.module.application")
+    id("org.hiero.gradle.module.library")
     id("org.hiero.gradle.feature.shadow")
     id("org.gradlex.java-module-packaging") version "1.2"
 }

--- a/cryptography/hedera-cryptography-ceremony/src/main/java/com/hedera/cryptography/ceremony/Orchestrator.java
+++ b/cryptography/hedera-cryptography-ceremony/src/main/java/com/hedera/cryptography/ceremony/Orchestrator.java
@@ -48,7 +48,7 @@ public class Orchestrator {
      *
      * @param args the CLI args
      */
-    public static void main(String[] args) throws S3ClientInitializationException {
+    public static void main(String[] args) {
         if (args.length != 7) {
             System.err.println(
                     "Usage: Orchestrator thisNodeId nodeId1,nodeId2,... s3Region s3Endpoint s3BucketName keyStorePath keyStorePassword");
@@ -123,6 +123,11 @@ public class Orchestrator {
                     // We don't really support a graceful shutdown, so an operator would have to kill the process.
                 }
             }
+        } catch (S3ClientInitializationException e) {
+            // This is pretty much unrecoverable.
+            System.err.println("FATAL: Unable to initialize S3Client");
+            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/gradle/aggregation/build.gradle.kts
+++ b/gradle/aggregation/build.gradle.kts
@@ -2,5 +2,5 @@
 dependencies {
     published(project(":hedera-cryptography-hints"))
     published(project(":hedera-cryptography-wraps"))
-    implementation(project(":hedera-cryptography-ceremony"))
+    published(project(":hedera-cryptography-ceremony"))
 }


### PR DESCRIPTION
**Description**:
This fix allows us to publish the TSS Ceremony fat jar to Maven and hence make official releases of the TSS Ceremony software.

**Related issue(s)**:

Fixes #542 

**Notes for reviewer**:
All should build and pass, and now publish as well.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
