### PR TITLE
build: activate Gradle project isolation for faster build startup

### DIFF
--- a/.github/workflows/zxf-snyk-monitor.yaml
+++ b/.github/workflows/zxf-snyk-monitor.yaml
@@ -55,7 +55,7 @@ jobs:
       # (empty) build.gradle.kts in the root folder.
       - name: Disable Gradle Configuration Cache
         run: |
-          sed -i 's/^org.gradle.configuration-cache=.*$/org.gradle.configuration-cache=false/' gradle.properties
+          sed -i 's/^org.gradle.unsafe.isolated-projects=.*$/org.gradle.unsafe.isolated-projects=false/' gradle.properties
           touch build.gradle.kts
 
       # This step is what actually uploads the Snyk analysis to the Snyk Cloud. The Snyk token is stored as a secret

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs=-Xmx2048m
 
 # Enable Gradle Caching
 org.gradle.caching=true
-org.gradle.configuration-cache=true
+org.gradle.unsafe.isolated-projects=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pluginManagement { includeBuild("gradle/plugins") }
 
-plugins { id("org.hiero.gradle.build") version "0.7.7" }
+plugins { id("org.hiero.gradle.build") version "0.7.10" }
 
 rootProject.name = "hedera-cryptography"
 


### PR DESCRIPTION
**Description**:

See: https://github.com/hiero-ledger/hiero-gradle-conventions/issues/477

**Related issue(s)**:

Updates convention plugins for:

- https://github.com/hiero-ledger/hiero-gradle-conventions/issues/477
