### PR TITLE
fix: pruning dependencies with multiple versions

### DIFF
--- a/cryptography/hedera-cryptography-wraps/Cargo.lock
+++ b/cryptography/hedera-cryptography-wraps/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-r1cs-std",
- "ark-std 0.5.0 (git+https://github.com/arkworks-rs/std)",
+ "ark-std",
 ]
 
 [[package]]
@@ -94,7 +94,7 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-snark",
- "ark-std 0.5.0 (git+https://github.com/arkworks-rs/std)",
+ "ark-std",
  "blake2",
  "derivative",
  "digest",
@@ -125,7 +125,7 @@ dependencies = [
  "ark-ff",
  "ark-poly",
  "ark-serialize",
- "ark-std 0.5.0 (git+https://github.com/arkworks-rs/std)",
+ "ark-std",
  "educe",
  "fnv",
  "hashbrown 0.16.1",
@@ -145,7 +145,7 @@ dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-r1cs-std",
- "ark-std 0.5.0 (git+https://github.com/arkworks-rs/std)",
+ "ark-std",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ dependencies = [
  "ark-ff-asm",
  "ark-ff-macros",
  "ark-serialize",
- "ark-std 0.5.0 (git+https://github.com/arkworks-rs/std)",
+ "ark-std",
  "digest",
  "educe",
  "num-bigint",
@@ -196,7 +196,7 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-snark",
- "ark-std 0.5.0 (git+https://github.com/arkworks-rs/std)",
+ "ark-std",
 ]
 
 [[package]]
@@ -208,7 +208,7 @@ dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-r1cs-std",
- "ark-std 0.5.0 (git+https://github.com/arkworks-rs/std)",
+ "ark-std",
 ]
 
 [[package]]
@@ -219,7 +219,7 @@ dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-r1cs-std",
- "ark-std 0.5.0 (git+https://github.com/arkworks-rs/std)",
+ "ark-std",
 ]
 
 [[package]]
@@ -231,7 +231,7 @@ dependencies = [
  "ark-ff",
  "ark-mnt4-298",
  "ark-r1cs-std",
- "ark-std 0.5.0 (git+https://github.com/arkworks-rs/std)",
+ "ark-std",
 ]
 
 [[package]]
@@ -242,7 +242,7 @@ dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-r1cs-std",
- "ark-std 0.5.0 (git+https://github.com/arkworks-rs/std)",
+ "ark-std",
 ]
 
 [[package]]
