### PR TITLE
chore(deps): Update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 version: 2
 updates:
   - package-ecosystem: gradle

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,12 @@ updates:
     directory: "/hiero-dependency-versions"
     schedule:
       interval: weekly
+    assignees:
+      - "swirlds-automation"
+    labels:
+      - "dependencies"
+    cooldown:
+      default-days: 5
     open-pull-requests-limit: 10
     groups:
       all-dependencies:
@@ -14,6 +20,12 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    assignees:
+      - "swirlds-automation"
+    labels:
+      - "dependencies"
+    cooldown:
+      default-days: 5
     open-pull-requests-limit: 10
     groups:
       all-dependencies:
@@ -24,6 +36,12 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    assignees:
+      - "swirlds-automation"
+    labels:
+      - "dependencies"
+    cooldown:
+      default-days: 5
     open-pull-requests-limit: 10
     groups:
       all-actions:


### PR DESCRIPTION
## Description

This pull request updates the `.github/dependabot.yml` configuration to improve the automation and management of dependency updates. The main changes add assignees, labels, and cooldown periods to Dependabot update groups, ensuring better tracking and control over automated pull requests.

**Dependabot automation and workflow improvements:**

* Added the `swirlds-automation` user as an assignee for Dependabot PRs in the `/hiero-dependency-versions`, `/`, and `/` (actions) directories to ensure responsibility is clearly assigned. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R7-R12) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R23-R28) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R39-R44)
* Added the `dependencies` label to all Dependabot PRs in these directories for easier filtering and tracking of dependency updates. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R7-R12) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R23-R28) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R39-R44)
* Introduced a cooldown period of 5 days between PRs for each group to prevent overwhelming the repository with too many updates at once. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R7-R12) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R23-R28) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R39-R44)

## Related Issue(s)

Closes #610