### PR TITLE
fix: sign huge files

### DIFF
--- a/cryptography/hedera-cryptography-ceremony/build.gradle.kts
+++ b/cryptography/hedera-cryptography-ceremony/build.gradle.kts
@@ -53,3 +53,8 @@ val nativeBinPath =
 dependencies { nativeBin(project(":hedera-cryptography-wraps")) }
 
 tasks.processResources { from(nativeBinPath) { include("com/hedera/nativelib/ceremony/**") } }
+
+tasks.withType<Test>().configureEach {
+    minHeapSize = "512m"
+    maxHeapSize = "4096m"
+}

--- a/cryptography/hedera-cryptography-ceremony/src/main/java/com/hedera/cryptography/ceremony/Crypto.java
+++ b/cryptography/hedera-cryptography-ceremony/src/main/java/com/hedera/cryptography/ceremony/Crypto.java
@@ -18,6 +18,7 @@ import java.nio.file.Path;
 import java.security.InvalidKeyException;
 import java.security.KeyPair;
 import java.security.KeyStoreException;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.SecureRandom;
@@ -85,6 +86,26 @@ class Crypto {
         return tssCert;
     }
 
+    private byte[] signFile(Path path) throws IOException {
+        try {
+            // Signature will throw OOM on a 2GB+ file, so we hash it first and then sign the hash:
+            final MessageDigest md = MessageDigest.getInstance("SHA-384");
+            try (final FileBytesIterator fileBytesIterator = new FileBytesIterator(path)) {
+                while (fileBytesIterator.hasNext()) {
+                    md.update(fileBytesIterator.next());
+                }
+            }
+
+            final Signature signature = Signature.getInstance(SigningSchema.ED25519.getSigningAlgorithm());
+            signature.initSign(keyPair.getPrivate());
+            signature.update(md.digest());
+
+            return signature.sign();
+        } catch (NoSuchAlgorithmException | InvalidKeyException | SignatureException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     /// Sign every file in the directory, write .sig files, and then write the signing.cert.pem file as well.
     void signDir(Path filesDir) throws IOException {
         final Map<String, byte[]> fileSignatures = new HashMap<>();
@@ -99,17 +120,8 @@ class Crypto {
 
                 final String fileName = path.getFileName().toString();
 
-                final Signature signature = Signature.getInstance(SigningSchema.ED25519.getSigningAlgorithm());
-                signature.initSign(keyPair.getPrivate());
-                try (final FileBytesIterator fileBytesIterator = new FileBytesIterator(path)) {
-                    while (fileBytesIterator.hasNext()) {
-                        signature.update(fileBytesIterator.next());
-                    }
-                }
-                fileSignatures.put(fileName, signature.sign());
+                fileSignatures.put(fileName, signFile(path));
             }
-        } catch (NoSuchAlgorithmException | InvalidKeyException | SignatureException e) {
-            throw new RuntimeException(e);
         }
 
         // Write each .sig file:

--- a/cryptography/hedera-cryptography-ceremony/src/main/java/com/hedera/cryptography/ceremony/Orchestrator.java
+++ b/cryptography/hedera-cryptography-ceremony/src/main/java/com/hedera/cryptography/ceremony/Orchestrator.java
@@ -173,6 +173,8 @@ public class Orchestrator {
         final S3DirectoryAccessor s3DirectoryAccessor = new S3DirectoryAccessor(s3Client, cycle);
         final Path parametersDir = s3DirectoryAccessor.downloadDir("parameters");
         PARAMETERS_PATHS.put(cycle, parametersDir);
+        System.err.println("Downloaded static parameters to "
+                + parametersDir.toAbsolutePath().toString());
 
         return parametersDir;
     }

--- a/cryptography/hedera-cryptography-ceremony/src/test/java/com/hedera/cryptography/ceremony/CryptoTest.java
+++ b/cryptography/hedera-cryptography-ceremony/src/test/java/com/hedera/cryptography/ceremony/CryptoTest.java
@@ -8,14 +8,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.cryptography.ceremony.crypto.SigningSchema;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.MessageDigest;
 import java.security.Signature;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.Random;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -97,14 +100,53 @@ public class CryptoTest {
         assertEquals(crypto.getKeyPair().getPublic(), cert.getPublicKey());
 
         // And then verify every signature
-        for (String name : KEY_CERT_FILES) {
-            assertTrue(Files.exists(KEYS_PATH.resolve(name + ".sig")));
+        verifySignature(KEYS_PATH, KEY_CERT_FILES, cert);
+    }
+
+    private void verifySignature(Path dir, List<String> files, X509Certificate cert) throws Exception {
+        for (String name : files) {
+            assertTrue(Files.exists(dir.resolve(name + ".sig")));
 
             Signature sig = Signature.getInstance(SigningSchema.ED25519.getSigningAlgorithm());
             sig.initVerify(cert);
-            sig.update(Files.readAllBytes(KEYS_PATH.resolve(name)));
 
-            assertTrue(sig.verify(Files.readAllBytes(KEYS_PATH.resolve(name + ".sig"))));
+            final MessageDigest md = MessageDigest.getInstance("SHA-384");
+            try (final FileBytesIterator fileBytesIterator = new FileBytesIterator(dir.resolve(name))) {
+                while (fileBytesIterator.hasNext()) {
+                    md.update(fileBytesIterator.next());
+                }
+            }
+            sig.update(md.digest());
+
+            assertTrue(sig.verify(Files.readAllBytes(dir.resolve(name + ".sig"))));
         }
+    }
+
+    @Test
+    void testSignHugeFile() throws Exception {
+        final Path path = Files.createTempDirectory("hugeFileDir");
+        System.err.println("Writing a huge file to disk. This can take a few seconds...");
+        try (FileOutputStream fos =
+                new FileOutputStream(path.resolve("testHugeFile.bin").toFile())) {
+            // Make a file of 4GB+1byte size
+            final long SIZE = (long) Integer.MAX_VALUE * 2L + 1;
+            final int CHUNKS = 64;
+            final int CHUNK_SIZE = (int) (SIZE / CHUNKS);
+            byte[] array = new byte[CHUNK_SIZE];
+            final Random random = new Random();
+            for (int i = 0; i < CHUNKS; i++) {
+                random.nextBytes(array);
+                fos.write(array);
+            }
+        }
+
+        System.err.println("Done writing the huge file to disk. On to signing and verifying...");
+        final Crypto crypto = new Crypto(NODE_ID, KEYS_PATH.toAbsolutePath().toString(), PASSWORD.toCharArray());
+
+        crypto.signDir(path);
+
+        final X509Certificate cert =
+                loadCertificate(path.resolve("certificate.pem").toAbsolutePath().toString());
+        verifySignature(path, List.of("testHugeFile.bin"), cert);
     }
 }


### PR DESCRIPTION
**Description**:
Fixing the signing of ceremony output so that we can sign huge files w/o throwing an OOM.

**Related issue(s)**:

Fixes #545 

**Notes for reviewer**:
A new unit test is added to try and sign a 4GB+1byte file.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
