### PR TITLE
fix: .ready files should be non-blank

### DIFF
--- a/cryptography/hedera-cryptography-ceremony/build.gradle.kts
+++ b/cryptography/hedera-cryptography-ceremony/build.gradle.kts
@@ -53,8 +53,3 @@ val nativeBinPath =
 dependencies { nativeBin(project(":hedera-cryptography-wraps")) }
 
 tasks.processResources { from(nativeBinPath) { include("com/hedera/nativelib/ceremony/**") } }
-
-tasks.withType<Test>().configureEach {
-    minHeapSize = "512m"
-    maxHeapSize = "4096m"
-}

--- a/cryptography/hedera-cryptography-ceremony/src/main/java/com/hedera/cryptography/ceremony/Phase.java
+++ b/cryptography/hedera-cryptography-ceremony/src/main/java/com/hedera/cryptography/ceremony/Phase.java
@@ -160,7 +160,7 @@ class Phase {
             s3DirectoryAccessor.uploadDir(outputDir, outputDirName);
 
             System.err.println("Writing ready marker " + readyFileNameAtIndex(thisIndex));
-            s3DirectoryAccessor.writeText(readyFileNameAtIndex(thisIndex), "");
+            s3DirectoryAccessor.writeText(readyFileNameAtIndex(thisIndex), "ready");
             System.err.println("Wrote: " + readyFileNameAtIndex(thisIndex));
 
             System.err.println("Phase " + phase + " is complete.");

--- a/cryptography/hedera-cryptography-ceremony/src/test/java/com/hedera/cryptography/ceremony/PhaseTest.java
+++ b/cryptography/hedera-cryptography-ceremony/src/test/java/com/hedera/cryptography/ceremony/PhaseTest.java
@@ -57,7 +57,7 @@ public class PhaseTest {
 
         verify(s3DirectoryAccessor, times(1)).uploadDir(outputPathCaptor.getValue(), "1.bin");
 
-        verify(s3DirectoryAccessor, times(1)).writeText("1.ready", "");
+        verify(s3DirectoryAccessor, times(1)).writeText("1.ready", "ready");
 
         verifyNoMoreInteractions(s3DirectoryAccessor, dataCruncher, crypto);
     }
@@ -87,7 +87,7 @@ public class PhaseTest {
 
         verify(s3DirectoryAccessor, times(1)).uploadDir(outputPathCaptor.getValue(), "2.bin");
 
-        verify(s3DirectoryAccessor, times(1)).writeText("2.ready", "");
+        verify(s3DirectoryAccessor, times(1)).writeText("2.ready", "ready");
 
         verifyNoMoreInteractions(s3DirectoryAccessor, dataCruncher, crypto);
     }
@@ -117,7 +117,7 @@ public class PhaseTest {
 
         verify(s3DirectoryAccessor, times(1)).uploadDir(outputPathCaptor.getValue(), "2.bin");
 
-        verify(s3DirectoryAccessor, times(1)).writeText("2.ready", "");
+        verify(s3DirectoryAccessor, times(1)).writeText("2.ready", "ready");
 
         verifyNoMoreInteractions(s3DirectoryAccessor, dataCruncher, crypto);
     }


### PR DESCRIPTION
**Description**:
Pleasing the S3Client by making .ready files non-blank.

**Related issue(s)**:

Fixes #547 

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
