### PR TITLE
perf: cache hinTS AggregationKey and CRS

### DIFF
--- a/cryptography/hedera-cryptography-hints/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
+++ b/cryptography/hedera-cryptography-hints/src/main/java/com/hedera/cryptography/hints/HintsLibraryBridge.java
@@ -370,6 +370,12 @@ public class HintsLibraryBridge {
             long thresholdNumerator,
             long thresholdDenominator);
 
+    /**
+     * Reset cached CRS and AggregatedKey values in native code.
+     * The values will be reparsed and cached again once a method accepting these values is called.
+     */
+    public native void resetCache();
+
     // Returns true if the n is a positive power of two, and the crs isn't null and its length matches or is greater
     // than the n.
     private static boolean validateCRS(final byte[] crs, final int n) {

--- a/cryptography/hedera-cryptography-hints/src/main/rust/jni_cache.rs
+++ b/cryptography/hedera-cryptography-hints/src/main/rust/jni_cache.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::any::Any;
+use std::sync::{Arc, RwLock};
+use jni::JNIEnv;
+use jni::objects::JByteArray;
+
+/// A cache for a value deserializable from a JByteArray.
+pub struct JNICache<T> {
+    /// The cached value
+    /// RwLock provides a thread-safe mutable cell.
+    /// Option lets us start with the cache empty.
+    /// Arc allows us to share the value as a reference with callers of the get() function.
+    option_value_cell: RwLock<Option<Arc<T>>>,
+
+    /// A supplier for a value to initialize the cache.
+    supplier: fn(&JNIEnv, &JByteArray) -> Result<T, Box<dyn Any>>
+}
+
+impl<T> JNICache<T> {
+    /// Create a new cache instance with no value installed.
+    pub const fn new(s: fn(&JNIEnv, &JByteArray) -> Result<T, Box<dyn Any>>) -> JNICache<T> {
+        JNICache {
+            option_value_cell: RwLock::new(None),
+            supplier: s
+        }
+    }
+
+    /// Get the cached value, and initialize it if necessary.
+    pub fn get(&self, env: &JNIEnv, jarray: &JByteArray) -> Result<Arc<T>, Box<dyn Any>> {
+        // Take locks for the shortest times possible.
+        // read()./write().unwrap() is safe. If it fails, we're in a much bigger trouble.
+        // Option./result.unwrap() is safe because it's guarded with proper if/else.
+        let is_none = { self.option_value_cell.read().unwrap().is_none() };
+        if is_none {
+            let result = (self.supplier)(env, jarray);
+            if result.is_err() {
+                return Err(result.err().unwrap());
+            }
+
+            *self.option_value_cell.write().unwrap() = Some(Arc::new(result.unwrap()));
+        }
+
+        Ok(self.option_value_cell.read().unwrap().as_ref().unwrap().clone())
+    }
+
+    /// Clear the cached value.
+    pub fn reset(&self) {
+        // write().unwrap() is safe. If it fails, we're in a much bigger trouble.
+        *self.option_value_cell.write().unwrap() = None;
+    }
+}

--- a/cryptography/hedera-cryptography-hints/src/main/rust/jni_hints.rs
+++ b/cryptography/hedera-cryptography-hints/src/main/rust/jni_hints.rs
@@ -5,7 +5,13 @@ use jni::JNIEnv;
 use jni::objects::{JByteArray, JIntArray, JLongArray, JObject, JObjectArray, JValue};
 use jni::sys::{jboolean, jbyteArray, jint, jlong, jobject, jsize};
 use crate::hints::{AggregationKey, ExtendedPublicKey, HinTS, PartialSignature, SecretKey, ThresholdSignature, VerificationKey, Weight, CRS, F};
+use crate::jni_cache::JNICache;
 use crate::jni_util;
+
+// Caches for some "static" values to save time on parsing them from bytes.
+// Java applications can reset the caches by calling HintsLibraryBridge.resetCache().
+static CRS_CACHE: JNICache<CRS> = JNICache::new(jni_util::deserialize_jbyte_array);
+static AGGREGATION_KEY_CACHE: JNICache<AggregationKey> = JNICache::new(jni_util::deserialize_jbyte_array);
 
 /// JNI for HintsLibraryBridge.generateSecretKey
 #[no_mangle]
@@ -36,8 +42,8 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_com
     party_id: jint,
     n: jint,
 ) -> jbyteArray {
-    let crs: CRS = match jni_util::deserialize_jbyte_array(&env, &crs_jarray) {
-        Ok(val) => val,
+    let crs: &CRS = match CRS_CACHE.get(&env, &crs_jarray) {
+        Ok(val) => &(val.clone()),
         Err(_) => return std::ptr::null_mut()
     };
 
@@ -66,8 +72,8 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_val
     party_id: jint,
     n: jint,
 ) -> jboolean {
-    let crs: CRS = match jni_util::deserialize_jbyte_array(&env, &crs_jarray) {
-        Ok(val) => val,
+    let crs: &CRS = match CRS_CACHE.get(&env, &crs_jarray) {
+        Ok(val) => &(val.clone()),
         Err(_) => return jboolean::from(false)
     };
 
@@ -93,8 +99,8 @@ pub unsafe extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBri
     weights_jarray: JLongArray,
     n: jint,
 ) -> jobject {
-    let crs: CRS = match jni_util::deserialize_jbyte_array(&env, &crs_jarray) {
-        Ok(val) => val,
+    let crs: &CRS = match CRS_CACHE.get(&env, &crs_jarray) {
+        Ok(val) => &(val.clone()),
         Err(_) => return std::ptr::null_mut()
     };
 
@@ -207,8 +213,8 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_ver
         Err(_) => return jboolean::from(false)
     };
 
-    let aggregation_key: AggregationKey = match jni_util::deserialize_jbyte_array(&env, &aggregation_key_jarray) {
-        Ok(val) => val,
+    let aggregation_key: &AggregationKey = match AGGREGATION_KEY_CACHE.get(&env, &aggregation_key_jarray) {
+        Ok(val) => &(val.clone()),
         Err(_) => return jboolean::from(false)
     };
 
@@ -238,8 +244,8 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_ver
         Err(_) => return jboolean::from(false)
     };
 
-    let aggregation_key: AggregationKey = match jni_util::deserialize_jbyte_array(&env, &aggregation_key_jarray) {
-        Ok(val) => val,
+    let aggregation_key: &AggregationKey = match AGGREGATION_KEY_CACHE.get(&env, &aggregation_key_jarray) {
+        Ok(val) => &(val.clone()),
         Err(_) => return jboolean::from(false)
     };
 
@@ -286,13 +292,13 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_agg
     parties_jarray: JIntArray,
     partial_signatures_jarray: JObjectArray,
 ) -> jbyteArray {
-    let crs: CRS = match jni_util::deserialize_jbyte_array(&env, &crs_jarray) {
-        Ok(val) => val,
+    let crs: &CRS = match CRS_CACHE.get(&env, &crs_jarray) {
+        Ok(val) => &(val.clone()),
         Err(_) => return std::ptr::null_mut()
     };
 
-    let aggregation_key: AggregationKey = match jni_util::deserialize_jbyte_array(&env, &aggregation_key_jarray) {
-        Ok(val) => val,
+    let aggregation_key: &AggregationKey = match AGGREGATION_KEY_CACHE.get(&env, &aggregation_key_jarray) {
+        Ok(val) => &(val.clone()),
         Err(_) => return std::ptr::null_mut()
     };
 
@@ -375,4 +381,13 @@ pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_ver
         Ok(val) => val,
         Err(_) => return jboolean::from(false)
     })
+}
+
+/// JNI for HintsLibraryBridge.resetCache
+#[no_mangle]
+pub extern "system" fn Java_com_hedera_cryptography_hints_HintsLibraryBridge_resetCache(
+    _env: JNIEnv,
+) {
+    CRS_CACHE.reset();
+    AGGREGATION_KEY_CACHE.reset();
 }

--- a/cryptography/hedera-cryptography-hints/src/main/rust/lib.rs
+++ b/cryptography/hedera-cryptography-hints/src/main/rust/lib.rs
@@ -9,3 +9,4 @@ pub mod errors;
 mod kzg;
 mod utils;
 mod jni_util;
+mod jni_cache;

--- a/cryptography/hedera-cryptography-hints/src/test/java/com/hedera/cryptography/hints/HintsLibraryBridgeTest.java
+++ b/cryptography/hedera-cryptography-hints/src/test/java/com/hedera/cryptography/hints/HintsLibraryBridgeTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -22,6 +23,11 @@ public class HintsLibraryBridgeTest {
                 expected,
                 actual,
                 () -> "Expected:\n" + Arrays.toString(expected) + "\nbut got:\n" + Arrays.toString(actual) + "\n");
+    }
+
+    @BeforeEach
+    void setup() {
+        INSTANCE.resetCache();
     }
 
     @Test
@@ -70,19 +76,23 @@ public class HintsLibraryBridgeTest {
         assertNull(INSTANCE.computeHints(crs, secretKey, Integer.MAX_VALUE, 4));
 
         // nulls
+        INSTANCE.resetCache();
         assertNull(INSTANCE.computeHints(null, secretKey, 2, 4));
+        INSTANCE.resetCache();
         assertNull(INSTANCE.computeHints(crs, null, 2, 4));
 
         // corrupt the CRS
         crs[27]++;
         crs[172]--;
         crs[387]++;
+        INSTANCE.resetCache();
         assertNull(INSTANCE.computeHints(crs, secretKey, 2, 4));
 
         // uncorrupt the CRS...
         crs[27]--;
         crs[172]++;
         crs[387]--;
+        INSTANCE.resetCache();
         // and corrupt the key instead
         secretKey[7]++;
         // surprisingly, a corrupted key works just fine, although of course the result should be incorrect
@@ -129,19 +139,23 @@ public class HintsLibraryBridgeTest {
         assertFalse(INSTANCE.validateHintsKey(crs, hints, Integer.MAX_VALUE, 4));
 
         // nulls
+        INSTANCE.resetCache();
         assertFalse(INSTANCE.validateHintsKey(null, hints, 2, 4));
+        INSTANCE.resetCache();
         assertFalse(INSTANCE.validateHintsKey(crs, null, 2, 4));
 
         // corrupt the CRS
         crs[27]++;
         crs[172]--;
         crs[387]++;
+        INSTANCE.resetCache();
         assertFalse(INSTANCE.validateHintsKey(crs, hints, 2, 4));
 
         // uncorrupt the CRS...
         crs[27]--;
         crs[172]++;
         crs[387]--;
+        INSTANCE.resetCache();
         // and corrupt the hints instead
         hints[17]++;
         hints[111]--;
@@ -197,8 +211,10 @@ public class HintsLibraryBridgeTest {
                 crs, new int[] {0, 1, 2}, new byte[][] {hints0, hints1, hints2}, new long[] {111, 1, 222}, 8));
 
         // nulls
+        INSTANCE.resetCache();
         assertNull(INSTANCE.preprocess(
                 null, new int[] {0, 1, 2}, new byte[][] {hints0, hints1, hints2}, new long[] {111, 1, 222}, 4));
+        INSTANCE.resetCache();
         assertNull(INSTANCE.preprocess(crs, null, new byte[][] {hints0, hints1, hints2}, new long[] {111, 1, 222}, 4));
         assertNull(INSTANCE.preprocess(crs, new int[] {0, 1, 2}, null, new long[] {111, 1, 222}, 4));
         assertNull(INSTANCE.preprocess(crs, new int[] {0, 1, 2}, new byte[][] {hints0, hints1, hints2}, null, 4));
@@ -227,6 +243,7 @@ public class HintsLibraryBridgeTest {
         crs[27]++;
         crs[172]--;
         crs[387]++;
+        INSTANCE.resetCache();
         assertNull(INSTANCE.preprocess(
                 crs, new int[] {0, 1, 2}, new byte[][] {hints0, hints1, hints2}, new long[] {111, 1, 222}, 4));
 
@@ -234,6 +251,7 @@ public class HintsLibraryBridgeTest {
         crs[27]--;
         crs[172]++;
         crs[387]--;
+        INSTANCE.resetCache();
         // and corrupt the hints instead
         hints1[17]++;
         hints1[111]--;
@@ -318,8 +336,11 @@ public class HintsLibraryBridgeTest {
         assertFalse(INSTANCE.verifyBls(EMPTY, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
         assertFalse(INSTANCE.verifyBls(signature, null, keys.aggregationKey(), partyId));
         assertFalse(INSTANCE.verifyBls(signature, EMPTY, keys.aggregationKey(), partyId));
+        INSTANCE.resetCache();
         assertFalse(INSTANCE.verifyBls(signature, HintsConstants.RANDOM_2, null, partyId));
+        INSTANCE.resetCache();
         assertFalse(INSTANCE.verifyBls(signature, HintsConstants.RANDOM_2, EMPTY, partyId));
+        INSTANCE.resetCache();
         assertFalse(INSTANCE.verifyBls(signature, HintsConstants.RANDOM_2, keys.aggregationKey(), -1));
         assertFalse(INSTANCE.verifyBls(signature, HintsConstants.RANDOM_2, keys.aggregationKey(), 666));
 
@@ -333,12 +354,14 @@ public class HintsLibraryBridgeTest {
         keys.aggregationKey()[17]++;
         keys.aggregationKey()[111]--;
         keys.aggregationKey()[302]++;
+        INSTANCE.resetCache();
         assertFalse(INSTANCE.verifyBls(signature, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
 
         // uncorrupt the aggregationKey and do a sanity check
         keys.aggregationKey()[17]--;
         keys.aggregationKey()[111]++;
         keys.aggregationKey()[302]--;
+        INSTANCE.resetCache();
         assertTrue(INSTANCE.verifyBls(signature, HintsConstants.RANDOM_2, keys.aggregationKey(), partyId));
     }
 
@@ -389,10 +412,13 @@ public class HintsLibraryBridgeTest {
                 null, keys.aggregationKey(), new int[] {0, 2}, new byte[][] {signature2, signature0}));
         assertFalse(INSTANCE.verifyBlsBatch(
                 EMPTY, keys.aggregationKey(), new int[] {0, 2}, new byte[][] {signature2, signature0}));
+        INSTANCE.resetCache();
         assertFalse(INSTANCE.verifyBlsBatch(
                 HintsConstants.RANDOM_2, null, new int[] {0, 2}, new byte[][] {signature2, signature0}));
+        INSTANCE.resetCache();
         assertFalse(INSTANCE.verifyBlsBatch(
                 HintsConstants.RANDOM_2, EMPTY, new int[] {0, 2}, new byte[][] {signature2, signature0}));
+        INSTANCE.resetCache();
         assertFalse(INSTANCE.verifyBlsBatch(
                 HintsConstants.RANDOM_2, keys.aggregationKey(), null, new byte[][] {signature2, signature0}));
         assertFalse(INSTANCE.verifyBlsBatch(
@@ -405,12 +431,14 @@ public class HintsLibraryBridgeTest {
 
         // Corrupt the aggregationKey
         keys.aggregationKey()[11]++;
+        INSTANCE.resetCache();
         assertFalse(INSTANCE.verifyBlsBatch(
                 HintsConstants.RANDOM_2, keys.aggregationKey(), new int[] {0, 2}, new byte[][] {signature2, signature0
                 }));
 
         // uncorrupt the aggregationKey...
         keys.aggregationKey()[11]--;
+        INSTANCE.resetCache();
         // corrupt a signature instead
         signature2[17]++;
         assertFalse(INSTANCE.verifyBlsBatch(
@@ -471,18 +499,23 @@ public class HintsLibraryBridgeTest {
         final AggregationAndVerificationKeys keys =
                 INSTANCE.preprocess(crs, new int[] {0, 2}, new byte[][] {hints0, hints2}, new long[] {111, 222}, 4);
 
+        INSTANCE.resetCache();
         assertNull(INSTANCE.aggregateSignatures(
                 null, keys.aggregationKey(), keys.verificationKey(), new int[] {0, 2}, new byte[][] {
                     signature2, signature0
                 }));
+        INSTANCE.resetCache();
         assertNull(INSTANCE.aggregateSignatures(
                 EMPTY, keys.aggregationKey(), keys.verificationKey(), new int[] {0, 2}, new byte[][] {
                     signature2, signature0
                 }));
+        INSTANCE.resetCache();
         assertNull(INSTANCE.aggregateSignatures(
                 crs, null, keys.verificationKey(), new int[] {0, 2}, new byte[][] {signature2, signature0}));
+        INSTANCE.resetCache();
         assertNull(INSTANCE.aggregateSignatures(
                 crs, EMPTY, keys.verificationKey(), new int[] {0, 2}, new byte[][] {signature2, signature0}));
+        INSTANCE.resetCache();
         assertNull(INSTANCE.aggregateSignatures(
                 crs, keys.aggregationKey(), null, new int[] {0, 2}, new byte[][] {signature2, signature0}));
         assertNull(INSTANCE.aggregateSignatures(
@@ -502,6 +535,7 @@ public class HintsLibraryBridgeTest {
         crs[27]++;
         crs[172]--;
         crs[387]++;
+        INSTANCE.resetCache();
         assertNull(INSTANCE.aggregateSignatures(
                 crs, keys.aggregationKey(), keys.verificationKey(), new int[] {0, 2}, new byte[][] {
                     signature2, signature0
@@ -510,6 +544,7 @@ public class HintsLibraryBridgeTest {
         crs[27]--;
         crs[172]++;
         crs[387]--;
+        INSTANCE.resetCache();
         // and corrupt the aggregationKey
         keys.aggregationKey()[11]++;
         assertNull(INSTANCE.aggregateSignatures(
@@ -519,6 +554,7 @@ public class HintsLibraryBridgeTest {
 
         // uncorrupt the aggregationKey...
         keys.aggregationKey()[11]--;
+        INSTANCE.resetCache();
         // the method survives a corrupt verificationKey, so...
         // corrupt a signature instead
         signature2[17]++;

--- a/cryptography/hedera-cryptography-wraps/src/jmh/java/com/hedera/cryptogaphy/wraps/SignatureBench.java
+++ b/cryptography/hedera-cryptography-wraps/src/jmh/java/com/hedera/cryptogaphy/wraps/SignatureBench.java
@@ -103,6 +103,9 @@ public class SignatureBench {
 
         @Setup(Level.Trial)
         public void setup() {
+            // New CRS, new AggregationKey:
+            HINTS.resetCache();
+
             crs = HINTS.initCRS(crsSize);
             numOfSigners = fullNumOfSigners ? (crsSize / 2 + 1) : 3;
 


### PR DESCRIPTION
**Description**:
Caching hinTS `AggregationKey` and `CRS` in native code, and adding an API (mostly for tests) to reset the cache.

See https://github.com/hashgraph/hedera-cryptography/pull/550 for baseline results.
Updated benchmark results:
1. verifyBls() is now O(1)
2. aggregateSignature() is still O(numOfSigners)+O(crsSize), but the coefficients seem to have dropped, so it's much faster than before.
```
Benchmark                               (crsSize)  (fullNumOfSigners)  Mode  Cnt   Score   Error  Units
SignatureBench.benchAggregateSignature          4               false  avgt    2   3.058          ms/op
SignatureBench.benchAggregateSignature          4                true  avgt    2   3.030          ms/op
SignatureBench.benchAggregateSignature          8               false  avgt    2   7.584          ms/op
SignatureBench.benchAggregateSignature          8                true  avgt    2   8.006          ms/op
SignatureBench.benchAggregateSignature         16               false  avgt    2  11.151          ms/op
SignatureBench.benchAggregateSignature         16                true  avgt    2  11.880          ms/op
SignatureBench.benchAggregateSignature         32               false  avgt    2  17.880          ms/op
SignatureBench.benchAggregateSignature         32                true  avgt    2  19.554          ms/op
SignatureBench.benchAggregateSignature         64               false  avgt    2  28.978          ms/op
SignatureBench.benchAggregateSignature         64                true  avgt    2  32.294          ms/op
SignatureBench.benchAggregateSignature        128               false  avgt    2  44.387          ms/op
SignatureBench.benchAggregateSignature        128                true  avgt    2  51.013          ms/op
SignatureBench.benchAggregateSignature        256               false  avgt    2  78.608          ms/op
SignatureBench.benchAggregateSignature        256                true  avgt    2  91.698          ms/op
SignatureBench.benchVerifyBls                   4               false  avgt    2   2.406          ms/op
SignatureBench.benchVerifyBls                   4                true  avgt    2   2.408          ms/op
SignatureBench.benchVerifyBls                   8               false  avgt    2   2.454          ms/op
SignatureBench.benchVerifyBls                   8                true  avgt    2   2.413          ms/op
SignatureBench.benchVerifyBls                  16               false  avgt    2   2.408          ms/op
SignatureBench.benchVerifyBls                  16                true  avgt    2   2.413          ms/op
SignatureBench.benchVerifyBls                  32               false  avgt    2   2.403          ms/op
SignatureBench.benchVerifyBls                  32                true  avgt    2   2.410          ms/op
SignatureBench.benchVerifyBls                  64               false  avgt    2   2.409          ms/op
SignatureBench.benchVerifyBls                  64                true  avgt    2   2.410          ms/op
SignatureBench.benchVerifyBls                 128               false  avgt    2   2.411          ms/op
SignatureBench.benchVerifyBls                 128                true  avgt    2   2.408          ms/op
SignatureBench.benchVerifyBls                 256               false  avgt    2   2.446          ms/op
SignatureBench.benchVerifyBls                 256                true  avgt    2   2.410          ms/op
```


**Related issue(s)**:

Fixes #552 

**Notes for reviewer**:
Tests have been updated to reset the cache where needed.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
