### PR TITLE
build: overhaul libsodium cross-platform aggregation logic

### DIFF
--- a/.github/workflows/855-call-extract-targets-and-libs.yaml
+++ b/.github/workflows/855-call-extract-targets-and-libs.yaml
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "855: [CALL] Extract Build Targets and Libs"
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "The git ref to read .github/workflows/support/.build-targets from (branch, tag, or commit SHA)."
+        type: string
+        default: ""
+    secrets:
+      github-token:
+        required: true
+        description: "GitHub Authorization Token for the workflow"
+    outputs:
+      hiero-libsodium-targets:
+        value: ${{ jobs.extract-build-targets-libs.outputs.hiero-libsodium-targets }}
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  extract-build-targets-libs:
+    name: Extract Build Targets and Libraries
+    runs-on: hl-crypto-lin-md
+    outputs:
+      hiero-libsodium-targets: ${{ steps.get-targets-and-libs.outputs.hiero-libsodium-targets }}
+    steps:
+      - name: Initialize Job
+        uses: pandaswhocode/initialize-github-job@c392c3e699995ab6030915302d2fc9bffb1e861f # v1.1.0
+        with:
+          checkout: "true"
+          checkout-token: "${{ secrets.github-token }}"
+          checkout-ref: "${{ inputs.ref }}"
+          checkout-fetch-depth: "1"
+
+      - name: Get Targets and Libraries
+        id: get-targets-and-libs
+        run: |
+          echo "::group::Extract build targets and libraries from .build-targets"
+          ENV_FILE=".github/workflows/support/.build-targets"
+          if [[ ! -f "${ENV_FILE}" ]]; then
+            echo "::error::Environment file not found at ${ENV_FILE}"
+            exit 1
+          fi
+
+          while IFS='=' read -r key value; do
+            [[ -z "${key}" || "${key}" == \#* ]] && continue
+            echo "${key}=${value}" | tee -a "${GITHUB_OUTPUT}"
+          done < "${ENV_FILE}"
+          echo "::endgroup::"
+
+      - name: Verify Extracted Vars
+        if: ${{ steps.get-targets-and-libs.outputs.hiero-libsodium-targets == '' }}
+        run: |
+          echo "::error::One or more required variables are missing or empty. Please ensure .build-targets contains all necessary variables."
+          echo "::group::Extracted Variables"
+            echo "hiero-libsodium-targets: '${{ steps.get-targets-and-libs.outputs.hiero-libsodium-targets }}'"
+          echo "::endgroup::"
+          exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ env:
   GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
   CG_EXEC: ionice -c 2 -n 2 nice -n 19
   # HIERO_LIBSODIUM_TARGETS is replicated in at least two other workflows, and all the definitions must match:
-  HIERO_LIBSODIUM_TARGETS: "darwin-arm64,aarch64-apple-darwin;darwin-amd64,x86_64-apple-darwin;linux-amd64,x86_64-linux-gnu;linux-arm64,aarch64-linux-gnu;windows-amd64,x86_64-w64-mingw32"
+  HIERO_LIBSODIUM_TARGETS: "darwin-arm64;darwin-amd64,x86_64-apple-darwin;linux-amd64;linux-arm64,aarch64-linux-gnu;windows-amd64,x86_64-w64-mingw32"
 
 jobs:
   build_rust_macos:
@@ -63,8 +63,8 @@ jobs:
         with:
           cache-read-only: false
 
-      - name: Build Cargo Darwin
-        run: ./gradlew cargoBuildX86Darwin cargoBuildAarch64Darwin
+      - name: Build Native Darwin
+        run: ./gradlew cargoBuildX86Darwin cargoBuildAarch64Darwin buildLibsodiumDarwinArm64 buildLibsodiumDarwinAmd64
 
   build_rust_linux_windows:
     name: Build Rust - Linux / Windows
@@ -112,8 +112,8 @@ jobs:
           sudo apt-get -y install binutils-aarch64-linux-gnu
           sudo apt-get -y install mingw-w64
 
-      - name: Build Cargo Linux / Windows
-        run: ./gradlew cargoBuildX86Linux cargoBuildAarch64Linux cargoBuildX86Windows
+      - name: Build Native Linux / Windows
+        run: ./gradlew cargoBuildX86Linux cargoBuildAarch64Linux cargoBuildX86Windows buildLibsodiumLinuxAmd64 buildLibsodiumLinuxArm64  buildLibsodiumWindowsAmd64
 
   build:
     name: Build TSS Crypto Library
@@ -142,24 +142,6 @@ jobs:
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
         with:
           cache-read-only: false
-
-      - name: Setup cross-build tools
-        # Make sure 'clang-cl' and 'llvm-lib' are installed for compiling crates with C++ code for Windows
-        # https://github.com/hiero-ledger/hiero-gradle-conventions/issues/97
-        # Also install g++-aarch64-linux-gnu because the compressor build via Rust/Go needs it.
-        # Finally, install mingw that we use to build for Windows target.
-        run: |
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
-          sudo add-apt-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main
-          sudo apt-get update
-          sudo apt-get -y install clang-tools-19
-          sudo ln -s /usr/bin/clang-cl-19 /usr/bin/clang-cl
-          sudo ln -s /usr/bin/llvm-lib-19 /usr/bin/llvm-lib
-          clang-cl -v
-          llvm-lib -v
-          sudo apt-get -y install g++-aarch64-linux-gnu
-          sudo apt-get -y install binutils-aarch64-linux-gnu
-          sudo apt-get -y install mingw-w64
 
       - name: Build software
         run: ./gradlew -PskipInstallRustToolchains=true assemble
@@ -209,14 +191,6 @@ jobs:
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
         with:
           cache-read-only: false
-
-      - name: Setup cross-build tools
-        run: |
-          brew install mingw-w64
-          brew tap messense/macos-cross-toolchains
-          brew trust messense/macos-cross-toolchains
-          brew install x86_64-unknown-linux-gnu
-          brew install aarch64-unknown-linux-gnu
 
       - name: Gradle Unit Test
         # We do -PskipInstallRustToolchains=true, because all cargoBuild task results are taken FROM-CACHE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,6 +210,13 @@ jobs:
         with:
           cache-read-only: false
 
+      - name: Setup cross-build tools
+        run: |
+          brew install mingw-w64
+          brew tap messense/macos-cross-toolchains
+          brew install x86_64-unknown-linux-gnu
+          brew install aarch64-unknown-linux-gnu
+
       - name: Gradle Unit Test
         # We do -PskipInstallRustToolchains=true, because all cargoBuild task results are taken FROM-CACHE
         run: ./gradlew test -PskipInstallRustToolchains=true --continue

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,14 +30,22 @@ env:
   GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
   GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
   CG_EXEC: ionice -c 2 -n 2 nice -n 19
-  # HIERO_LIBSODIUM_TARGETS is replicated in at least two other workflows, and all the definitions must match:
-  HIERO_LIBSODIUM_TARGETS: "darwin-arm64;darwin-amd64,x86_64-apple-darwin;linux-amd64;linux-arm64,aarch64-linux-gnu;windows-amd64,x86_64-w64-mingw32"
 
 jobs:
+  read-build-targets:
+    name: Read Build Targets
+    uses: ./.github/workflows/855-call-extract-targets-and-libs.yaml
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
   build_rust_macos:
     # Build macOS Rust targets separately on a macOS runner to have access to macOS SDKs
     name: Build Rust - macOS
+    needs:
+      - read-build-targets
     runs-on: macos-14
+    env:
+      HIERO_LIBSODIUM_TARGETS: ${{ needs.read-build-targets.outputs.hiero-libsodium-targets }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
@@ -68,7 +76,10 @@ jobs:
 
   build_rust_linux_windows:
     name: Build Rust - Linux / Windows
+    needs: read-build-targets
     runs-on: hl-crypto-lin-md
+    env:
+      HIERO_LIBSODIUM_TARGETS: ${{ needs.read-build-targets.outputs.hiero-libsodium-targets }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
@@ -118,9 +129,12 @@ jobs:
   build:
     name: Build TSS Crypto Library
     needs:
+      - read-build-targets
       - build_rust_macos
       - build_rust_linux_windows
     runs-on: hl-crypto-lin-lg
+    env:
+      HIERO_LIBSODIUM_TARGETS: ${{ needs.read-build-targets.outputs.hiero-libsodium-targets }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
@@ -159,12 +173,16 @@ jobs:
 
   test-cross-platform:
     name: Test on ${{ matrix.os }}
-    needs: build
+    needs:
+      - read-build-targets
+      - build
     strategy:
       matrix:
         # removed windows from test as the windows build does not complete due to size of runner (2c/7gb RAM)
         os: [macos-14]
     runs-on: ${{ matrix.os }}
+    env:
+      HIERO_LIBSODIUM_TARGETS: ${{ needs.read-build-targets.outputs.hiero-libsodium-targets }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
           cache-read-only: false
 
       - name: Build Native Libraries for Darwin
-        run: ./gradlew cargoBuildX86Darwin cargoBuildAarch64Darwin :libsodium:buildLibsodiumDarwinArm64 :libsodium:buildLibsodiumDarwinAmd64 :libsodium:test
+        run: ./gradlew cargoBuildX86Darwin cargoBuildAarch64Darwin :libsodium:buildLibsodiumDarwinArm64 :libsodium:buildLibsodiumDarwinAmd64
 
   build_rust_linux_windows:
     name: Build Rust - Linux / Windows
@@ -113,7 +113,7 @@ jobs:
           sudo apt-get -y install mingw-w64
 
       - name: Build Native Libraries for Linux / Windows
-        run: ./gradlew cargoBuildX86Linux cargoBuildAarch64Linux cargoBuildX86Windows :libsodium:buildLibsodiumLinuxAmd64 :libsodium:buildLibsodiumLinuxArm64 :libsodium:buildLibsodiumWindowsAmd64 :libsodium:test
+        run: ./gradlew cargoBuildX86Linux cargoBuildAarch64Linux cargoBuildX86Windows :libsodium:buildLibsodiumLinuxAmd64 :libsodium:buildLibsodiumLinuxArm64 :libsodium:buildLibsodiumWindowsAmd64
 
   build:
     name: Build TSS Crypto Library

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,6 +214,7 @@ jobs:
         run: |
           brew install mingw-w64
           brew tap messense/macos-cross-toolchains
+          brew trust messense/macos-cross-toolchains
           brew install x86_64-unknown-linux-gnu
           brew install aarch64-unknown-linux-gnu
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ env:
   GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
   CG_EXEC: ionice -c 2 -n 2 nice -n 19
   # HIERO_LIBSODIUM_TARGETS is replicated in at least two other workflows, and all the definitions must match:
-  HIERO_LIBSODIUM_TARGETS: "darwin-arm64;darwin-amd64,x86_64-apple-darwin;linux-amd64;linux-arm64,aarch64-linux-gnu;windows-amd64,x86_64-w64-mingw32"
+  HIERO_LIBSODIUM_TARGETS: "darwin-arm64,aarch64-apple-darwin;darwin-amd64,x86_64-apple-darwin;linux-amd64,x86_64-linux-gnu;linux-arm64,aarch64-linux-gnu;windows-amd64,x86_64-w64-mingw32"
 
 jobs:
   build_rust_macos:
@@ -63,8 +63,8 @@ jobs:
         with:
           cache-read-only: false
 
-      - name: Build Native Libraries for Darwin
-        run: ./gradlew cargoBuildX86Darwin cargoBuildAarch64Darwin :libsodium:buildLibsodiumDarwinArm64 :libsodium:buildLibsodiumDarwinAmd64
+      - name: Build Cargo Darwin
+        run: ./gradlew cargoBuildX86Darwin cargoBuildAarch64Darwin
 
   build_rust_linux_windows:
     name: Build Rust - Linux / Windows
@@ -112,8 +112,8 @@ jobs:
           sudo apt-get -y install binutils-aarch64-linux-gnu
           sudo apt-get -y install mingw-w64
 
-      - name: Build Native Libraries for Linux / Windows
-        run: ./gradlew cargoBuildX86Linux cargoBuildAarch64Linux cargoBuildX86Windows :libsodium:buildLibsodiumLinuxAmd64 :libsodium:buildLibsodiumLinuxArm64 :libsodium:buildLibsodiumWindowsAmd64
+      - name: Build Cargo Linux / Windows
+        run: ./gradlew cargoBuildX86Linux cargoBuildAarch64Linux cargoBuildX86Windows
 
   build:
     name: Build TSS Crypto Library

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,6 +143,24 @@ jobs:
         with:
           cache-read-only: false
 
+      - name: Setup cross-build tools
+        # Make sure 'clang-cl' and 'llvm-lib' are installed for compiling crates with C++ code for Windows
+        # https://github.com/hiero-ledger/hiero-gradle-conventions/issues/97
+        # Also install g++-aarch64-linux-gnu because the compressor build via Rust/Go needs it.
+        # Finally, install mingw that we use to build for Windows target.
+        run: |
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
+          sudo add-apt-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main
+          sudo apt-get update
+          sudo apt-get -y install clang-tools-19
+          sudo ln -s /usr/bin/clang-cl-19 /usr/bin/clang-cl
+          sudo ln -s /usr/bin/llvm-lib-19 /usr/bin/llvm-lib
+          clang-cl -v
+          llvm-lib -v
+          sudo apt-get -y install g++-aarch64-linux-gnu
+          sudo apt-get -y install binutils-aarch64-linux-gnu
+          sudo apt-get -y install mingw-w64
+
       - name: Build software
         run: ./gradlew -PskipInstallRustToolchains=true assemble
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ env:
   GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
   GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
   CG_EXEC: ionice -c 2 -n 2 nice -n 19
+  # HIERO_LIBSODIUM_TARGETS is replicated in at least two other workflows, and all the definitions must match:
+  HIERO_LIBSODIUM_TARGETS: "darwin-arm64;darwin-amd64,x86_64-apple-darwin;linux-amd64;linux-arm64,aarch64-linux-gnu;windows-amd64,x86_64-w64-mingw32"
 
 jobs:
   build_rust_macos:
@@ -61,14 +63,8 @@ jobs:
         with:
           cache-read-only: false
 
-      - name: Build Cargo Darwin
-        run: ./gradlew cargoBuildX86Darwin cargoBuildAarch64Darwin
-
-      - name: Build libsodium darwin-arm64
-        run: ./gradlew :libsodium:build
-
-      - name: Build libsodium darwin-amd64
-        run: HIERO_LIBSODIUM_TARGET=darwin-amd64 HIERO_LIBSODIUM_CONFIGURE_HOST=x86_64-apple-darwin ./gradlew :libsodium:assemble
+      - name: Build Native Libraries for Darwin
+        run: ./gradlew cargoBuildX86Darwin cargoBuildAarch64Darwin :libsodium:buildLibsodiumDarwinArm64 :libsodium:buildLibsodiumDarwinAmd64 :libsodium:test
 
   build_rust_linux_windows:
     name: Build Rust - Linux / Windows
@@ -116,17 +112,8 @@ jobs:
           sudo apt-get -y install binutils-aarch64-linux-gnu
           sudo apt-get -y install mingw-w64
 
-      - name: Build Cargo Linux / Windows
-        run: ./gradlew cargoBuildX86Linux cargoBuildAarch64Linux cargoBuildX86Windows
-
-      - name: Build libsodium linux-amd64
-        run: ./gradlew :libsodium:build
-
-      - name: Build libsodium linux-arm64
-        run: HIERO_LIBSODIUM_TARGET=linux-arm64 HIERO_LIBSODIUM_CONFIGURE_HOST=aarch64-linux-gnu ./gradlew :libsodium:assemble
-
-      - name: Build libsodium windows-amd64
-        run: HIERO_LIBSODIUM_TARGET=windows-amd64 HIERO_LIBSODIUM_CONFIGURE_HOST=x86_64-w64-mingw32 ./gradlew :libsodium:assemble
+      - name: Build Native Libraries for Linux / Windows
+        run: ./gradlew cargoBuildX86Linux cargoBuildAarch64Linux cargoBuildX86Windows :libsodium:buildLibsodiumLinuxAmd64 :libsodium:buildLibsodiumLinuxArm64 :libsodium:buildLibsodiumWindowsAmd64 :libsodium:test
 
   build:
     name: Build TSS Crypto Library

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -38,7 +38,7 @@ env:
   GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
   GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
   # HIERO_LIBSODIUM_TARGETS must match the definition in build.xml:
-  HIERO_LIBSODIUM_TARGETS: "darwin-arm64,aarch64-apple-darwin;darwin-amd64,x86_64-apple-darwin;linux-amd64,x86_64-linux-gnu;linux-arm64,aarch64-linux-gnu;windows-amd64,x86_64-w64-mingw32"
+  HIERO_LIBSODIUM_TARGETS: "darwin-arm64;darwin-amd64,x86_64-apple-darwin;linux-amd64;linux-arm64,aarch64-linux-gnu;windows-amd64,x86_64-w64-mingw32"
 
 jobs:
   create-github-release:
@@ -66,24 +66,6 @@ jobs:
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
         with:
           gradle-version: wrapper
-
-      - name: Setup cross-build tools
-        # Make sure 'clang-cl' and 'llvm-lib' are installed for compiling crates with C++ code for Windows
-        # https://github.com/hiero-ledger/hiero-gradle-conventions/issues/97
-        # Also install g++-aarch64-linux-gnu because the compressor build via Rust/Go needs it.
-        # Finally, install mingw that we use to build for Windows target.
-        run: |
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
-          sudo add-apt-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main
-          sudo apt-get update
-          sudo apt-get -y install clang-tools-19
-          sudo ln -s /usr/bin/clang-cl-19 /usr/bin/clang-cl
-          sudo ln -s /usr/bin/llvm-lib-19 /usr/bin/llvm-lib
-          clang-cl -v
-          llvm-lib -v
-          sudo apt-get -y install g++-aarch64-linux-gnu
-          sudo apt-get -y install binutils-aarch64-linux-gnu
-          sudo apt-get -y install mingw-w64
 
       - name: Install GnuPG Tools
         run: |

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -37,13 +37,21 @@ env:
   LC_ALL: C.UTF-8
   GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
   GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
-  # HIERO_LIBSODIUM_TARGETS must match the definition in build.xml:
-  HIERO_LIBSODIUM_TARGETS: "darwin-arm64;darwin-amd64,x86_64-apple-darwin;linux-amd64;linux-arm64,aarch64-linux-gnu;windows-amd64,x86_64-w64-mingw32"
 
 jobs:
+  read-build-targets:
+    name: Read Build Targets
+    uses: ./.github/workflows/855-call-extract-targets-and-libs.yaml
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
   create-github-release:
     name: Github / Release
+    needs:
+      - read-build-targets
     runs-on: hl-crypto-lin-md
+    env:
+      HIERO_LIBSODIUM_TARGETS: ${{ needs.read-build-targets.outputs.hiero-libsodium-targets }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -37,6 +37,8 @@ env:
   LC_ALL: C.UTF-8
   GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
   GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+  # HIERO_LIBSODIUM_TARGETS must match the definition in build.xml:
+  HIERO_LIBSODIUM_TARGETS: "darwin-arm64;darwin-amd64,x86_64-apple-darwin;linux-amd64;linux-arm64,aarch64-linux-gnu;windows-amd64,x86_64-w64-mingw32"
 
 jobs:
   create-github-release:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -67,6 +67,24 @@ jobs:
         with:
           gradle-version: wrapper
 
+      - name: Setup cross-build tools
+        # Make sure 'clang-cl' and 'llvm-lib' are installed for compiling crates with C++ code for Windows
+        # https://github.com/hiero-ledger/hiero-gradle-conventions/issues/97
+        # Also install g++-aarch64-linux-gnu because the compressor build via Rust/Go needs it.
+        # Finally, install mingw that we use to build for Windows target.
+        run: |
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
+          sudo add-apt-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main
+          sudo apt-get update
+          sudo apt-get -y install clang-tools-19
+          sudo ln -s /usr/bin/clang-cl-19 /usr/bin/clang-cl
+          sudo ln -s /usr/bin/llvm-lib-19 /usr/bin/llvm-lib
+          clang-cl -v
+          llvm-lib -v
+          sudo apt-get -y install g++-aarch64-linux-gnu
+          sudo apt-get -y install binutils-aarch64-linux-gnu
+          sudo apt-get -y install mingw-w64
+
       - name: Install GnuPG Tools
         run: |
           if ! command -v gpg2 >/dev/null 2>&1; then

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -38,7 +38,7 @@ env:
   GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
   GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
   # HIERO_LIBSODIUM_TARGETS must match the definition in build.xml:
-  HIERO_LIBSODIUM_TARGETS: "darwin-arm64;darwin-amd64,x86_64-apple-darwin;linux-amd64;linux-arm64,aarch64-linux-gnu;windows-amd64,x86_64-w64-mingw32"
+  HIERO_LIBSODIUM_TARGETS: "darwin-arm64,aarch64-apple-darwin;darwin-amd64,x86_64-apple-darwin;linux-amd64,x86_64-linux-gnu;linux-arm64,aarch64-linux-gnu;windows-amd64,x86_64-w64-mingw32"
 
 jobs:
   create-github-release:

--- a/.github/workflows/publish_snapshot_release.yml
+++ b/.github/workflows/publish_snapshot_release.yml
@@ -23,7 +23,7 @@ env:
   JAVA_DISTRIBUTION: temurin
   JAVA_VERSION: 25.0.2
   # HIERO_LIBSODIUM_TARGETS must match the definition in build.xml:
-  HIERO_LIBSODIUM_TARGETS: "darwin-arm64,aarch64-apple-darwin;darwin-amd64,x86_64-apple-darwin;linux-amd64,x86_64-linux-gnu;linux-arm64,aarch64-linux-gnu;windows-amd64,x86_64-w64-mingw32"
+  HIERO_LIBSODIUM_TARGETS: "darwin-arm64;darwin-amd64,x86_64-apple-darwin;linux-amd64;linux-arm64,aarch64-linux-gnu;windows-amd64,x86_64-w64-mingw32"
 
 jobs:
   publish-maven-central:
@@ -50,24 +50,6 @@ jobs:
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
         with:
           gradle-version: ${{ env.GRADLE_VERSION }}
-
-      - name: Setup cross-build tools
-        # Make sure 'clang-cl' and 'llvm-lib' are installed for compiling crates with C++ code for Windows
-        # https://github.com/hiero-ledger/hiero-gradle-conventions/issues/97
-        # Also install g++-aarch64-linux-gnu because the compressor build via Rust/Go needs it.
-        # Finally, install mingw that we use to build for Windows target.
-        run: |
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
-          sudo add-apt-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main
-          sudo apt-get update
-          sudo apt-get -y install clang-tools-19
-          sudo ln -s /usr/bin/clang-cl-19 /usr/bin/clang-cl
-          sudo ln -s /usr/bin/llvm-lib-19 /usr/bin/llvm-lib
-          clang-cl -v
-          llvm-lib -v
-          sudo apt-get -y install g++-aarch64-linux-gnu
-          sudo apt-get -y install binutils-aarch64-linux-gnu
-          sudo apt-get -y install mingw-w64
 
       - name: Install GnuPG Tools
         run: |

--- a/.github/workflows/publish_snapshot_release.yml
+++ b/.github/workflows/publish_snapshot_release.yml
@@ -23,7 +23,7 @@ env:
   JAVA_DISTRIBUTION: temurin
   JAVA_VERSION: 25.0.2
   # HIERO_LIBSODIUM_TARGETS must match the definition in build.xml:
-  HIERO_LIBSODIUM_TARGETS: "darwin-arm64;darwin-amd64,x86_64-apple-darwin;linux-amd64;linux-arm64,aarch64-linux-gnu;windows-amd64,x86_64-w64-mingw32"
+  HIERO_LIBSODIUM_TARGETS: "darwin-arm64,aarch64-apple-darwin;darwin-amd64,x86_64-apple-darwin;linux-amd64,x86_64-linux-gnu;linux-arm64,aarch64-linux-gnu;windows-amd64,x86_64-w64-mingw32"
 
 jobs:
   publish-maven-central:

--- a/.github/workflows/publish_snapshot_release.yml
+++ b/.github/workflows/publish_snapshot_release.yml
@@ -22,13 +22,21 @@ env:
   GRADLE_VERSION: wrapper
   JAVA_DISTRIBUTION: temurin
   JAVA_VERSION: 25.0.2
-  # HIERO_LIBSODIUM_TARGETS must match the definition in build.xml:
-  HIERO_LIBSODIUM_TARGETS: "darwin-arm64;darwin-amd64,x86_64-apple-darwin;linux-amd64;linux-arm64,aarch64-linux-gnu;windows-amd64,x86_64-w64-mingw32"
 
 jobs:
+  read-build-targets:
+    name: Read Build Targets
+    uses: ./.github/workflows/855-call-extract-targets-and-libs.yaml
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
   publish-maven-central:
     name: Publish Maven Central
+    needs:
+      - read-build-targets
     runs-on: hl-crypto-lin-md
+    env:
+      HIERO_LIBSODIUM_TARGETS: ${{ needs.read-build-targets.outputs.hiero-libsodium-targets }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0

--- a/.github/workflows/publish_snapshot_release.yml
+++ b/.github/workflows/publish_snapshot_release.yml
@@ -51,6 +51,24 @@ jobs:
         with:
           gradle-version: ${{ env.GRADLE_VERSION }}
 
+      - name: Setup cross-build tools
+        # Make sure 'clang-cl' and 'llvm-lib' are installed for compiling crates with C++ code for Windows
+        # https://github.com/hiero-ledger/hiero-gradle-conventions/issues/97
+        # Also install g++-aarch64-linux-gnu because the compressor build via Rust/Go needs it.
+        # Finally, install mingw that we use to build for Windows target.
+        run: |
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
+          sudo add-apt-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main
+          sudo apt-get update
+          sudo apt-get -y install clang-tools-19
+          sudo ln -s /usr/bin/clang-cl-19 /usr/bin/clang-cl
+          sudo ln -s /usr/bin/llvm-lib-19 /usr/bin/llvm-lib
+          clang-cl -v
+          llvm-lib -v
+          sudo apt-get -y install g++-aarch64-linux-gnu
+          sudo apt-get -y install binutils-aarch64-linux-gnu
+          sudo apt-get -y install mingw-w64
+
       - name: Install GnuPG Tools
         run: |
           if ! command -v gpg2 >/dev/null 2>&1; then

--- a/.github/workflows/publish_snapshot_release.yml
+++ b/.github/workflows/publish_snapshot_release.yml
@@ -22,6 +22,8 @@ env:
   GRADLE_VERSION: wrapper
   JAVA_DISTRIBUTION: temurin
   JAVA_VERSION: 25.0.2
+  # HIERO_LIBSODIUM_TARGETS must match the definition in build.xml:
+  HIERO_LIBSODIUM_TARGETS: "darwin-arm64;darwin-amd64,x86_64-apple-darwin;linux-amd64;linux-arm64,aarch64-linux-gnu;windows-amd64,x86_64-w64-mingw32"
 
 jobs:
   publish-maven-central:

--- a/.github/workflows/support/.build-targets
+++ b/.github/workflows/support/.build-targets
@@ -1,0 +1,1 @@
+hiero-libsodium-targets=darwin-arm64;darwin-amd64,x86_64-apple-darwin;linux-amd64;linux-arm64,aarch64-linux-gnu;windows-amd64,x86_64-w64-mingw32

--- a/cryptography/libsodium/build.gradle.kts
+++ b/cryptography/libsodium/build.gradle.kts
@@ -16,8 +16,11 @@ tasks.test {
 }
 
 /// Where we check out the libsodium repo from GitHub into the local build/ directory:
-val libRepositoryDir = layout.buildDirectory.dir("third-party/libsodium")
-val libOutputDir = layout.buildDirectory.dir("third-party/libsodium/output")
+/// Must end with "libsodium" or whatever name the GitHub repo has:
+val libRepositoryDir = layout.buildDirectory.dir("libsodium/input/libsodium")
+/// Where build tasks write output to:
+/// Must be outside of input/ above so that Gradle is happy:
+val libOutputDir = layout.buildDirectory.dir("libsodium/output")
 
 tasks.register<GitClone>("cloneLibsodium") {
     localCloneDirectory = libRepositoryDir

--- a/cryptography/libsodium/build.gradle.kts
+++ b/cryptography/libsodium/build.gradle.kts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-import java.util.regex.Pattern
 import org.gradle.api.internal.file.FileOperations
+import org.gradle.internal.extensions.stdlib.capitalized
+import org.gradle.kotlin.dsl.register
 import org.hiero.gradle.tasks.GitClone
 
 plugins { id("org.hiero.gradle.module.library") }
@@ -8,14 +9,12 @@ plugins { id("org.hiero.gradle.module.library") }
 testModuleInfo { requires("org.junit.jupiter.api") }
 
 tasks.test {
-    // It's a bit odd why test doesn't depend on assemble by default...
-    dependsOn("assemble")
-
     jvmArgs(
         "--enable-native-access=com.hedera.common.nativesupport,com.hedera.cryptography.libsodium"
     )
 }
 
+/// Where we check out the libsodium repo from GitHub into the local build/ directory:
 val libDir = layout.buildDirectory.dir("libsodium")
 
 tasks.register<GitClone>("cloneLibsodium") {
@@ -25,110 +24,63 @@ tasks.register<GitClone>("cloneLibsodium") {
     tag = "1.0.22-RELEASE"
 }
 
-interface Injected {
-    @get:Inject val execOps: ExecOperations
-    @get:Inject val files: FileOperations
-}
+abstract class BuildLibsodiumTask : DefaultTask() {
+    @get:Inject protected abstract val execOps: ExecOperations
+    @get:Inject protected abstract val files: FileOperations
 
-tasks.assemble {
-    val injected = objects.newInstance(Injected::class.java)
+    /// Where the native library repo is checked out via GitClone. Must contain ./configure.
+    /// Likely build/<name>/.
+    @get:InputDirectory abstract val libraryDir: DirectoryProperty
 
-    val srcDir = libDir.get()
-    val makefileExists = file(srcDir.file("Makefile")).exists()
-    val buildDir = libDir.get().dir("src/libsodium/.libs")
-    val dstDir = layout.buildDirectory.dir("resources/main/com/hedera/nativelib/libsodium")
+    /// ./configure --host ... string, or a blank string to omit the --host arg.
+    @get:Input abstract val configureHost: Property<String>
 
-    dependsOn("cloneLibsodium")
+    /// Where the binary library to be written.
+    // Likely build/resources/main/com/hedera/nativelib/<name>/<os>/<arch>/.
+    @get:OutputDirectory abstract val outputDir: DirectoryProperty
 
-    // HIERO_LIBSODIUM_TARGET=os-arch
-    // where os is linux, darwin, or windows, and arch is amd64 or arm64
-    // Example: HIERO_LIBSODIUM_TARGET=darwin-amd64
-    // By default, assume we build for the host target and infer the value of HIERO_LIBSODIUM_TARGET
-    // accordingly. If HIERO_LIBSODIUM_TARGET env var is defined explicitly, then the caller should
-    // probably also define HIERO_LIBSODIUM_CONFIGURE_HOST to let ./configure --host ... choose the
-    // correct toolchain. The caller may also define CFLAGS, CC, AR, and whatever else if needed.
-    // For example, to build for Windows target (e.g. on a Mac host) run:
-    // HIERO_LIBSODIUM_TARGET=windows-amd64 HIERO_LIBSODIUM_CONFIGURE_HOST=x86_64-w64-mingw32
-    // ./gradlew assemble
-    val target =
-        providers
-            .environmentVariable("HIERO_LIBSODIUM_TARGET")
-            .orElse(
-                providers.provider {
-                    val hostOperatingSystem =
-                        System.getProperty("os.name").lowercase().let {
-                            if (it.contains("windows")) {
-                                "windows"
-                            } else if (it.contains("mac")) {
-                                "darwin"
-                            } else {
-                                "linux"
-                            }
-                        }
-                    val hostArchitecture =
-                        System.getProperty("os.arch").let {
-                            if (it.contains("x86_64")) {
-                                "amd64"
-                            } else if (it.contains("aarch64")) {
-                                "arm64"
-                            } else {
-                                // There's "386" and "armv6l" at https://go.dev/dl/ .
-                                it
-                            }
-                        }
-
-                    "${hostOperatingSystem}-${hostArchitecture}"
-                }
-            )
-            .get()
-    val targetOsArch = target.split(Pattern.compile("-"), 2)
-
-    val hieroLibsodiumConfigureHost =
-        providers.environmentVariable("HIERO_LIBSODIUM_CONFIGURE_HOST").orElse("").get()
-
-    doFirst {
+    @TaskAction
+    fun action() {
         // Clean everything first. Useful for subsequent cross-platform builds in the same local
         // repo, e.g. in CI.
+        val makefileExists = files.file(libraryDir.file("Makefile")).exists()
         if (makefileExists) {
-            injected.execOps.exec {
-                workingDir(srcDir)
+            execOps.exec {
+                workingDir(libraryDir)
                 commandLine("make", "clean")
             }
         }
 
-        injected.execOps.exec {
+        execOps.exec {
             val cmd = mutableListOf("sh", "./configure")
-            if (hieroLibsodiumConfigureHost != "") {
+            if (configureHost.get() != "") {
                 // ./configure calls target a "host", so:
                 cmd.add("--host")
-                cmd.add(hieroLibsodiumConfigureHost)
+                cmd.add(configureHost.get())
             }
 
-            workingDir(srcDir)
+            workingDir(libraryDir)
             commandLine(cmd)
         }
 
-        injected.execOps.exec {
-            workingDir(srcDir)
+        execOps.exec {
+            workingDir(libraryDir)
             commandLine("make")
         }
 
         // Copy the lib to the resources
-        val targetDir = dstDir.get().dir(targetOsArch[0]).dir(targetOsArch[1])
-        val libExt =
-            if (targetOsArch[0].contains("linux")) {
-                "so"
-            } else if (targetOsArch[0].contains("darwin")) {
-                "dylib"
-            } else { // Windows
-                "dll"
-            }
+        val libExts = listOf("so", "dylib", "dll")
         // libsodium native build adds a "-/.26" suffix/infix to the lib name.
         // It has something to do with ABI version or maybe something else.
-        val filename = listOf("libsodium?26.${libExt}", "libsodium.${libExt}.26")
+        val filename =
+            libExts
+                .flatMap { libExt -> listOf("libsodium?26.${libExt}", "libsodium.${libExt}.26") }
+                .toList()
+        val buildDir = libraryDir.get().dir("src/libsodium/.libs")
+        val targetDir = outputDir.get()
         println("Copy $filename from $buildDir/ to $targetDir/")
-        injected.files.mkdir(targetDir)
-        injected.files.sync {
+        files.mkdir(targetDir)
+        files.sync {
             from(buildDir)
             into(targetDir)
 
@@ -140,11 +92,105 @@ tasks.assemble {
             rename { name -> name.replace(".26", "").replace("-26", "") }
         }
         println("Finished copying files.")
-        println("Destination listing so far: ${dstDir.get().asFile.absolutePath}")
-        injected.execOps.exec {
-            workingDir(srcDir)
-            commandLine("ls", "-lR", dstDir.get().asFile.absolutePath)
-        }
+        // The output dir w/o the os/arch/ path to print everything we have so far:
+        val resourcesDir = outputDir.get().file("../..").asFile.absolutePath
+        println("Destination listing so far: $resourcesDir")
+        execOps.exec { commandLine("ls", "-lR", resourcesDir) }
         println("-----")
+    }
+}
+
+/// A descriptor for a native target
+data class NativeTarget(val os: String, val arch: String, val configureHost: String) {}
+
+// HIERO_LIBSODIUM_TARGETS env var can be defined to cross-build for different platforms.
+// If undefined, only a build for the local host target will be performed.
+// Example:
+//
+// HIERO_LIBSODIUM_TARGETS="darwin-arm64;darwin-amd64,x86_64-apple-darwin;linux-amd64;linux-arm64,aarch64-linux-gnu;windows-amd64,x86_64-w64-mingw32"
+//
+// This is a semicolon-separated list of target definitions. Each definition starts with a target
+// name in the form of os-arch, where os is linux, darwin, or windows, and arch is amd64 or arm64.
+// The target definition can optionally be followed by a comma and a ./configure --host ...
+// value that will be passed to the ./configure script to use a proper toolchain for cross-
+// compilation. If the host value is missing, then ./configure will be invoked w/o any parameters,
+// assuming a local host build for the local host target (i.e. no cross-compilation.)
+//
+// Each defined target will result in creating a :libsodium:buildLibsodium<Os><Arch> Gradle task
+// where <Os> and <Arch> will be capitalized versions of the os and arch from the target name.
+//
+// The :libsodium:compile[Test]Java targets will take a dependency on the local host target build
+// task only. This is to ensure that unit tests can access a local host target-built native library.
+//
+// The jar task takes a dependency on all the buildLibsodium tasks for all targets.
+// This is to ensure that the published artifact in CI has native libraries for all supported
+// platforms.
+//
+// Individual GitHub CI runner tasks could build specific targets on specific hosts (e.g. darwin on
+// Mac) and the Gradle Cache will take care of aggregating all the results when assembling the final
+// artifact to be published to Maven.
+val hostOperatingSystem =
+    System.getProperty("os.name").lowercase().let {
+        if (it.contains("windows")) {
+            "windows"
+        } else if (it.contains("mac")) {
+            "darwin"
+        } else {
+            "linux"
+        }
+    }
+val hostArchitecture =
+    System.getProperty("os.arch").let {
+        if (it.contains("x86_64")) {
+            "amd64"
+        } else if (it.contains("aarch64")) {
+            "arm64"
+        } else {
+            // There's "386" and "armv6l" at https://go.dev/dl/ .
+            it
+        }
+    }
+
+val targets =
+    providers
+        .environmentVariable("HIERO_LIBSODIUM_TARGETS")
+        .map { targetsString ->
+            targetsString
+                .split(";")
+                .map { targetDef ->
+                    val targetDefParts = targetDef.split(",")
+                    val osArch = targetDefParts[0].split("-")
+                    NativeTarget(
+                        osArch[0],
+                        osArch[1],
+                        if (targetDefParts.size > 1) targetDefParts[1] else "",
+                    )
+                }
+                .toList()
+        }
+        .orElse(listOf(NativeTarget(hostOperatingSystem, hostArchitecture, "")))
+        .get()
+
+targets.forEach { target ->
+    val name = "buildLibsodium" + target.os.capitalized() + target.arch.capitalized()
+    println("Registering $name per $target")
+    val task =
+        tasks.register<BuildLibsodiumTask>(name) {
+            dependsOn("cloneLibsodium")
+            libraryDir = libDir
+            configureHost = target.configureHost
+            outputDir =
+                layout.buildDirectory.dir(
+                    "resources/main/com/hedera/nativelib/libsodium/${target.os}/${target.arch}"
+                )
+        }
+
+    // Include all built native libraries into the .jar:
+    tasks.jar { from(task) }
+
+    // If we run unit tests on the host platform, then we need the library available:
+    if (target.os == hostOperatingSystem && target.arch == hostArchitecture) {
+        tasks.compileJava { dependsOn(name) }
+        tasks.compileTestJava { dependsOn(name) }
     }
 }

--- a/cryptography/libsodium/build.gradle.kts
+++ b/cryptography/libsodium/build.gradle.kts
@@ -204,3 +204,11 @@ targets.forEach { target ->
     tasks.compileJava { dependsOn(name) }
     tasks.compileTestJava { dependsOn(name) }
 }
+
+tasks.named<Jar>("jar") {
+    // Each native library goes into its own os/arch/ subdirectory, and our `ls -lR` proves it.
+    // However, Gradle still complains:
+    //    Entry libsodium.dylib is a duplicate but no duplicate handling strategy has been set.
+    // So we do this:
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+}

--- a/cryptography/libsodium/build.gradle.kts
+++ b/cryptography/libsodium/build.gradle.kts
@@ -2,6 +2,7 @@
 import org.gradle.api.internal.file.FileOperations
 import org.gradle.internal.extensions.stdlib.capitalized
 import org.gradle.kotlin.dsl.register
+import org.hiero.gradle.services.TaskLockService
 import org.hiero.gradle.tasks.GitClone
 
 plugins { id("org.hiero.gradle.module.library") }
@@ -15,38 +16,45 @@ tasks.test {
 }
 
 /// Where we check out the libsodium repo from GitHub into the local build/ directory:
-val libDir = layout.buildDirectory.dir("libsodium")
+val libRepositoryDir = layout.buildDirectory.dir("third-party/libsodium")
+val libOutputDir = layout.buildDirectory.dir("third-party/libsodium/output")
 
 tasks.register<GitClone>("cloneLibsodium") {
-    localCloneDirectory = libDir
+    localCloneDirectory = libRepositoryDir
     url = "https://github.com/jedisct1/libsodium.git"
     // branch = "master"
     tag = "1.0.22-RELEASE"
 }
 
 // We cannot build from a single repo for multiple targets at once. So we limit parallelizm:
-abstract class TaskMutex : BuildService<BuildServiceParameters.None>
-
-val mutexService =
-    gradle.sharedServices.registerIfAbsent("taskMutex", TaskMutex::class.java) {
-        maxParallelUsages.set(1)
-    }
+gradle.sharedServices.registerIfAbsent("lock", TaskLockService::class) { maxParallelUsages = 1 }
 
 /// Builds a native library via ./configure && make and copies .so/.dylib/.dll to resources.
+@CacheableTask
 abstract class BuildLibsodiumTask : DefaultTask() {
+    @get:ServiceReference("lock") abstract val lock: Property<TaskLockService>
+
     @get:Inject protected abstract val execOps: ExecOperations
     @get:Inject protected abstract val files: FileOperations
 
     /// Where the native library repo is checked out via GitClone. Must contain ./configure.
-    /// Likely build/<name>/.
-    @get:InputDirectory abstract val libraryDir: DirectoryProperty
+    /// Likely build/third-party/<name>/repository.
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val libraryDir: DirectoryProperty
 
     /// ./configure --host ... string, or a blank string to omit the --host arg.
     @get:Input abstract val configureHost: Property<String>
 
     /// Where the binary library to be written.
-    // Likely build/resources/main/com/hedera/nativelib/<name>/<os>/<arch>/.
+    /// Likely build/third-party/<name>/output/<os>-<arch>.
     @get:OutputDirectory abstract val outputDir: DirectoryProperty
+
+    /// Path under the outputDir
+    // Likely com/hedera/nativelib/<name>/<os>/<arch>/
+    // The os/arch tuple must appear twice in both outputDir and outputPath,
+    // because that's how Gradle wants it...
+    @get:Input abstract val outputPath: Property<String>
 
     @TaskAction
     fun action() {
@@ -86,7 +94,7 @@ abstract class BuildLibsodiumTask : DefaultTask() {
                 .flatMap { libExt -> listOf("libsodium?26.${libExt}", "libsodium.${libExt}.26") }
                 .toList()
         val buildDir = libraryDir.get().dir("src/libsodium/.libs")
-        val targetDir = outputDir.get()
+        val targetDir = outputDir.get().dir(outputPath.get())
         println("Copy $filename from $buildDir/ to $targetDir/")
         files.mkdir(targetDir)
         files.sync {
@@ -102,7 +110,7 @@ abstract class BuildLibsodiumTask : DefaultTask() {
         }
         println("Finished copying files.")
         // The output dir w/o the os/arch/ path to print everything we have so far:
-        val resourcesDir = outputDir.get().file("../..").asFile.absolutePath
+        val resourcesDir = outputDir.get().file("..").asFile.absolutePath
         println("Destination listing so far: $resourcesDir")
         execOps.exec { commandLine("ls", "-lR", resourcesDir) }
         println("-----")
@@ -182,33 +190,14 @@ val targets =
 
 targets.forEach { target ->
     val name = "buildLibsodium" + target.os.capitalized() + target.arch.capitalized()
-    println("Registering $name per $target")
     val task =
         tasks.register<BuildLibsodiumTask>(name) {
-            usesService(mutexService)
-            dependsOn("cloneLibsodium")
-            libraryDir = libDir
+            libraryDir = tasks.named<GitClone>("cloneLibsodium").flatMap { it.localCloneDirectory }
             configureHost = target.configureHost
-            outputDir =
-                layout.buildDirectory.dir(
-                    "resources/main/com/hedera/nativelib/libsodium/${target.os}/${target.arch}"
-                )
+            outputDir = libOutputDir.get().dir("${target.os}-${target.arch}")
+            outputPath = "com/hedera/nativelib/libsodium/${target.os}/${target.arch}"
         }
 
-    // Include all built native libraries into the .jar:
-    tasks.jar { from(task) }
-
-    // The compile tasks must also depend on the native builds. Technically, only the local host
-    // target library is required, e.g. to run the code and/or unit tests locally.
-    // But Gradle requires all of them because they all make it into the resources/. So:
-    tasks.compileJava { dependsOn(name) }
-    tasks.compileTestJava { dependsOn(name) }
-}
-
-tasks.named<Jar>("jar") {
-    // Each native library goes into its own os/arch/ subdirectory, and our `ls -lR` proves it.
-    // However, Gradle still complains:
-    //    Entry libsodium.dylib is a duplicate but no duplicate handling strategy has been set.
-    // So we do this:
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    // Include all built native libraries into the .jar and mark them as resources for tests to use:
+    sourceSets["main"].resources.srcDir(task)
 }

--- a/cryptography/libsodium/build.gradle.kts
+++ b/cryptography/libsodium/build.gradle.kts
@@ -24,6 +24,14 @@ tasks.register<GitClone>("cloneLibsodium") {
     tag = "1.0.22-RELEASE"
 }
 
+// We cannot build from a single repo for multiple targets at once. So we limit parallelizm:
+abstract class TaskMutex : BuildService<BuildServiceParameters.None>
+
+val mutexService =
+    gradle.sharedServices.registerIfAbsent("taskMutex", TaskMutex::class.java) {
+        maxParallelUsages.set(1)
+    }
+
 abstract class BuildLibsodiumTask : DefaultTask() {
     @get:Inject protected abstract val execOps: ExecOperations
     @get:Inject protected abstract val files: FileOperations
@@ -176,6 +184,7 @@ targets.forEach { target ->
     println("Registering $name per $target")
     val task =
         tasks.register<BuildLibsodiumTask>(name) {
+            usesService(mutexService)
             dependsOn("cloneLibsodium")
             libraryDir = libDir
             configureHost = target.configureHost

--- a/cryptography/libsodium/build.gradle.kts
+++ b/cryptography/libsodium/build.gradle.kts
@@ -32,6 +32,7 @@ val mutexService =
         maxParallelUsages.set(1)
     }
 
+/// Builds a native library via ./configure && make and copies .so/.dylib/.dll to resources.
 abstract class BuildLibsodiumTask : DefaultTask() {
     @get:Inject protected abstract val execOps: ExecOperations
     @get:Inject protected abstract val files: FileOperations
@@ -197,9 +198,9 @@ targets.forEach { target ->
     // Include all built native libraries into the .jar:
     tasks.jar { from(task) }
 
-    // If we run unit tests on the host platform, then we need the library available:
-    if (target.os == hostOperatingSystem && target.arch == hostArchitecture) {
-        tasks.compileJava { dependsOn(name) }
-        tasks.compileTestJava { dependsOn(name) }
-    }
+    // The compile tasks must also depend on the native builds. Technically, only the local host
+    // target library is required, e.g. to run the code and/or unit tests locally.
+    // But Gradle requires all of them because they all make it into the resources/. So:
+    tasks.compileJava { dependsOn(name) }
+    tasks.compileTestJava { dependsOn(name) }
 }


### PR DESCRIPTION
**Description**:
Fixing the cross-platform aggregation of native libsodium libraries by means of setting up a cross-platform build on every host: both Linux and Mac runners in CI build libsodium for all platforms locally. This is done so because a Gradle Cache-based solution that we use for our hints and wraps Rust libraries didn't work for libsodium for an unknown reason.

Note: on Mac, libsodium doesn't require the Apple SDK which has licensing restrictions that force us to build hints and wraps on Mac natively. Since the Apple SDK isn't needed for libsodium, we can cross-compile libsodium for Mac on Linux.

On developer laptops, local builds continue to build libsodium for the local host platform only, because that's the only locally-runnable binary. If anyone needs to reproduce the full CI build for all platforms, then they can simply define the `HIERO_LIBSODIUM_TARGETS` env var similar to our CI setup and install cross-build tools, similar to how we configure our CI runners (see GitHub scripts in this PR.)

**Related issue(s)**:

Fixes #623 

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
