### PR TITLE
fix: libsodium binary copying

### DIFF
--- a/cryptography/libsodium/build.gradle.kts
+++ b/cryptography/libsodium/build.gradle.kts
@@ -112,47 +112,27 @@ tasks.assemble {
             } else { // Windows
                 "dll"
             }
-        // libsodium native build adds a "-/.26" suffix to the lib name.
+        // libsodium native build adds a "-/.26" suffix/infix to the lib name.
         // It has something to do with ABI version or maybe something else.
         val filename = listOf("libsodium?26.${libExt}", "libsodium.${libExt}.26")
         println("Copy $filename from $buildDir/ to $targetDir/")
         injected.files.mkdir(targetDir)
-        println("Source: ${buildDir.asFile.absolutePath}")
-        injected.execOps.exec {
-            workingDir(srcDir)
-            commandLine("ls", "-l", buildDir.asFile.absolutePath)
-        }
-        println("-----")
-        println("Before: ${targetDir.asFile.absolutePath}")
-        injected.execOps.exec {
-            workingDir(srcDir)
-            commandLine("ls", "-l", targetDir.asFile.absolutePath)
-        }
-        println("-----")
         injected.files.sync {
             from(buildDir)
             into(targetDir)
 
             include(filename)
 
-            eachFile {
-                println("   dn $displayName")
-                println("   name $name")
-                println("   path $path")
-                println("   sn $sourceName")
-                println("   sp $sourcePath")
-                println("   rp ${relativePath.pathString}")
-                println("   rsp ${relativeSourcePath.pathString}")
-            }
+            eachFile { println("   Copying: $displayName") }
 
             // Remove the "-/.26" suffix because we don't need it.
             rename { name -> name.replace(".26", "").replace("-26", "") }
         }
         println("Finished copying files.")
-        println("After: ${targetDir.asFile.absolutePath}")
+        println("Destination listing so far: ${dstDir.get().asFile.absolutePath}")
         injected.execOps.exec {
             workingDir(srcDir)
-            commandLine("ls", "-l", targetDir.asFile.absolutePath)
+            commandLine("ls", "-lR", dstDir.get().asFile.absolutePath)
         }
         println("-----")
     }

--- a/cryptography/libsodium/build.gradle.kts
+++ b/cryptography/libsodium/build.gradle.kts
@@ -114,7 +114,7 @@ tasks.assemble {
             }
         // libsodium native build adds a "-/.26" suffix to the lib name.
         // It has something to do with ABI version or maybe something else.
-        val filename = "libsodium?26.${libExt}"
+        val filename = listOf("libsodium?26.${libExt}", "libsodium.${libExt}.26")
         println("Copy $filename from $buildDir/ to $targetDir/")
         injected.files.mkdir(targetDir)
         println("Source: ${buildDir.asFile.absolutePath}")

--- a/cryptography/libsodium/build.gradle.kts
+++ b/cryptography/libsodium/build.gradle.kts
@@ -117,14 +117,43 @@ tasks.assemble {
         val filename = "libsodium?26.${libExt}"
         println("Copy $filename from $buildDir/ to $targetDir/")
         injected.files.mkdir(targetDir)
+        println("Source: ${buildDir.asFile.absolutePath}")
+        injected.execOps.exec {
+            workingDir(srcDir)
+            commandLine("ls", "-l", buildDir.asFile.absolutePath)
+        }
+        println("-----")
+        println("Before: ${targetDir.asFile.absolutePath}")
+        injected.execOps.exec {
+            workingDir(srcDir)
+            commandLine("ls", "-l", targetDir.asFile.absolutePath)
+        }
+        println("-----")
         injected.files.sync {
             from(buildDir)
             into(targetDir)
 
             include(filename)
 
+            eachFile {
+                println("   dn $displayName")
+                println("   name $name")
+                println("   path $path")
+                println("   sn $sourceName")
+                println("   sp $sourcePath")
+                println("   rp ${relativePath.pathString}")
+                println("   rsp ${relativeSourcePath.pathString}")
+            }
+
             // Remove the "-/.26" suffix because we don't need it.
             rename { name -> name.replace(".26", "").replace("-26", "") }
         }
+        println("Finished copying files.")
+        println("After: ${targetDir.asFile.absolutePath}")
+        injected.execOps.exec {
+            workingDir(srcDir)
+            commandLine("ls", "-l", targetDir.asFile.absolutePath)
+        }
+        println("-----")
     }
 }


### PR DESCRIPTION
**Description**:
Modifying the filename pattern to match built libraries on all platforms, including Linux where the ".26" is an actual suffix of the filename rather than the library name as on Mac and Windows.

Also adding a diagnostic `ls -lR` output of the destination directory that prints all the binaries accumulated in the resources directory so far.

**Related issue(s)**:

Fixes #618 

**Notes for reviewer**:
Tested in the PR checks of this very PR, and it works.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
