### PR TITLE
fix: additional defensive checks in Groth16

### DIFF
--- a/cryptography/hedera-cryptography-wraps/src/main/rust/groth16/src/verifier.rs
+++ b/cryptography/hedera-cryptography-wraps/src/main/rust/groth16/src/verifier.rs
@@ -7,7 +7,7 @@ use crate::{r1cs_to_qap::R1CSToQAP, Groth16};
 
 use super::{PreparedVerifyingKey, Proof, VerifyingKey};
 
-use ark_relations::gr1cs::Result as R1CSResult;
+use ark_relations::gr1cs::{Result as R1CSResult, SynthesisError};
 
 use core::ops::{AddAssign, Neg};
 
@@ -28,6 +28,10 @@ impl<E: Pairing, QAP: R1CSToQAP> Groth16<E, QAP> {
         pvk: &PreparedVerifyingKey<E>,
         public_inputs: &[E::ScalarField],
     ) -> R1CSResult<E::G1> {
+        if (public_inputs.len() + 1) != pvk.vk.gamma_abc_g1.len() {
+            return Err(SynthesisError::AssignmentMissing);
+        }
+
         let mut g_ic = pvk.vk.gamma_abc_g1[0].into_group();
         for (i, b) in public_inputs.iter().zip(pvk.vk.gamma_abc_g1.iter().skip(1)) {
             g_ic.add_assign(&b.mul_bigint(i.into_bigint()));

--- a/cryptography/hedera-cryptography-wraps/src/main/rust/groth16/src/verifier.rs
+++ b/cryptography/hedera-cryptography-wraps/src/main/rust/groth16/src/verifier.rs
@@ -62,7 +62,8 @@ impl<E: Pairing, QAP: R1CSToQAP> Groth16<E, QAP> {
             ],
         );
 
-        let test = E::final_exponentiation(qap).unwrap();
+        let test = E::final_exponentiation(qap)
+            .ok_or_else(|| SynthesisError::AssignmentMissing)?;
 
         Ok(test.0 == pvk.alpha_g1_beta_g2)
     }


### PR DESCRIPTION
**Description**:
This PR adds some additional defensive checks in Groth16 module to prevent malformed inputs from triggering errors.
