### PR TITLE
feat: introduce libsodium native library build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,12 @@ jobs:
       - name: Build Cargo Darwin
         run: ./gradlew cargoBuildX86Darwin cargoBuildAarch64Darwin
 
+      - name: Build libsodium darwin-arm64
+        run: ./gradlew :libsodium:build
+
+      - name: Build libsodium darwin-amd64
+        run: HIERO_LIBSODIUM_TARGET=darwin-amd64 HIERO_LIBSODIUM_CONFIGURE_HOST=x86_64-apple-darwin ./gradlew :libsodium:assemble
+
   build_rust_linux_windows:
     name: Build Rust - Linux / Windows
     runs-on: hl-crypto-lin-md
@@ -112,6 +118,15 @@ jobs:
 
       - name: Build Cargo Linux / Windows
         run: ./gradlew cargoBuildX86Linux cargoBuildAarch64Linux cargoBuildX86Windows
+
+      - name: Build libsodium linux-amd64
+        run: ./gradlew :libsodium:build
+
+      - name: Build libsodium linux-arm64
+        run: HIERO_LIBSODIUM_TARGET=linux-arm64 HIERO_LIBSODIUM_CONFIGURE_HOST=aarch64-linux-gnu ./gradlew :libsodium:assemble
+
+      - name: Build libsodium windows-amd64
+        run: HIERO_LIBSODIUM_TARGET=windows-amd64 HIERO_LIBSODIUM_CONFIGURE_HOST=x86_64-w64-mingw32 ./gradlew :libsodium:assemble
 
   build:
     name: Build TSS Crypto Library

--- a/cryptography/hedera-cryptography-wraps/src/test/java/com/hedera/cryptography/wraps/WRAPSLibraryBridgeTest.java
+++ b/cryptography/hedera-cryptography-wraps/src/test/java/com/hedera/cryptography/wraps/WRAPSLibraryBridgeTest.java
@@ -816,7 +816,7 @@ public class WRAPSLibraryBridgeTest {
         assertNull(WRAPS.formatRotationMessage(keys, weights, nodeIds, new byte[0]));
     }
 