@@ -253,7 +253,7 @@ dependencies = [
  "ahash",
  "ark-ff",
  "ark-serialize",
- "ark-std 0.5.0 (git+https://github.com/arkworks-rs/std)",
+ "ark-std",
  "educe",
  "fnv",
  "hashbrown 0.16.1",
@@ -270,7 +270,7 @@ dependencies = [
  "ark-ff",
  "ark-poly",
  "ark-serialize",
- "ark-std 0.5.0 (git+https://github.com/arkworks-rs/std)",
+ "ark-std",
  "blake2",
  "derivative",
  "digest",
@@ -287,7 +287,7 @@ dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-relations",
- "ark-std 0.5.0 (git+https://github.com/arkworks-rs/std?rev=73dcad0)",
+ "ark-std",
  "educe",
  "itertools",
  "num-bigint",
@@ -304,7 +304,7 @@ dependencies = [
  "ark-ff",
  "ark-poly",
  "ark-serialize",
- "ark-std 0.5.0 (git+https://github.com/arkworks-rs/std)",
+ "ark-std",
  "foldhash",
  "indexmap",
  "tracing",
@@ -316,7 +316,7 @@ version = "0.5.0"
 source = "git+https://github.com/arkworks-rs/algebra#08aa6de11f481f241ab7d6015be6db89eb03e2f1"
 dependencies = [
  "ark-serialize-derive",
- "ark-std 0.5.0 (git+https://github.com/arkworks-rs/std)",
+ "ark-std",
  "digest",
  "num-bigint",
 ]
@@ -339,22 +339,13 @@ dependencies = [
  "ark-ff",
  "ark-relations",
  "ark-serialize",
- "ark-std 0.5.0 (git+https://github.com/arkworks-rs/std)",
+ "ark-std",
 ]
 
 [[package]]
 name = "ark-std"
 version = "0.5.0"
 source = "git+https://github.com/arkworks-rs/std?rev=73dcad0#73dcad089f915f4b8126f67e91f78029ba76876e"
-dependencies = [
- "num-traits",
- "rand",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.5.0"
-source = "git+https://github.com/arkworks-rs/std#1693bc56d2ca6657b623f33a3f0b009d0ffeb892"
 dependencies = [
  "num-traits",
  "rand",
@@ -369,7 +360,7 @@ dependencies = [
  "ark-ff",
  "ark-pallas",
  "ark-r1cs-std",
- "ark-std 0.5.0 (git+https://github.com/arkworks-rs/std)",
+ "ark-std",
 ]
 
 [[package]]
@@ -425,7 +416,7 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-snark",
- "ark-std 0.5.0 (git+https://github.com/arkworks-rs/std)",
+ "ark-std",
  "blake2",
  "clap",
  "digest",
@@ -645,7 +636,7 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-snark",
- "ark-std 0.5.0 (git+https://github.com/arkworks-rs/std)",
+ "ark-std",
  "ark-vesta",
  "num-bigint",
  "num-integer",
@@ -1207,7 +1198,7 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-snark",
- "ark-std 0.5.0 (git+https://github.com/arkworks-rs/std)",
+ "ark-std",
  "blake2",
  "digest",
  "folding-schemes",

--- a/cryptography/hedera-cryptography-wraps/Cargo.toml
+++ b/cryptography/hedera-cryptography-wraps/Cargo.toml
@@ -20,7 +20,7 @@ ark-relations = { git = "https://github.com/arkworks-rs/snark" }
 ark-snark = { git = "https://github.com/arkworks-rs/snark" }
 ark-crypto-primitives = { git = "https://github.com/winderica/crypto-primitives", rev = "af003fc" }
 ark-r1cs-std = { git = "https://github.com/winderica/r1cs-std", rev = "ae8283a" }         # "sw-fix-updated" branch
-ark-std = { git = "https://github.com/arkworks-rs/std" }
+ark-std = { git = "https://github.com/arkworks-rs/std", rev = "73dcad0", default-features = false }
 ark-poly-commit = { git = "https://github.com/arkworks-rs/poly-commit" }
 
 

--- a/cryptography/hedera-cryptography-wraps/src/main/rust/groth16/Cargo.toml
+++ b/cryptography/hedera-cryptography-wraps/src/main/rust/groth16/Cargo.toml
@@ -23,18 +23,18 @@ ark-ff = { version = "0.5.0", default-features = false }
 ark-ec = { version = "0.5.0", default-features = false }
 ark-serialize = { version = "0.5.0", default-features = false, features = [ "derive" ] }
 ark-poly = { version = "0.5.0", default-features = false }
-ark-std = { version = "0.5.0", default-features = false }
+ark-std = { git = "https://github.com/arkworks-rs/std", rev = "73dcad0", default-features = false }
 ark-relations = { version = "0.5.0", default-features = false }
 ark-snark = { version = "0.5.0", default-features = false }
-ark-r1cs-std = { version = "0.5.0", default-features = false, optional = true }
-ark-crypto-primitives = { version = "0.5.0", default-features = false, features = [ "snark", "sponge" ] }
+ark-r1cs-std = { git = "https://github.com/winderica/r1cs-std", rev = "ae8283a", default-features = false, optional = true }
+ark-crypto-primitives = { git = "https://github.com/winderica/crypto-primitives", rev = "af003fc", default-features = false, features = [ "snark", "sponge" ] }
 
 tracing = { version = "0.1", default-features = false, features = ["attributes" ], optional = true }
 educe = { version = "0.6.0", default-features = false, features = [ "Clone" ], optional = true }
 rayon = { version = "1", optional = true }
 
 [dev-dependencies]
-ark-r1cs-std = { version = "0.5.0", default-features = true }
+ark-r1cs-std = { git = "https://github.com/winderica/r1cs-std", rev = "ae8283a", default-features = false }
 
 
 [features]

--- a/cryptography/hedera-cryptography-wraps/src/main/rust/groth16/Cargo.toml
+++ b/cryptography/hedera-cryptography-wraps/src/main/rust/groth16/Cargo.toml
@@ -19,25 +19,18 @@ edition = "2021"
 ################################# Dependencies ################################
 
 [dependencies]
-ark-ff = { git = "https://github.com/arkworks-rs/algebra.git", default-features = false }
-ark-ec = { git = "https://github.com/arkworks-rs/algebra.git", default-features = false }
-
-# IntelliJ IDEA grays out the ark-serialize dependency, but the code needs it still:
-ark-serialize = { git = "https://github.com/arkworks-rs/algebra.git", default-features = false, features = [ "derive" ] }
-
-ark-poly = { git = "https://github.com/arkworks-rs/algebra.git", default-features = false }
+ark-ff = { version = "0.5.0", default-features = false }
+ark-ec = { version = "0.5.0", default-features = false }
+ark-serialize = { version = "0.5.0", default-features = false, features = [ "derive" ] }
+ark-poly = { version = "0.5.0", default-features = false }
 ark-std = { version = "0.5.0", default-features = false }
-
-ark-relations = { git = "https://github.com/arkworks-rs/snark.git", default-features = false }
-
-# IntelliJ IDEA grays out the ark-snark dependency, but the code needs it still:
-ark-snark = { git = "https://github.com/arkworks-rs/snark.git", default-features = false }
-
+ark-relations = { version = "0.5.0", default-features = false }
+ark-snark = { version = "0.5.0", default-features = false }
 ark-r1cs-std = { version = "0.5.0", default-features = false, optional = true }
 ark-crypto-primitives = { version = "0.5.0", default-features = false, features = [ "snark", "sponge" ] }
+
 tracing = { version = "0.1", default-features = false, features = ["attributes" ], optional = true }
 educe = { version = "0.6.0", default-features = false, features = [ "Clone" ], optional = true }
-
 rayon = { version = "1", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
**Description**:
This PR fixes the issue where `ark-std` was being used twice, with different commit hashes.
