### PR TITLE
fix: catch all exceptions in Orchestrator

### DIFF
--- a/cryptography/hedera-cryptography-ceremony/src/main/java/com/hedera/cryptography/ceremony/Orchestrator.java
+++ b/cryptography/hedera-cryptography-ceremony/src/main/java/com/hedera/cryptography/ceremony/Orchestrator.java
@@ -105,7 +105,8 @@ public class Orchestrator {
                                         crypto)
                                 .run();
                     }
-                } catch (S3ResponseException | IOException e) {
+                } catch (Exception e) {
+                    // We do want to catch any and all exceptions here by design. See a comment below for reasoning.
                     e.printStackTrace();
 
                     // An S3 call failed (or maybe a disk read/write failed.) On one hand we could die here.


### PR DESCRIPTION
**Description**:
I discovered an `UncheckedIOException` killing the Orchestrator. To prevent this and similar scenarios and make the Orchestrator resilient, I'm now catching any and all exceptions.

The Orchestrator will wait for 15 minutes after printing the stack trace. So even if the error is unrecoverable, we won't stress external systems (e.g. S3) with requests that just cannot succeed. However, in most cases, those exceptions are sporadic - e.g. a temporary network failure - and we want the Orchestrator to continue running, rather than require DevOps/humans to manually restart it each time this happens. Note that we print the stack trace to the log, so we can investigate the failures if needed.

**Related issue(s)**:

Fixes #553 

**Notes for reviewer**:
All should work.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