-    // @Test
+    @Test
     public void testConstructWrapsProof() {
         if (!WRAPSLibraryBridge.isProofSupported()) {
             // Gradle script will download artifacts and set TSS_LIB_WRAPS_ARTIFACTS_PATH to bypass this.

--- a/cryptography/hedera-cryptography-wraps/src/test/java/com/hedera/cryptography/wraps/WRAPSLibraryBridgeTest.java
+++ b/cryptography/hedera-cryptography-wraps/src/test/java/com/hedera/cryptography/wraps/WRAPSLibraryBridgeTest.java
@@ -816,7 +816,7 @@ public class WRAPSLibraryBridgeTest {
         assertNull(WRAPS.formatRotationMessage(keys, weights, nodeIds, new byte[0]));
     }
 
-    @Test
+    // @Test
     public void testConstructWrapsProof() {
         if (!WRAPSLibraryBridge.isProofSupported()) {
             // Gradle script will download artifacts and set TSS_LIB_WRAPS_ARTIFACTS_PATH to bypass this.

--- a/cryptography/libsodium/build.gradle.kts
+++ b/cryptography/libsodium/build.gradle.kts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+import java.util.regex.Pattern
+import org.gradle.api.internal.file.FileOperations
+import org.hiero.gradle.tasks.GitClone
+
+plugins { id("org.hiero.gradle.module.library") }
+
+val srcDir = layout.buildDirectory.dir("libsodium")
+val dstDir = layout.buildDirectory.dir("resources/main/com/hedera/nativelib/libsodium")
+
+tasks.register<GitClone>("cloneLibsodium") {
+    localCloneDirectory = srcDir
+    url = "https://github.com/jedisct1/libsodium.git"
+    // branch = "master"
+    tag = "1.0.22-RELEASE"
+}
+
+interface Injected {
+    @get:Inject val execOps: ExecOperations
+    @get:Inject val files: FileOperations
+}
+
+tasks.assemble {
+    val injected = objects.newInstance(Injected::class.java)
+    val execOps = injected.execOps
+    val files = injected.files
+
+    dependsOn("cloneLibsodium")
+
+    // HIERO_LIBSODIUM_TARGET=os-arch
+    // where os is linux, darwin, or windows, and arch is amd64 or arm64
+    // Example: HIERO_LIBSODIUM_TARGET=darwin-amd64
+    // By default, assume we build for the host target and infer the value of HIERO_LIBSODIUM_TARGET
+    // accordingly. If HIERO_LIBSODIUM_TARGET env var is defined explicitly, then the caller should
+    // probably also define HIERO_LIBSODIUM_CONFIGURE_HOST to let ./configure --host ... choose the
+    // correct toolchain. The caller may also define CFLAGS, CC, AR, and whatever else if needed.
+    // For example, to build for Windows target (e.g. on a Mac host) run:
+    // HIERO_LIBSODIUM_TARGET=windows-amd64 HIERO_LIBSODIUM_CONFIGURE_HOST=x86_64-w64-mingw32
+    // ./gradlew assemble
+    val target =
+        providers
+            .environmentVariable("HIERO_LIBSODIUM_TARGET")
+            .orElse(
+                providers.provider {
+                    val hostOperatingSystem =
+                        System.getProperty("os.name").lowercase().let {
+                            if (it.contains("windows")) {
+                                "windows"
+                            } else if (it.contains("mac")) {
+                                "darwin"
+                            } else {
+                                "linux"
+                            }
+                        }
+                    val hostArchitecture =
+                        System.getProperty("os.arch").let {
+                            if (it.contains("x86_64")) {
+                                "amd64"
+                            } else if (it.contains("aarch64")) {
+                                "arm64"
+                            } else {
+                                // There's "386" and "armv6l" at https://go.dev/dl/ .
+                                it
+                            }
+                        }
+
+                    "${hostOperatingSystem}-${hostArchitecture}"
+                }
+            )
+            .get()
+    val targetOsArch = target.split(Pattern.compile("-"), 2)
+
+    doFirst {
+        // Clean everything first. Useful for subsequent cross-platform builds in the same local
+        // repo, e.g. in CI.
+        if (file(srcDir.get().file("Makefile")).exists()) {
+            execOps.exec {
+                workingDir(srcDir)
+                commandLine("make", "clean")
+            }
+        }
+
+        execOps.exec {
+            val cmd = mutableListOf("sh", "./configure")
+            if (providers.environmentVariable("HIERO_LIBSODIUM_CONFIGURE_HOST").isPresent) {
+                // ./configure calls target a "host", so:
+                cmd.add("--host")
+                cmd.add(providers.environmentVariable("HIERO_LIBSODIUM_CONFIGURE_HOST").get())
+            }
+
+            workingDir(srcDir)
+            commandLine(cmd)
+        }
+
+        execOps.exec {
+            workingDir(srcDir)
+            commandLine("make")
+        }
+
+        // Copy the lib to the resources
+        val targetDir = dstDir.get().dir(targetOsArch[0]).dir(targetOsArch[1])
+        val buildDir = srcDir.get().dir("src/libsodium/.libs")
+        val libExt =
+            if (targetOsArch[0].contains("linux")) {
+                "so"
+            } else if (targetOsArch[0].contains("darwin")) {
+                "dylib"
+            } else { // Windows
+                "dll"
+            }
+        // libsodium native build adds a "-/.26" suffix to the lib name.
+        // It has something to do with ABI version or maybe something else.
+        val filename = "libsodium?26.${libExt}"
+        println("Copy $filename from $buildDir/ to $targetDir/")
+        files.mkdir(targetDir)
+        files.sync {
+            from(buildDir)
+            into(targetDir)
+
+            include(filename)
+
+            // Remove the "-/.26" suffix because we don't need it.
+            rename { name -> name.replace(".26", "").replace("-26", "") }
+        }
+    }
+}

--- a/cryptography/libsodium/build.gradle.kts
+++ b/cryptography/libsodium/build.gradle.kts
@@ -5,11 +5,10 @@ import org.hiero.gradle.tasks.GitClone
 
 plugins { id("org.hiero.gradle.module.library") }
 
-val srcDir = layout.buildDirectory.dir("libsodium")
-val dstDir = layout.buildDirectory.dir("resources/main/com/hedera/nativelib/libsodium")
+val libDir = layout.buildDirectory.dir("libsodium")
 
 tasks.register<GitClone>("cloneLibsodium") {
-    localCloneDirectory = srcDir
+    localCloneDirectory = libDir
     url = "https://github.com/jedisct1/libsodium.git"
     // branch = "master"
     tag = "1.0.22-RELEASE"
@@ -22,8 +21,11 @@ interface Injected {
 
 tasks.assemble {
     val injected = objects.newInstance(Injected::class.java)
-    val execOps = injected.execOps
-    val files = injected.files
+
+    val srcDir = libDir.get()
+    val makefileExists = file(srcDir.file("Makefile")).exists()
+    val buildDir = libDir.get().dir("src/libsodium/.libs")
+    val dstDir = layout.buildDirectory.dir("resources/main/com/hedera/nativelib/libsodium")
 
     dependsOn("cloneLibsodium")
 
@@ -70,36 +72,38 @@ tasks.assemble {
             .get()
     val targetOsArch = target.split(Pattern.compile("-"), 2)
 
+    val hieroLibsodiumConfigureHost =
+        providers.environmentVariable("HIERO_LIBSODIUM_CONFIGURE_HOST").orElse("").get()
+
     doFirst {
         // Clean everything first. Useful for subsequent cross-platform builds in the same local
         // repo, e.g. in CI.
-        if (file(srcDir.get().file("Makefile")).exists()) {
-            execOps.exec {
+        if (makefileExists) {
+            injected.execOps.exec {
                 workingDir(srcDir)
                 commandLine("make", "clean")
             }
         }
 
-        execOps.exec {
+        injected.execOps.exec {
             val cmd = mutableListOf("sh", "./configure")
-            if (providers.environmentVariable("HIERO_LIBSODIUM_CONFIGURE_HOST").isPresent) {
+            if (hieroLibsodiumConfigureHost != "") {
                 // ./configure calls target a "host", so:
                 cmd.add("--host")
-                cmd.add(providers.environmentVariable("HIERO_LIBSODIUM_CONFIGURE_HOST").get())
+                cmd.add(hieroLibsodiumConfigureHost)
             }
 
             workingDir(srcDir)
             commandLine(cmd)
         }
 
-        execOps.exec {
+        injected.execOps.exec {
             workingDir(srcDir)
             commandLine("make")
         }
 
         // Copy the lib to the resources
         val targetDir = dstDir.get().dir(targetOsArch[0]).dir(targetOsArch[1])
-        val buildDir = srcDir.get().dir("src/libsodium/.libs")
         val libExt =
             if (targetOsArch[0].contains("linux")) {
                 "so"
@@ -112,8 +116,8 @@ tasks.assemble {
         // It has something to do with ABI version or maybe something else.
         val filename = "libsodium?26.${libExt}"
         println("Copy $filename from $buildDir/ to $targetDir/")
-        files.mkdir(targetDir)
-        files.sync {
+        injected.files.mkdir(targetDir)
+        injected.files.sync {
             from(buildDir)
             into(targetDir)
 

--- a/cryptography/libsodium/src/main/java/com/hedera/cryptography/libsodium/DummyClass.java
+++ b/cryptography/libsodium/src/main/java/com/hedera/cryptography/libsodium/DummyClass.java
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.cryptography.libsodium;
+
+/// A dummy class to allow the build to succeed.
+/// Will be replaced with proper Java FFM bindings in future PRs.
+public class DummyClass {}

--- a/cryptography/libsodium/src/main/java/module-info.java
+++ b/cryptography/libsodium/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+/// Java FFM bindings for libsodium.
+module com.hedera.cryptography.ceremony {
+    exports com.hedera.cryptography.libsodium;
+}

--- a/gradle/aggregation/build.gradle.kts
+++ b/gradle/aggregation/build.gradle.kts
@@ -3,4 +3,5 @@ dependencies {
     published(project(":hedera-cryptography-hints"))
     published(project(":hedera-cryptography-wraps"))
     published(project(":hedera-cryptography-ceremony"))
+    published(project(":libsodium"))
 }


### PR DESCRIPTION
**Description**:
Building the native libsodium library and adding it to resources of a new `com.hedera.cryptography:libsodium` package.

The `:libsodium:assemble` target builds for the native host platform by default. The cross-compilation is enabled via `HIERO_LIBSODIUM_TARGET` and `HIERO_LIBSODIUM_CONFIGURE_HOST` env vars that GitHub scripts use to build the library for all the supported platforms (the same set for which we build TSS hints and wraps libraries.)

**Related issue(s)**:

Fixes #614 

**Notes for reviewer**:
Just adding a build for a new 3rd-party native library and bundle it into the hiero-cryptography artifacts. We'll introduce Java FFM bindings for calling functions from this library in separate PRs in the future.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
